### PR TITLE
elliot bugfixes

### DIFF
--- a/app/serializers/match_schedule_serializer.py
+++ b/app/serializers/match_schedule_serializer.py
@@ -25,6 +25,8 @@ class MatchScheduleSerializer:
             result["id"] = tag.id
         if tag.name:
             result["name"] = tag.name
+        if getattr(tag, "team", None):
+            result["team"] = tag.team
         return result
 
     @staticmethod
@@ -50,18 +52,23 @@ class MatchScheduleSerializer:
         if match.name:
             result["name"] = match.name
 
-        # Optional string fields - only include if non-empty
-        # Note: team1, team2, refs are NOT exported - they are derived from _initial fields
+        # Optional string fields - only include if non-empty.
+        # Prefer _initial (user tokens: tag::X, Match::winner, or explicit id); fall back to
+        # team1/team2/refs when set directly so export still includes team info.
         if match.team1_initial:
             result["team1_initial"] = match.team1_initial
+        elif getattr(match, "team1", False):
+            result["team1_initial"] = match.team1
         if match.team2_initial:
             result["team2_initial"] = match.team2_initial
+        elif getattr(match, "team2", False):
+            result["team2_initial"] = match.team2
         if match.refs_initial:
             result["refs_initial"] = match.refs_initial
+        elif getattr(match, "refs", False):
+            result["refs_initial"] = match.refs
         if match.field:
             result["field"] = match.field
-        if match.skip_condition:
-            result["skip_condition"] = match.skip_condition
         if match.skip_condition:
             result["skip_condition"] = match.skip_condition
 
@@ -123,6 +130,7 @@ class MatchScheduleSerializer:
         result = {
             "event": tournament_url,
             "name": name,
+            "team": str(data.get("team", "")).strip() or None,
         }
 
         # Include id if present (for same-tournament updates)

--- a/app/services/schedule_import_export_service.py
+++ b/app/services/schedule_import_export_service.py
@@ -18,6 +18,18 @@ if TYPE_CHECKING:  # pragma: no cover
     from models import Field, Match, Tag
 
 
+def _is_explicit_team_id(token: str) -> bool:
+    """True if the token is an explicit team ID (not tag:: or match::winner/loser)."""
+    if not token or not str(token).strip():
+        return False
+    t = str(token).strip()
+    if t.lower().startswith("tag::"):
+        return False
+    if "::winner" in t.lower() or "::loser" in t.lower():
+        return False
+    return True
+
+
 @dataclass(frozen=True)
 class ImportResult:
     """Result of an import operation."""
@@ -171,6 +183,60 @@ class ScheduleImportExportService:
         return errors
 
     @staticmethod
+    def _validate_teams_registered(
+        tournament_url: str,
+        tags_data: list[dict],
+        matches_data: list[dict],
+    ) -> list[str]:
+        """
+        Ensure every team referenced by ID (in tags or matches) is registered for the tournament.
+        Returns a list of error messages; empty if all referenced teams are registered.
+        """
+        from app.domain.enums import TeamRegistrationStatus
+        from models import TeamRegistration
+
+        # Collect all team IDs referenced by ID (not tag:: or match::winner/loser)
+        team_ids: set[str] = set()
+
+        for tag in tags_data:
+            team_val = str(tag.get("team", "")).strip()
+            if team_val:
+                team_ids.add(team_val)
+
+        for m in matches_data:
+            for field_name in ("team1_initial", "team2_initial"):
+                tok = str(m.get(field_name, "")).strip()
+                if tok and _is_explicit_team_id(tok):
+                    team_ids.add(tok)
+            refs_raw = str(m.get("refs_initial", "")).strip()
+            if refs_raw:
+                for part in refs_raw.split(","):
+                    tok = part.strip()
+                    if tok and _is_explicit_team_id(tok):
+                        team_ids.add(tok)
+
+        if not team_ids:
+            return []
+
+        registered_team_ids: set[str] = {
+            reg.team
+            for reg in TeamRegistration.query.filter_by(event=tournament_url)
+            .filter(TeamRegistration.status != TeamRegistrationStatus.CANCELLED)
+            .all()
+        }
+
+        unregistered = team_ids - registered_team_ids
+        if not unregistered:
+            return []
+
+        errors: list[str] = []
+        for tid in sorted(unregistered):
+            errors.append(
+                f"Team '{tid}' is not registered for this tournament."
+            )
+        return errors
+
+    @staticmethod
     @allow_Q
     def export_schedule(tournament_url: str) -> Result[str, ArctosError]:
         """
@@ -297,6 +363,13 @@ class ScheduleImportExportService:
             if isinstance(res, Err):
                 errors.append(f"Match validation error: {res.value.message}")
 
+        # 5. Ensure all teams referenced by ID (tags and matches) are registered
+        errors.extend(
+            ScheduleImportExportService._validate_teams_registered(
+                tournament_url, tags_data, matches_data
+            )
+        )
+
         # If any validation errors, abort before making any changes
         if errors:
             error_count = len(errors)
@@ -351,6 +424,7 @@ class ScheduleImportExportService:
                     ).first()
                     if tag:
                         tag.name = tag_dict["name"]
+                        tag.team = tag_dict.get("team")
                         tags_updated += 1
                     else:
                         # ID doesn't exist, create new (don't include id in creation)

--- a/app/utils/toml_helpers.py
+++ b/app/utils/toml_helpers.py
@@ -71,7 +71,7 @@ def write_toml_schedule(
 
     Args:
         event: Tournament URL
-        tags: List of tag dicts with 'id' and 'name'
+        tags: List of tag dicts with 'id', 'name', and optional 'team' (team id)
         fields: List of field dicts with 'id', 'name', 'camera'
         matches: List of match dicts with match attributes
         metadata: Optional metadata dict (e.g., export_date, version)
@@ -101,6 +101,8 @@ def write_toml_schedule(
                 lines.append(f'id = {tag["id"]}')
             if "name" in tag and tag["name"]:
                 lines.append(f'name = "{_escape_toml_string(tag["name"])}"')
+            if "team" in tag and tag["team"]:
+                lines.append(f'team = "{_escape_toml_string(tag["team"])}"')
             lines.append("")
 
     # Fields

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -42,6 +42,34 @@ fn local_datetime_to_utc_iso(local_str: &str) -> Option<String> {
     Some(local.with_timezone(&Utc).format("%Y-%m-%dT%H:%M:%SZ").to_string())
 }
 
+/// Convert a UTC-ish ISO datetime string from the API into a `datetime-local` value (local time, no timezone).
+fn utc_iso_to_local_datetime_input(iso: &str) -> Option<String> {
+    use chrono::NaiveDateTime;
+    let s = iso.trim();
+    if s.is_empty() {
+        return None;
+    }
+
+    let utc_dt = if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        dt.naive_utc()
+    } else if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f") {
+        dt
+    } else if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+        dt
+    } else if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M") {
+        dt
+    } else if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+        dt
+    } else if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M") {
+        dt
+    } else {
+        return None;
+    };
+
+    let local = utc_dt + chrono::Duration::minutes(schedule_tz_offset_minutes());
+    Some(local.format("%Y-%m-%dT%H:%M").to_string())
+}
+
 /// Effective start time for timeline/date nav: confirmed when set, else nominal.
 fn effective_start_str(m: &MatchSetupData) -> Option<&str> {
     m.confirmed_start_time.as_deref().or(m.nominal_start_time.as_deref())
@@ -1249,18 +1277,10 @@ fn CreateMatchModal(
                                 div { class: "col-md-6",
                                     div { class: "mb-3",
                                         label { class: "form-label", "Field" }
-                                        input {
-                                            class: "form-control",
-                                            "type": "text",
-                                            list: "field-list-create",
+                                        select {
+                                            class: "form-select",
                                             value: "{field}",
-                                            placeholder: "Select or type field name",
-                                            oninput: move |e| {
-                                                let val = e.value();
-                                                on_field_change(val);
-                                            },
-                                        }
-                                        datalist { id: "field-list-create",
+                                            onchange: move |e| on_field_change(e.value()),
                                             option { value: "", "Select Field" }
                                             for f in &data.fields {
                                                 option { value: "{f.name}", "{f.name}" }
@@ -1322,9 +1342,9 @@ fn CreateMatchModal(
                                                 value: team1(),
                                                 on_change: move |s| team1.set(s),
                                                 multiple: false,
-                                                placeholder: "Pseudonym, MatchName::winner, tag::TagName".to_string(),
+                                                placeholder: "team, match winner/loser, or tag".to_string(),
                                             }
-                                            div { class: "form-text", "Team, match winner/loser (MatchName::winner), or tag (tag::TagName)" }
+                                            div { class: "form-text", "team, match winner/loser, or tag" }
                                         }
                                     }
                                     div { class: "col-md-6",
@@ -1337,9 +1357,9 @@ fn CreateMatchModal(
                                                 value: team2(),
                                                 on_change: move |s| team2.set(s),
                                                 multiple: false,
-                                                placeholder: "Pseudonym, MatchName::winner, tag::TagName".to_string(),
+                                                placeholder: "team, match winner/loser, or tag".to_string(),
                                             }
-                                            div { class: "form-text", "Team, match winner/loser (MatchName::winner), or tag (tag::TagName)" }
+                                            div { class: "form-text", "team, match winner/loser, or tag" }
                                         }
                                     }
                                 }
@@ -1352,9 +1372,9 @@ fn CreateMatchModal(
                                         value: refs(),
                                         on_change: move |s| refs.set(s),
                                         multiple: true,
-                                        placeholder: "Comma-separated: pseudonym, MatchName::winner, tag::TagName".to_string(),
+                                        placeholder: "(optional) teams, match winners/losers, or tags".to_string(),
                                     }
-                                    div { class: "form-text", "Comma-separated list of teams, match winner/loser, or tags" }
+                                    div { class: "form-text", "(optional) teams, match winners/losers, or tags" }
                                 }
                                 div { class: "row",
                                     div { class: "col-md-4",
@@ -1649,7 +1669,7 @@ fn FieldsModal(
     let mut preview_modal_closed = use_signal(|| None::<std::sync::Arc<std::sync::atomic::AtomicBool>>);
     let mut preview_cameras = use_signal(|| vec![] as Vec<String>);
     let mut preview_selected_camera = use_signal(|| String::new());
-    let mut preview_cache_bust = use_signal(|| "0".to_string());
+    let preview_cache_bust = use_signal(|| "0".to_string());
     let mut editing_field_id = use_signal(|| None::<u32>);
     let mut editing_name = use_signal(|| "".to_string());
     let mut editing_camera_urls = use_signal(|| vec!["".to_string()]);
@@ -3351,12 +3371,7 @@ fn EditMatchModal(
     let mut length = use_signal(|| m.nominal_length.unwrap_or(60));
     
     let start_time_init = if let Some(t) = &m.nominal_start_time {
-        // Format for datetime-local: YYYY-MM-DDTHH:MM
-        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(t) {
-            dt.format("%Y-%m-%dT%H:%M").to_string()
-        } else {
-            t.chars().take(16).collect::<String>()
-        }
+        utc_iso_to_local_datetime_input(t).unwrap_or_else(|| t.chars().take(16).collect::<String>())
     } else {
         "".to_string()
     };
@@ -3492,7 +3507,11 @@ fn EditMatchModal(
                 field: Some(field()),
                 schedule_type: Some(schedule_type()),
                 length: len,
-                start_time: if start_time().is_empty() { None } else { Some(start_time()) },
+                start_time: if start_time().is_empty() {
+                    None
+                } else {
+                    local_datetime_to_utc_iso(&start_time()).or_else(|| Some(start_time()))
+                },
                 previous_match_id: Some(previous_match_id()),
                 refs: Some(refs_vec),
                 team1: Some(team1()),
@@ -3783,18 +3802,10 @@ fn EditMatchModal(
                                 div { class: "col-md-6",
                                     div { class: "mb-3",
                                         label { class: "form-label", "Field" }
-                                        input {
-                                            class: "form-control",
-                                            "type": "text",
-                                            list: "field-list-edit",
+                                        select {
+                                            class: "form-select",
                                             value: "{field}",
-                                            placeholder: "Select or type field name",
-                                            oninput: move |e| {
-                                                let val = e.value();
-                                                on_field_change_edit(val);
-                                            },
-                                        }
-                                        datalist { id: "field-list-edit",
+                                            onchange: move |e| on_field_change_edit(e.value()),
                                             option { value: "", "Select Field" }
                                             for f in &data.fields {
                                                 option { value: "{f.name}", "{f.name}" }
@@ -3856,7 +3867,7 @@ fn EditMatchModal(
                                                 value: team1(),
                                                 on_change: move |s| team1.set(s),
                                                 multiple: false,
-                                                placeholder: "Pseudonym, MatchName::winner, tag::TagName".to_string(),
+                                                placeholder: "team 1".to_string(),
                                             }
                                             div { class: "form-text", "Team, match winner/loser, or tag" }
                                         }
@@ -3871,9 +3882,9 @@ fn EditMatchModal(
                                                 value: team2(),
                                                 on_change: move |s| team2.set(s),
                                                 multiple: false,
-                                                placeholder: "Pseudonym, MatchName::winner, tag::TagName".to_string(),
+                                                placeholder: "team 2".to_string(),
                                             }
-                                            div { class: "form-text", "Team pseudonym, match winner/loser, or tag" }
+                                            div { class: "form-text", "Team, match winner/loser, or tag" }
                                         }
                                     }
                                 }
@@ -3886,9 +3897,9 @@ fn EditMatchModal(
                                         value: refs(),
                                         on_change: move |s| refs.set(s),
                                         multiple: true,
-                                        placeholder: "Comma-separated: pseudonym, MatchName::winner, tag::TagName".to_string(),
+                                        placeholder: "(optional) teams, match winners/losers, or tags".to_string(),
                                     }
-                                    div { class: "form-text", "Comma-separated list of team pseudonyms, match references, or tags" }
+                                    div { class: "form-text", "(optional) teams, match winners/losers, or tags" }
                                 }
                                 div { class: "row",
                                     div { class: "col-md-4",


### PR DESCRIPTION
- edit match modal now shows timezone correctly
- field is an actual dropdown (elliot was having issues)
- toml export includes explicitly set teams now
- toml export includes tag settings (since now that is a state)
- toml import validates that explicit tags have valid matching registrations
- match edit/create modals now don't reference the old `::` syntax (since it's all abstracted away now)