### PR TITLE
add script to generate permission key more easily

### DIFF
--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -126,7 +126,7 @@ def check_tournament_access(tournament_url):
     return True, tournament
 
 
-def generate_permission_key(url_slug, secret_key=None):
+def generate_permission_key(url_slug: str, secret_key=None):
     """
     Generate a permission key for a specific URL slug.
 
@@ -140,16 +140,13 @@ def generate_permission_key(url_slug, secret_key=None):
     if secret_key is None:
         secret_key = current_app.config.get("SECRET_KEY", "default-secret-key")
 
-    # Normalize the URL slug (lowercase, strip whitespace)
-    normalized_slug = url_slug.lower().strip()
-
-    # Generate HMAC-SHA256 hash
-    hmac_obj = hmac.new(
-        secret_key.encode("utf-8"), normalized_slug.encode("utf-8"), hashlib.sha256
-    )
-
-    # Return first 16 characters of hex digest for easier sharing
-    return hmac_obj.hexdigest()[:16]
+    # only use first 16 chars bc otherwise its annoying
+    # if you need to type it out without copy-pasting
+    return hmac.new(
+        secret_key.encode("utf-8"),
+        url_slug.lower().strip().encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()[:16]
 
 
 def validate_permission_key(url_slug, provided_key, secret_key=None):

--- a/generate_permission_key.py
+++ b/generate_permission_key.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+generate permission keys to create new tournaments. uses app secret key. if none is passed.
+
+Usage:
+    uv run generate_permission_key.py <url_slug> [secret_key]
+
+"""
+
+import sys
+import os
+
+# Add the project root to the path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from flask import Flask
+from app import create_app
+from app.utils.helpers import generate_permission_key
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python generate_permission_key.py <url_slug> [secret_key]")
+        print("\nExample:")
+        print("  python generate_permission_key.py my-tournament")
+        print("  python generate_permission_key.py my-tournament my-secret-key")
+        sys.exit(1)
+
+    url_slug = sys.argv[1]
+    secret_key = sys.argv[2] if len(sys.argv) > 2 else None
+
+    if secret_key:
+        # Use provided secret key
+        key = generate_permission_key(url_slug, secret_key)
+        print(f"Permission key for '{url_slug}': {key}")
+    else:
+        # Use Flask app's SECRET_KEY
+        app = create_app()
+        with app.app_context():
+            key = generate_permission_key(url_slug)
+            print(f"Permission key for '{url_slug}': {key}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_perm_key.py
+++ b/tests/unit/test_perm_key.py
@@ -1,0 +1,15 @@
+import pytest
+from app.utils.helpers import generate_permission_key, validate_permission_key
+
+
+@pytest.mark.unit
+def test_permission_key(app):
+    k = generate_permission_key("FoW_25")
+    assert len(k) == 16, f"expected key of length 16 but got len(key)={len(k)}"
+    assert validate_permission_key("FoW_25", k)
+    assert not validate_permission_key(
+        "FoW-25", k
+    ), "expected key not to match because of different url slug"
+    assert not validate_permission_key(
+        "FoW_25", k, "non-matching secret"
+    ), "expected key not to match because of different secret"


### PR DESCRIPTION
during the Great Cleanup :tm: i accidentally removed the `generate_permission_key.py` file. it has now been replaced.
Also added a test for the key checking.

now we can once again `uv run generate_permission_key.py <url_slug>` on the server to get a key instead of starting up a python shell and importing stuff