### PR TITLE
[Feature] Environment Setup Scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *.py[cod]
 
 # secrets
+.env
 .env.*
 run
 
@@ -27,6 +28,7 @@ dioxus/
 *.csr
 *.key
 *.crt
+*.pem
 
 
 # cargo (i sure hope it does)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,86 @@
+.DEFAULT_GOAL := help
+
+SETUP_DIR := setup
+UNAME_S   := $(shell uname -s)
+UNAME_M   := $(shell uname -m)
+REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+ENV_FILE  ?= .env
+
+# Defaults for the gunicorn invocation; override on the command line, e.g.
+#   make run WORKERS=10 BIND=0.0.0.0:9000 CERTFILE= KEYFILE=
+WORKERS  ?= 5
+BIND     ?= 0.0.0.0:8081
+CERTFILE ?= cert.pem
+KEYFILE  ?= key.pem
+
+# Self-signed cert defaults; override on the command line, e.g.
+#   make certs CERT_DAYS=730 CERT_SUBJECT=/CN=arctos.example.com
+CERT_DAYS    ?= 365
+CERT_SUBJECT ?= /CN=localhost
+
+.PHONY: help setup setup-os setup-macos setup-ubuntu setup-python setup-frontend install all run certs
+
+help: ## Show available targets
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n\nTargets:\n"} \
+		/^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+all: setup install setup-frontend ## Run full setup: system deps, python deps, and frontend tools
+
+setup: setup-os ## Auto-detect OS and run the appropriate system setup
+
+setup-os:
+ifeq ($(UNAME_S),Darwin)
+	@$(MAKE) --no-print-directory setup-macos
+else ifeq ($(UNAME_S),Linux)
+	@$(MAKE) --no-print-directory setup-ubuntu
+else
+	@echo "Unsupported OS: $(UNAME_S). Only macOS and Linux (Ubuntu) are supported."; exit 1
+endif
+
+setup-macos: ## Install macOS system dependencies (Homebrew, Xcode CLI, packages, Python)
+	@chmod +x $(SETUP_DIR)/setup-macos.sh
+	@$(SETUP_DIR)/setup-macos.sh
+
+setup-ubuntu: ## Install Ubuntu system dependencies (apt packages, uv, Python)
+	@chmod +x $(SETUP_DIR)/setup-ubuntu.sh
+	@$(SETUP_DIR)/setup-ubuntu.sh
+
+setup-python: ## Install the project's Python toolchain via uv
+	@chmod +x $(SETUP_DIR)/setup-python.sh
+	@$(SETUP_DIR)/setup-python.sh
+
+install: ## Sync backend Python dependencies with uv
+	@uv sync
+
+setup-frontend: ## Install the Dioxus CLI required to build/serve the frontend
+	@cargo install dioxus-cli
+
+certs: ## Generate self-signed SSL certs at $(CERTFILE)/$(KEYFILE) (use FORCE=1 to overwrite)
+	@if [ -z "$(FORCE)" ] && { [ -f "$(CERTFILE)" ] || [ -f "$(KEYFILE)" ]; }; then \
+		echo "refusing to overwrite existing $(CERTFILE) / $(KEYFILE); pass FORCE=1 to regenerate"; \
+		exit 1; \
+	fi
+	@command -v openssl >/dev/null || { echo "openssl not found in PATH"; exit 1; }
+	@openssl req -x509 -newkey rsa:4096 \
+		-keyout "$(KEYFILE)" -out "$(CERTFILE)" \
+		-sha256 -days $(CERT_DAYS) -nodes \
+		-subj "$(CERT_SUBJECT)"
+	@chmod 600 "$(KEYFILE)"
+	@echo "Generated $(CERTFILE) and $(KEYFILE) (valid $(CERT_DAYS) days, subject $(CERT_SUBJECT))"
+
+run: ## Run the backend with gunicorn (loads $(ENV_FILE) if present)
+	@uv sync
+	@if [ ! -f "$(ENV_FILE)" ]; then \
+		echo "warning: $(ENV_FILE) not found; continuing with current environment only"; \
+	fi
+	@set -a; \
+	[ -f "$(ENV_FILE)" ] && . "./$(ENV_FILE)"; \
+	set +a; \
+	PYTHONPATH="$(REPO_ROOT):$$PYTHONPATH" \
+	uv run gunicorn \
+		--workers=$(WORKERS) \
+		--bind $(BIND) \
+		--log-level debug \
+		$(if $(strip $(CERTFILE)),--certfile=$(CERTFILE)) \
+		$(if $(strip $(KEYFILE)),--keyfile=$(KEYFILE)) \
+		run_app:app

--- a/README.md
+++ b/README.md
@@ -11,61 +11,68 @@ see [CONTRIBUTING](CONTRIBUTING.md) for how to get involved.
 ### Part 1: Backend
 
 1. Install [uv](https://docs.astral.sh/uv/).
-2. Set up your SSL certs. if you're using nginx you can do this there
-   and use certbot or something. If you're just testing, you can
-   create self-signed certs:
+2. Set up your SSL certs. If you're using nginx you can do this there
+   and use [certbot](https://certbot.eff.org/). If you're just testing, you can
+   generate self-signed certs with:
 
 ```bash
 openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365
 ```
 
-3. Create a bash script called `run` with the following contents:
+or
 
 ```bash
-#!/bin/bash -e
-
-uv sync
-
-ARCTOS_CORS_DEV=1 \
-ARCTOS_API_BASE=http://127.0.0.1:8081 \
-EXTERNAL_BASE_URL=your_public_domain_or_ip \
-PYTHONPATH=path/to/arctos:$PYTHONPATH \
-YOUTUBE_API_KEY=your_youtube_api_key \
-GOOGLE_CLIENT_SECRET=your_google_client_secret \
-GOOGLE_CLIENT_ID=your_google_client_id \
-SECRET_KEY=your_app_secret_key \
-	uv run gunicorn \
-        --workers=5 \
-        --bind 0.0.0.0:8081 \
-        --log-level debug \
-        --certfile=cert.pem \
-        --keyfile=key.pem \
-        run_app:app
-
+make certs
 ```
 
-with all the info filled out. If you don't have some of these, you can
-leave them empty; they are only needed for the sign in with google and
-youtube auto-seek features.  the `SECRET_KEY` variable must be a
-random value for security reasons. You can get one by running
+   This writes `cert.pem` and `key.pem` to the repo root (valid for
+   365 days, `CN=localhost`). Override with
+   `make certs CERT_DAYS=730 CERT_SUBJECT=/CN=arctos.example.com`,
+   and pass `FORCE=1` to overwrite existing certs.
+
+3. Create a `.env` file at the repo root with the variables you need:
+
+```bash
+ARCTOS_CORS_DEV=1
+ARCTOS_API_BASE=http://127.0.0.1:8081
+EXTERNAL_BASE_URL=your_public_domain_or_ip
+YOUTUBE_API_KEY=your_youtube_api_key
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+GOOGLE_CLIENT_ID=your_google_client_id
+SECRET_KEY=your_app_secret_key
+```
+
+If you don't have some of these, you can leave them empty; they are
+only needed for the sign in with google and youtube auto-seek
+features. The `SECRET_KEY` variable must be a random value for
+security reasons. You can get one by running
 
 ```bash
 python -c "import os; print(os.urandom(12).hex())"
 ```
 
-The gunicorn args provided are just examples; set workers as high as
-you'd like, set it to bind to whatever you need, and omit the
-`certfile` and `keyfile` arguments if you're handling SSL elsewhere.
-
-> [!IMPORTANT] 
-> 
+> [!IMPORTANT]
+>
 > The `ARCTOS_CORS_DEV` and `ARCTOS_API_BASE` are only for dev
 > environments where you don't have a reverse proxy set up to direct
 > traffic and are thus hosting the frontend and backend on different
 > ports.
 
-4. run `chmod +x run`
-5. finally, start the app with `./run`
+4. Start the app:
+
+```bash
+make run
+```
+
+This loads `.env`, runs `uv sync`, and starts gunicorn. The defaults
+match the example above (5 workers, binding `0.0.0.0:8081`, using
+`cert.pem`/`key.pem`). Override any of them on the command line, e.g.:
+
+```bash
+make run WORKERS=10 BIND=0.0.0.0:9000
+make run CERTFILE= KEYFILE=          # if you handle SSL elsewhere
+make run ENV_FILE=.env.prod          # use a different env file
+```
 
 #### Video storage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,8 @@ dependencies = [
     "werkzeug==3.1.4",
     "wtforms==3.2.1",
 ]
+
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
+default = true

--- a/setup/Brewfile
+++ b/setup/Brewfile
@@ -1,0 +1,3 @@
+brew "git"
+brew "git-lfs"
+brew "uv"

--- a/setup/apt-packages.txt
+++ b/setup/apt-packages.txt
@@ -1,0 +1,2 @@
+git
+git-lfs

--- a/setup/setup-macos.sh
+++ b/setup/setup-macos.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# installs XCode CLI tools that homebrew uses to install/compile packages
+# only run this if CLI tools are not already installed, otherwise it would raise an error
+if ! xcode-select -p &> /dev/null; then
+    xcode-select --install
+    echo "Installed XCode CLI tools"
+fi
+
+# installs homebrew if it's not yet installed
+if ! command -v brew &> /dev/null; then
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    echo "Installed Homebrew"
+fi
+
+directory=$(dirname "${BASH_SOURCE[0]}")
+
+brew bundle --file="${directory}/Brewfile"
+echo "Installed Homebrew packages"
+
+chmod +x "${directory}/setup-python.sh"
+"${directory}/setup-python.sh"

--- a/setup/setup-python.sh
+++ b/setup/setup-python.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+directory=$(dirname "${BASH_SOURCE[0]}")
+
+# Detect platform and set Python version
+if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
+    python_version="cpython-3.12.13-macos-aarch64-none"
+elif [[ "$(uname -s)" == "Linux" && "$(uname -m)" == "x86_64" ]]; then
+    python_version="cpython-3.12.13-linux-x86_64-gnu"
+else
+    echo "Unsupported platform. Only ARM64 macOS and x86_64 Ubuntu are supported."
+    exit 1
+fi
+
+echo "Using Python version: ${python_version}"
+
+uv python install ${python_version}
+echo "Installed Python"
+

--- a/setup/setup-ubuntu.sh
+++ b/setup/setup-ubuntu.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+directory=$(dirname "${BASH_SOURCE[0]}")
+
+xargs sudo apt-get install -y < "${directory}/apt-packages.txt"
+echo "Installed apt packages"
+
+bash -c "$(curl -LsSf https://astral.sh/uv/install.sh)"
+echo "Installed uv"
+
+chmod +x "${directory}/setup-python.sh"
+"${directory}/setup-python.sh"


### PR DESCRIPTION
Creates a setup script for ubuntu / macos and `Make` macros for running them.

From the root of the directory, one can run `make help` to see all available macros

```
~/arctos$ make help
Usage: make <target>

Targets:
  help              Show available targets
  all               Run full setup: system deps, python deps, and frontend tools
  setup             Auto-detect OS and run the appropriate system setup
  setup-macos       Install macOS system dependencies (Homebrew, Xcode CLI, packages, Python)
  setup-ubuntu      Install Ubuntu system dependencies (apt packages, uv, Python)
  setup-python      Install the project's Python toolchain via uv
  install           Sync backend Python dependencies with uv
  setup-frontend    Install the Dioxus CLI required to build/serve the frontend
  certs             Generate self-signed SSL certs at $(CERTFILE)/$(KEYFILE) (use FORCE=1 to overwrite)
  run               Run the backend with gunicorn (loads $(ENV_FILE) if present)
```