### PR TITLE
Enable Pragma, Setup Alembic Baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ instance/*
 static/uploads/*
 preview/*
 dioxus/
+backups/
 
 
 # certs

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ CERT_SUBJECT ?= /CN=localhost
         setup setup-os setup-macos setup-ubuntu setup-python install setup-frontend \
         lint format \
         test unit integration \
-        run certs
+        run certs \
+        db-baseline db-migrate db-revision db-current db-history \
+        db-backup db-check-duplicates
 
 help: ## Show available targets
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n\nTargets:\n"} \
@@ -100,6 +102,40 @@ run: ## Run the backend with gunicorn (loads $(ENV_FILE) if present)
 		$(if $(strip $(CERTFILE)),--certfile=$(CERTFILE)) \
 		$(if $(strip $(KEYFILE)),--keyfile=$(KEYFILE)) \
 		run_app:app
+
+# ── Database migrations ───────────────────────────────────────────────────────
+#
+# All targets shell out to alembic via `uv run` so the project-pinned version
+# is always used. See `migrations/README.md` for the full workflow.
+# Run `make db-backup` BEFORE every db-migrate.
+
+db-baseline: ## One-shot: stamp an existing database at the current alembic head
+	@uv run alembic stamp head
+
+db-migrate: ## Apply all outstanding migrations (run `make db-backup` first!)
+	@uv run alembic upgrade head
+
+db-revision: ## Autogenerate a migration; usage: make db-revision MSG="snake_case_message"
+	@if [ -z "$(MSG)" ]; then \
+		echo "error: pass MSG=... e.g. make db-revision MSG=\"add_unique_player_email\""; \
+		exit 1; \
+	fi
+	@uv run alembic revision --autogenerate -m "$(MSG)"
+
+db-current: ## Print the revision currently applied to the database
+	@uv run alembic current
+
+db-history: ## Print the full alembic revision history
+	@uv run alembic history
+
+db-backup: ## Snapshot the live SQLite database to backups/ (run BEFORE every db-migrate)
+	@chmod +x scripts/backup_db.sh
+	@scripts/backup_db.sh
+
+db-check-duplicates: ## Report rows that violate would-be-unique column groups
+	@uv run python scripts/check_duplicates.py
+
+# ── Misc ──────────────────────────────────────────────────────────────────────
 
 certs: ## Generate self-signed SSL certs at $(CERTFILE)/$(KEYFILE) (use FORCE=1 to overwrite)
 	@if [ -z "$(FORCE)" ] && { [ -f "$(CERTFILE)" ] || [ -f "$(KEYFILE)" ]; }; then \

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,64 @@
+# Alembic configuration for Arctos.
+#
+# Schema migrations are versioned in `migrations/versions/`.  The runtime
+# database URL is resolved by `migrations/env.py` (it imports the same Flask
+# config the application uses), so the `sqlalchemy.url` line below is left
+# blank on purpose — overriding it in `[alembic]` would silently bypass the
+# instance-folder resolution and point alembic at a different file.
+#
+# Common commands (always run via `uv run`):
+#   uv run alembic upgrade head
+#   uv run alembic downgrade -1
+#   uv run alembic revision --autogenerate -m "describe_change_in_snake_case"
+#   uv run alembic stamp head     # one-time baseline for an existing DB
+#
+# Convenience wrappers exist in the top-level Makefile (`make db-migrate`,
+# `make db-revision MSG=...`, `make db-baseline`).
+
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+# Filenames look like `0002_normalise_match_refs.py` so the chronological
+# order in `migrations/versions/` matches the dependency order of revisions.
+file_template = %%(rev)s_%%(slug)s
+sqlalchemy.url =
+
+[post_write_hooks]
+hooks = ruff_format
+ruff_format.type = console_scripts
+ruff_format.entrypoint = ruff
+ruff_format.options = format REVISION_SCRIPT_FILENAME
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -101,6 +101,8 @@ def create_app(config: dict | None = None) -> Flask:
         app.config.update(config)
 
     # SQLite: increase busy timeout; finalize workers and HTTP handlers share one file.
+    # The same timeout is also re-asserted via PRAGMA in `set_sqlite_pragmas` below so
+    # that every new DBAPI connection gets it regardless of how the engine was built.
     uri = app.config.get("SQLALCHEMY_DATABASE_URI") or ""
     if isinstance(uri, str) and uri.startswith("sqlite"):
         opts = dict(app.config.get("SQLALCHEMY_ENGINE_OPTIONS") or {})
@@ -132,7 +134,10 @@ def create_app(config: dict | None = None) -> Flask:
     db = db_instance
     db.init_app(app)
     init_db(db)
-    # WAL + busy_timeout: readers/writers interleave better than default rollback journal.
+    # Per-connection SQLite pragmas. WAL + busy_timeout let readers/writers interleave
+    # better than the default rollback journal; foreign-key enforcement is added here
+    # because SQLite ships with it OFF by default and only honours it when the pragma
+    # is set on EVERY new connection.
     try:
         with app.app_context():
             eng = db.engine
@@ -140,11 +145,27 @@ def create_app(config: dict | None = None) -> Flask:
                 from sqlalchemy import event
 
                 @event.listens_for(eng, "connect")
-                def _sqlite_pragma(dbapi_connection, _connection_record):
+                def set_sqlite_pragmas(dbapi_connection, _connection_record):
+                    """Apply Arctos-required SQLite pragmas to a fresh DBAPI connection.
+
+                    Runs once per new connection that SQLAlchemy's pool hands out:
+
+                    * ``journal_mode=WAL`` — readers and writers do not block each
+                      other; required because finalize workers and HTTP handlers
+                      share a single database file.
+                    * ``busy_timeout=30000`` — wait up to 30 s for a competing writer
+                      instead of failing immediately with ``SQLITE_BUSY``.
+                    * ``foreign_keys=ON`` — SQLite disables FK enforcement by default
+                      and only checks it when this pragma is set on the connection.
+                      Without this every ``ForeignKey`` in the schema is decorative
+                      and deletes silently orphan child rows. This is the one
+                      non-obvious pragma; do not remove it.
+                    """
                     cur = dbapi_connection.cursor()
                     try:
                         cur.execute("PRAGMA journal_mode=WAL")
                         cur.execute("PRAGMA busy_timeout=30000")
+                        cur.execute("PRAGMA foreign_keys=ON")
                     finally:
                         cur.close()
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,214 @@
+# Deploying Arctos
+
+This runbook is for the person who runs deploys against the production
+Arctos database. Read it top to bottom once; keep it open during a deploy.
+
+## One-time setup (per database)
+
+The first time alembic is introduced to a database that was previously
+managed by `db.create_all()`, stamp it at the current baseline so
+subsequent migrations can be applied normally:
+
+```bash
+make db-baseline
+```
+
+This only inserts a row into the `alembic_version` table; it does not
+modify any data. **Run this once per database, ever.** After this point,
+every schema change goes through `make db-migrate`.
+
+## The deploy loop
+
+Every deploy follows the same shape:
+
+1. **Pull** the latest code: `git pull origin dev`
+2. **Backup** the database (always): `make db-backup <tag>`
+3. **Apply** the change — depends on what kind of change it is (see below)
+4. **Verify** — depends on the change
+5. **Restart** the application service
+
+Skip step 5 only when the PR description says explicitly "no restart needed".
+
+## Picking a runbook by change type
+
+Every PR that touches the database or schema must declare which of the
+following sections to follow in its description. You should not need to
+read the code to know how to deploy.
+
+| Change type | When you see... | Follow |
+|---|---|---|
+| Schema migration | New file under `migrations/versions/` | [Schema migration](#schema-migration) |
+| Data migration | New script under `scripts/` named `backfill_*.py` | [Data migration](#data-migration) |
+| Application code only | Changes only under `app/`, no new migration | [Application code](#application-code) |
+| Destructive migration | Migration containing `op.drop_column` / `op.drop_table` | [Destructive migration](#destructive-migration) |
+
+A single PR may combine an application-code change with a schema migration.
+In that case the PR description should list both sets of steps in the order
+to run them — usually the schema migration first, then the restart.
+
+---
+
+## Schema migration
+
+Adds tables, columns, indexes, or constraints. Reversible: `alembic
+downgrade` undoes additive changes cleanly.
+
+```bash
+git pull origin dev
+
+# Pre-flight: if this migration adds a UNIQUE constraint anywhere, the
+# live data must be free of duplicates first. Skip this step if the PR
+# description says no UNIQUE constraint is added.
+make db-check-duplicates    # must exit 0 to continue
+
+# Backup. Tag descriptively so you can find this snapshot later.
+make db-backup pre-<short-name-of-change>
+
+# Apply.
+make db-migrate
+
+# Verify the new revision is the head.
+make db-current
+
+# Restart.
+```
+
+**If the migration fails partway:** SQLite + alembic does its best to keep
+DDL in a transaction; usually nothing was applied and you can investigate,
+fix the migration, and re-run. If `make db-current` shows a half-applied
+state, restore the backup (see [Rollback reference](#rollback-reference)).
+
+**If `db-check-duplicates` reports duplicates:** the unique constraint
+*will* fail at migration time. Resolve the duplicates (merge or delete
+the offending rows in SQL) before continuing. Coordinate with the PR
+author — the policy for which row to keep is a product decision.
+
+---
+
+## Data migration
+
+A standalone Python script that reads from the existing schema and writes
+to tables added in a previous schema migration. Does not change the schema
+itself, and does not require an application restart — the running app
+doesn't know about the new tables yet.
+
+```bash
+git pull origin dev
+
+make db-backup pre-<short-name-of-change>
+
+uv run python scripts/<backfill_script_name>.py
+```
+
+The script prints progress and exits non-zero on validation failure. Its
+module docstring tells you what to verify after it finishes (usually a
+few SQL queries that compare row counts between the old and new
+representations).
+
+**If the script fails partway:** re-running is safe. Backfill scripts use
+`session.merge()` so duplicate rows are not created.
+
+**If validation queries report a mismatch:** stop. Do not proceed to any
+later phase that depends on the new tables being correct. Talk to the PR
+author; the fix is usually in the script, not in the data.
+
+---
+
+## Application code
+
+No database change. Just a code deploy.
+
+---
+
+## Destructive migration
+
+Drops columns or tables. **Irreversible at the data level** — once
+applied, the only path back is restoring the backup. There is no
+`alembic downgrade` that recovers dropped column data.
+
+**Pre-conditions** (the PR description must confirm both):
+
+1. A previous application-code deploy has removed every read and every
+   write of the columns being dropped.
+
+If missing, do not deploy. Talk to the PR author.
+
+```bash
+git pull origin dev
+
+# Backup with a final-sounding tag — this is the one that matters.
+make db-backup pre-cutover-FINAL
+
+# Stop the app. SQLite's DROP COLUMN rebuilds the table internally and
+# does not coexist well with concurrent writers.
+
+make db-migrate
+make db-current
+```
+
+**If anything is wrong after this:** stop the app, restore the backup,
+restart. There is no alternative recovery.
+
+---
+
+## Rollback reference
+
+| Step that failed | Recovery |
+|---|---|
+| Schema migration (additive) | Usually nothing was applied; investigate and re-run. If state is partial, restore the backup. |
+| Data migration script | Re-run after fixing the script — writes are idempotent. |
+| Application code deploy | `git revert <sha>` and restart. |
+| Destructive migration | Stop app, restore backup, restart. No alternative. |
+
+### Restoring a backup
+
+```bash
+cp backups/tournament-<tag>-<ts>.db instance/tournament.db
+
+# Required: these sidecars belong to the old database file.
+# SQLite recreates them on the next connection.
+rm -f instance/tournament.db-shm instance/tournament.db-wal
+```
+
+Verify with `make db-current` (should print whichever revision the backup
+was taken at) and a smoke test before considering the rollback complete.
+
+---
+
+## Quick command reference
+
+| Command | Purpose |
+|---|---|
+| `make db-baseline` | One-shot — stamp alembic baseline on a DB that has never had alembic |
+| `make db-backup [tag]` | Snapshot to `backups/tournament-<tag>-<unix_ts>.db` |
+| `make db-check-duplicates` | Report rows that would block a future UNIQUE constraint |
+| `make db-migrate` | Apply all pending migrations (`alembic upgrade head`) |
+| `make db-current` | Show the revision currently applied to the database |
+| `make db-history` | Show the full revision history |
+
+---
+
+## PR-description template
+
+PR authors should include a block in this format at the top of every PR
+that touches the database or schema:
+
+```markdown
+## Deploy
+
+**Type:** schema migration
+**Pre-flight:** `make db-check-duplicates` must exit 0
+**Steps:**
+1. `make db-backup pre-add-unique-emails`
+2. `make db-migrate`
+3. `make db-current` → expect `0003_add_unique_emails (head)`
+4. `sudo systemctl restart arctos`
+5. Smoke test: register a player, then register a second player with the
+   same email — expect 4xx.
+
+**Rollback:** restore the backup taken in step 1.
+```
+
+If a PR is missing a Deploy block, ask the author to add one before merging.
+A clear Deploy block is a hard merge-blocking requirement for any PR that
+the production database owner will execute.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,48 @@
+# Alembic migrations
+
+This directory holds the versioned schema migrations for Arctos. Every
+schema change after the initial baseline is shipped as a numbered
+revision file under `versions/`.
+
+## Layout
+
+```
+migrations/
+  env.py              # Alembic environment — wires alembic to app.models.db
+  script.py.mako      # Template used when generating new revisions
+  versions/
+    0001_baseline.py  # Empty baseline (existing schema, no upgrade ops)
+    ...               # One file per subsequent revision
+```
+
+`alembic.ini` lives at the repository root.
+
+## Day-to-day commands
+
+Run everything via `uv run` so the project's pinned alembic version is used.
+
+| Goal | Command (Makefile shortcut in parens) |
+|---|---|
+| Stamp an existing DB at the current head (one-shot) | `uv run alembic stamp head` (`make db-baseline`) |
+| Apply all outstanding migrations | `uv run alembic upgrade head` (`make db-migrate`) |
+| Roll back the most recent migration | `uv run alembic downgrade -1` |
+| Generate a new migration from model changes | `uv run alembic revision --autogenerate -m "snake_case_message"` (`make db-revision MSG=...`) |
+| Inspect the current revision applied to the DB | `uv run alembic current` |
+| Show the full revision history | `uv run alembic history` |
+
+## Pointing alembic at a different database
+
+By default the env file resolves to `instance/tournament.db` (matching how
+Flask's instance-folder convention expands `sqlite:///tournament.db`).
+Override with the `SQLALCHEMY_DATABASE_URI` environment variable:
+
+```bash
+SQLALCHEMY_DATABASE_URI=sqlite:////tmp/test.db uv run alembic upgrade head
+```
+
+## Documentation requirements
+
+Every migration file **must** have a module-level docstring explaining *why* the change is being made.
+
+Pre-commit hooks and CI may enforce this; in any case, treat it as a hard
+review-time requirement.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,128 @@
+"""Alembic environment for Arctos.
+
+Loaded by Alembic's CLI on every invocation. Pulls the live SQLAlchemy
+metadata from ``app.models`` so ``alembic revision --autogenerate`` produces
+migrations that exactly match the running ORM schema, and resolves the
+database URL the same way Flask does (instance-folder relative for SQLite).
+
+The Flask application factory (:func:`app.create_app`) is intentionally
+**not** invoked here. Alembic only needs ``db.metadata`` and a database URL;
+running the full factory would also fire boot-time schedule recomputation,
+OAuth client registration, and ``db.create_all()`` — none of which belong in
+a migration tool, and ``create_all`` would race with the migration we are
+about to apply.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from logging.config import fileConfig
+from pathlib import Path
+
+from alembic import context
+from sqlalchemy import engine_from_config, event, pool
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+# Side-effect import: registers every model class against ``db.metadata``.
+# Must happen before ``target_metadata = db.metadata`` is evaluated below or
+# autogenerate would diff the live database against an empty schema and try
+# to drop every table.
+from app.models import db  # noqa: E402
+
+
+def _resolve_database_url() -> str:
+    """Return the same SQLAlchemy URL the running Flask app would use.
+
+    Resolution order:
+
+    1. ``SQLALCHEMY_DATABASE_URI`` from the environment — lets CI and devs
+       point alembic at a throwaway database without editing files.
+    2. The default ``sqlite:///<repo>/instance/tournament.db``, mirroring
+       Flask's instance-folder convention. The application config string
+       ``sqlite:///tournament.db`` is interpreted by Flask-SQLAlchemy as
+       *relative to the instance folder*; alembic has no concept of an
+       instance folder, so we expand it to an absolute path here.
+    """
+    override = os.environ.get("SQLALCHEMY_DATABASE_URI")
+    if override:
+        return override
+    instance_db = PROJECT_ROOT / "instance" / "tournament.db"
+    return f"sqlite:///{instance_db}"
+
+
+config = context.config
+if not config.get_main_option("sqlalchemy.url"):
+    config.set_main_option("sqlalchemy.url", _resolve_database_url())
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = db.metadata
+
+
+def run_migrations_offline() -> None:
+    """Render the migration as raw SQL without opening a DB connection.
+
+    Used for ``alembic upgrade --sql`` style review workflows. ``render_as_batch``
+    is enabled for SQLite because almost every ``ALTER`` requires the
+    table-rebuild dance that batch mode encapsulates.
+    """
+    url = config.get_main_option("sqlalchemy.url") or ""
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        render_as_batch=url.startswith("sqlite"),
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Apply migrations against a live database connection.
+
+    Mirrors the application's per-connection ``PRAGMA foreign_keys = ON``
+    (see ``app.set_sqlite_pragmas``) so DDL emitted by the migration is
+    checked against existing data — otherwise a migration that adds a FK
+    could pass here and fail in production. The pragma is installed via a
+    ``connect`` event listener rather than ``connection.exec_driver_sql``
+    because the latter would autobegin a transaction; SQLite silently
+    ignores ``PRAGMA foreign_keys`` inside a transaction, AND the orphan
+    transaction would swallow alembic's stamp/version INSERT on close.
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    if connectable.dialect.name == "sqlite":
+
+        @event.listens_for(connectable, "connect")
+        def _enable_sqlite_fk(dbapi_connection, _connection_record):
+            cur = dbapi_connection.cursor()
+            try:
+                cur.execute("PRAGMA foreign_keys = ON")
+            finally:
+                cur.close()
+
+    with connectable.connect() as connection:
+        is_sqlite = connection.dialect.name == "sqlite"
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            render_as_batch=is_sqlite,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,34 @@
+"""${message}
+
+REPLACE THIS PLACEHOLDER with a paragraph (>=20 chars) explaining WHY this
+migration exists, not just what SQL it runs. A docstring like
+"Add headref_allowlist table" is insufficient; prefer something like
+"Normalise Tournament.head_refs_allowed_list (comma-separated player IDs)
+into a proper join table with FK enforcement and a unique constraint."
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/0001_baseline.py
+++ b/migrations/versions/0001_baseline.py
@@ -1,0 +1,55 @@
+"""Baseline — declare the current schema as the alembic starting point.
+
+This revision is intentionally a no-op. It exists so that an existing
+Arctos database (created historically via ``db.create_all()``) can be
+brought under Alembic management with::
+
+    uv run alembic stamp head
+
+after which every subsequent schema change is shipped as a real, versioned
+migration on top of this baseline.
+
+Why an empty migration instead of generating a full ``CREATE TABLE`` script
+for the existing schema?
+
+* Production databases already contain the schema; running a generated
+  ``CREATE TABLE`` upgrade against them would error out.
+* The existing schema is documented by the SQLAlchemy models themselves
+  (``app/models/``), which are the source of truth for ``--autogenerate``
+  diffs going forward.
+* New empty databases (CI, fresh dev clones) are still bootstrapped by the
+  application's start-up ``db.create_all()`` call; Alembic is layered on
+  top of that bootstrap, not in place of it.
+
+After this baseline, the workflow is:
+
+1. ``make db-baseline`` (one-shot per database) stamps this revision.
+2. Edit ``app/models/*`` to declare the new schema.
+3. ``make db-revision MSG="describe_change"`` autogenerates a migration.
+4. Review the generated file, write a real docstring describing *why* the
+   change is being made, then ``make db-migrate``.
+
+Revision ID: 0001_baseline
+Revises:
+Create Date: 2026-04-24
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "0001_baseline"
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """No-op: see module docstring."""
+    pass
+
+
+def downgrade() -> None:
+    """No-op: cannot downgrade past the initial baseline."""
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "alembic>=1.18.4",
     "authlib==1.6.5",
     "bcrypt==5.0.0",
     "bleach==6.3.0",

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# scripts/backup_db.sh — snapshot the live Arctos SQLite database.
+#
+# WHEN TO RUN
+#   Run this script BEFORE every Alembic migration that mutates the schema or
+#   data — that is, before every invocation of `make db-migrate` (or the raw
+#   `uv run alembic upgrade head`). Any migration that adds a constraint,
+#   alters a column type, drops a column, or rebuilds a table is potentially
+#   destructive; skipping a backup before one risks data loss with no
+#   recovery path. Migrations that are pure no-ops (e.g. an empty baseline)
+#   do not need a backup, but running this script anyway is the cheapest way
+#   to verify the backup path and instance-folder permissions are correctly
+#   configured.
+#
+# WHAT IT DOES
+#   Uses SQLite's online `.backup` command (not `cp`) so the snapshot is
+#   internally consistent even if the application is mid-write — `.backup`
+#   acquires the right SQLite locks and copies pages atomically.
+#
+# OUTPUT
+#   Snapshots are written to `backups/<source_basename>-<tag>-<unix_ts>.db`.
+#   The default tag is `pre-migration`; pass a more descriptive tag
+#   explicitly to make the filename self-documenting:
+#
+#     scripts/backup_db.sh                       # backups/tournament-pre-migration-<ts>.db
+#     scripts/backup_db.sh add-unique-email      # backups/tournament-add-unique-email-<ts>.db
+#     scripts/backup_db.sh pre-drop-refs-column  # backups/tournament-pre-drop-refs-column-<ts>.db
+#
+# CONFIGURATION
+#   ARCTOS_DB_PATH    Absolute path to the SQLite file. If unset, defaults
+#                     to `<repo>/instance/tournament.db` (Flask's instance
+#                     folder convention).
+#   ARCTOS_BACKUP_DIR Directory the snapshot is written into. If unset,
+#                     defaults to `<repo>/backups/`.
+#
+# EXIT CODES
+#   0   Backup written successfully.
+#   1   Source database does not exist or `.backup` failed.
+#   2   `sqlite3` CLI not found in PATH.
+#
+# RECOVERY
+#   To restore a snapshot, stop the application, then:
+#
+#     cp backups/tournament-<tag>-<ts>.db instance/tournament.db
+#     rm -f instance/tournament.db-shm instance/tournament.db-wal
+#
+#   The WAL/SHM sidecars must be removed because they belong to the old
+#   database file; SQLite recreates them on the next connection.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DB_PATH="${ARCTOS_DB_PATH:-$REPO_ROOT/instance/tournament.db}"
+BACKUP_DIR="${ARCTOS_BACKUP_DIR:-$REPO_ROOT/backups}"
+TAG="${1:-pre-migration}"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+    echo "error: sqlite3 CLI not found in PATH (install with 'sudo apt-get install sqlite3' or 'brew install sqlite')" >&2
+    exit 2
+fi
+
+if [ ! -f "$DB_PATH" ]; then
+    echo "error: database not found at $DB_PATH" >&2
+    echo "       set ARCTOS_DB_PATH to override the default location" >&2
+    exit 1
+fi
+
+mkdir -p "$BACKUP_DIR"
+
+SRC_BASENAME="$(basename "$DB_PATH" .db)"
+TIMESTAMP="$(date +%s)"
+DEST="$BACKUP_DIR/${SRC_BASENAME}-${TAG}-${TIMESTAMP}.db"
+
+if [ -e "$DEST" ]; then
+    echo "error: refusing to overwrite existing backup at $DEST" >&2
+    exit 1
+fi
+
+echo "Backing up $DB_PATH"
+echo "         -> $DEST"
+sqlite3 "$DB_PATH" ".backup '$DEST'"
+
+# Sanity check: SQLite's PRAGMA integrity_check returns "ok" on a valid file.
+INTEGRITY="$(sqlite3 "$DEST" "PRAGMA integrity_check;" | head -n 1)"
+if [ "$INTEGRITY" != "ok" ]; then
+    echo "error: backup failed integrity check (got: $INTEGRITY)" >&2
+    exit 1
+fi
+
+SIZE_HUMAN="$(du -h "$DEST" | cut -f1)"
+echo "Backup complete (${SIZE_HUMAN}, integrity: ok)."

--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""scripts/check_duplicates.py — find rows that should be unique together.
+
+Several pairs of columns in the Arctos schema *should* be unique together
+but currently have no database-level constraint enforcing it. Examples:
+
+* ``team_registrations(team, event)`` — a team registered twice for the same
+  tournament double-counts toward ``n_max_teams``.
+* ``matches(name, event)`` — the skip-condition DSL looks matches up by name;
+  duplicates make the lookup ambiguous.
+* ``fields(name, event)`` — ``Match.field`` references fields by name; two
+  same-named fields in one event are indistinguishable.
+
+The full list of (table, columns) pairs lives in the ``CHECKS`` constant
+below. The plan is to add a real ``UNIQUE`` constraint for each pair, but
+adding a unique constraint to a table that already contains duplicates
+fails at migration time. This script reports the offenders so they can be
+merged or deleted before the constraint is added.
+
+Usage::
+
+    uv run python scripts/check_duplicates.py            # check default DB
+    uv run python scripts/check_duplicates.py --db /path/to/snapshot.db
+    SQLALCHEMY_DATABASE_URI=sqlite:////tmp/test.db \\
+        uv run python scripts/check_duplicates.py        # via env var
+
+Pre-conditions:
+    * The database file exists and is readable by the current user.
+    * The tables listed in ``CHECKS`` exist (tables that don't are skipped
+      with a note rather than failing).
+
+Exit codes:
+    * ``0`` — every check returned zero duplicate groups.
+    * ``1`` — at least one duplicate group was found. The offending column
+      values are printed so an operator can merge or delete the conflicting
+      rows before any unique-constraint migration is applied.
+
+CI integration:
+    Wire this into the same job that runs the test suite so duplicates
+    introduced by application code are caught early, before they block a
+    schema change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class DuplicateCheck:
+    """One duplicate-detection query.
+
+    Attributes:
+        table: SQL table the check is run against.
+        columns: Tuple of column names that should be unique together.
+        why: Human-readable note explaining the impact of duplicates, so
+            operators reading the report do not have to dig into the schema
+            to understand why a duplicate matters.
+    """
+
+    table: str
+    columns: tuple[str, ...]
+    why: str
+
+
+# Each entry is a (table, columns) pair that should logically be unique together
+# but currently has no database-level UNIQUE constraint. Add new entries here
+# whenever you identify another such pair; the rest of the script picks them up
+# automatically.
+CHECKS: Sequence[DuplicateCheck] = (
+    DuplicateCheck(
+        table="team_registrations",
+        columns=("team", "event"),
+        why="A team can register for the same tournament twice, double-counting toward n_max_teams.",
+    ),
+    DuplicateCheck(
+        table="team_registrations",
+        columns=("team", "league_id"),
+        why="Same as above, for league registrations.",
+    ),
+    DuplicateCheck(
+        table="player_registrations",
+        columns=("player", "event"),
+        why="A player can register multiple times per event.",
+    ),
+    DuplicateCheck(
+        table="player_registrations",
+        columns=("player", "league_id"),
+        why="Same as above, for league registrations.",
+    ),
+    DuplicateCheck(
+        table="headrefs",
+        columns=("player", "event"),
+        why="Duplicate head-ref rows break head-ref counting logic.",
+    ),
+    DuplicateCheck(
+        table="matches",
+        columns=("name", "event"),
+        why="The skip-condition DSL references matches by name; duplicates make it ambiguous.",
+    ),
+    DuplicateCheck(
+        table="tags",
+        columns=("name", "event"),
+        why="ASS expressions look up teams by tag name; duplicates cause silent wrong results.",
+    ),
+    DuplicateCheck(
+        table="fields",
+        columns=("name", "event"),
+        why="Match.field references fields by name string; duplicates are indistinguishable.",
+    ),
+    DuplicateCheck(
+        table="sidecompresults",
+        columns=("comp", "player"),
+        why="A player should have one result per side competition.",
+    ),
+)
+
+
+def _resolve_database_url(cli_db: str | None) -> str:
+    """Pick a database URL using the same precedence as ``migrations/env.py``.
+
+    Args:
+        cli_db: The value passed via ``--db`` on the command line, or ``None``.
+
+    Returns:
+        A SQLAlchemy URL string. Order of precedence: ``--db`` flag, then
+        ``SQLALCHEMY_DATABASE_URI`` from the environment, then the default
+        ``sqlite:///<repo>/instance/tournament.db``.
+    """
+    if cli_db:
+        if cli_db.startswith("sqlite:") or "://" in cli_db:
+            return cli_db
+        return f"sqlite:///{Path(cli_db).expanduser().resolve()}"
+    env = os.environ.get("SQLALCHEMY_DATABASE_URI")
+    if env:
+        return env
+    return f"sqlite:///{PROJECT_ROOT / 'instance' / 'tournament.db'}"
+
+
+def _table_exists(engine: Engine, table_name: str) -> bool:
+    """Return True iff ``table_name`` exists in the connected database.
+
+    Used so that running this script against a freshly created database
+    (where some tables may not yet exist) skips the check with a warning
+    instead of raising an opaque ``OperationalError``.
+    """
+    inspector = sa.inspect(engine)
+    return table_name in inspector.get_table_names()
+
+
+def _run_check(engine: Engine, check: DuplicateCheck) -> list[tuple]:
+    """Execute one duplicate-detection query and return offending rows.
+
+    Rows where any of the grouping columns is ``NULL`` are excluded because
+    SQLite's ``UNIQUE`` constraint treats ``NULL`` values as distinct (SQL-
+    standard ``UNIQUE`` semantics), so such rows would not violate a future
+    unique constraint and reporting them would be a false positive. This
+    matters most for the polymorphic registration tables where every row has
+    exactly one of ``event`` / ``league_id`` set.
+
+    Args:
+        engine: A live SQLAlchemy :class:`~sqlalchemy.engine.Engine`.
+        check: The :class:`DuplicateCheck` to run.
+
+    Returns:
+        A list of tuples, one per duplicate group, of the form
+        ``(*column_values, count)``. Empty if the table is clean.
+    """
+    cols = ", ".join(check.columns)
+    not_null = " AND ".join(f"{c} IS NOT NULL" for c in check.columns)
+    sql = sa.text(
+        f"SELECT {cols}, COUNT(*) AS n "  # noqa: S608 — column names are static, not user input
+        f"FROM {check.table} "
+        f"WHERE {not_null} "
+        f"GROUP BY {cols} "
+        f"HAVING COUNT(*) > 1 "
+        f"ORDER BY n DESC"
+    )
+    with engine.connect() as conn:
+        result = conn.execute(sql)
+        return [tuple(row) for row in result]
+
+
+def _format_report(check: DuplicateCheck, rows: Iterable[tuple]) -> str:
+    """Render a human-readable report for one failing check.
+
+    The output format is intentionally pasteable into a chat or commit
+    message: one line of context, then a markdown table of duplicates.
+    """
+    lines = [
+        f"  table:   {check.table}",
+        f"  columns: {', '.join(check.columns)}",
+        f"  impact:  {check.why}",
+        "  duplicates:",
+    ]
+    header = "    " + " | ".join(list(check.columns) + ["count"])
+    lines.append(header)
+    lines.append("    " + "-" * (len(header) - 4))
+    for row in rows:
+        lines.append("    " + " | ".join(repr(v) for v in row))
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run every check; return 0 if clean, 1 if any duplicates were found.
+
+    Args:
+        argv: Optional argv override (for tests). Defaults to ``sys.argv[1:]``.
+
+    Returns:
+        ``0`` when every table is clean (or all relevant tables are missing),
+        ``1`` when at least one duplicate group was reported.
+    """
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--db",
+        help="Path or SQLAlchemy URL to check. Defaults to instance/tournament.db.",
+    )
+    args = parser.parse_args(argv)
+
+    url = _resolve_database_url(args.db)
+    print(f"Checking duplicates against: {url}")
+    engine = sa.create_engine(url)
+
+    try:
+        any_failures = False
+        skipped: list[str] = []
+        for check in CHECKS:
+            if not _table_exists(engine, check.table):
+                skipped.append(check.table)
+                continue
+            duplicates = _run_check(engine, check)
+            if duplicates:
+                any_failures = True
+                print(f"\n[FAIL] {check.table} ({', '.join(check.columns)}): {len(duplicates)} duplicate group(s)")
+                print(_format_report(check, duplicates))
+            else:
+                print(f"[ ok ] {check.table} ({', '.join(check.columns)})")
+
+        if skipped:
+            unique_skipped = sorted(set(skipped))
+            print(
+                f"\nNote: skipped {len(unique_skipped)} table(s) that do not exist in this DB: "
+                f"{', '.join(unique_skipped)}"
+            )
+    finally:
+        engine.dispose()
+
+    if any_failures:
+        print(
+            "\nResult: duplicates present. Resolve them (merge or delete the "
+            "conflicting rows) before adding a UNIQUE constraint to the affected table."
+        )
+        return 1
+    print("\nResult: all duplicate checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup/Brewfile
+++ b/setup/Brewfile
@@ -1,3 +1,4 @@
 brew "git"
 brew "git-lfs"
 brew "uv"
+brew "sqlite"

--- a/setup/Brewfile
+++ b/setup/Brewfile
@@ -1,4 +1,3 @@
 brew "git"
-brew "git-lfs"
 brew "uv"
 brew "sqlite"

--- a/setup/apt-packages.txt
+++ b/setup/apt-packages.txt
@@ -1,3 +1,2 @@
 git
-git-lfs
 sqlite3

--- a/setup/apt-packages.txt
+++ b/setup/apt-packages.txt
@@ -1,2 +1,3 @@
 git
 git-lfs
+sqlite3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,6 +175,48 @@ def head_ref_player(test_db, tournament):
     return p
 
 
+@pytest.fixture
+def seeded_teams(test_db):
+    """Seed the dummy ``Team`` rows that older tests reference by string ID.
+
+    Many tests insert ``Match.team1``/``team2`` or ``TeamRegistration.team``
+    values like ``"team1"``, ``"team_1"``, etc. without ever creating the
+    corresponding ``Team`` row. SQLite enforces the foreign keys on those
+    columns (see ``app.set_sqlite_pragmas``), so the inserts raise
+    ``IntegrityError`` unless the parent ``Team`` rows already exist.
+
+    Opting into this fixture seeds a superset of the IDs those tests use, so
+    they can keep referencing string literals without each one having to
+    create teams individually. New tests should prefer the explicit ``team``
+    fixture (or build their own teams).
+
+    Returns:
+        The tuple of team IDs that were ensured to exist.
+    """
+    ids = (
+        "team1",
+        "team2",
+        "team3",
+        "team_1",
+        "team_2",
+        "t1",
+        "t2",
+        "t3",
+        "explicit_team",
+        "tag_resolved_team",
+        "resolved_team_a",
+        "resolved_team_b",
+        "resolved_tag_team",
+    )
+    existing = {t.id for t in Team.query.filter(Team.id.in_(ids)).all()}
+    for tid in ids:
+        if tid in existing:
+            continue
+        db.session.add(Team(id=tid, name=tid, pw_hash="dummy_hash"))
+    db.session.commit()
+    return ids
+
+
 def create_match(
     tournament_url,
     name,

--- a/tests/integration/test_match_start.py
+++ b/tests/integration/test_match_start.py
@@ -10,7 +10,7 @@ from tests.utils import login_as
 
 
 @pytest.mark.integration
-def test_start_match_post_starts_match(app, client, tournament, head_ref_player):
+def test_start_match_post_starts_match(app, client, tournament, head_ref_player, seeded_teams):
     """A head ref can successfully start a READY_TO_START match via the API."""
     with app.app_context():
         t = db.session.merge(tournament)
@@ -91,7 +91,9 @@ def test_start_match_post_rejects_overlap(app, client, tournament, head_ref_play
 
 
 @pytest.mark.integration
-def test_start_match_post_rejects_when_another_in_progress_on_same_field(app, client, tournament, head_ref_player):
+def test_start_match_post_rejects_when_another_in_progress_on_same_field(
+    app, client, tournament, head_ref_player, seeded_teams
+):
     """Starting a match on a field that has another match IN_PROGRESS returns 400 with field-busy reason."""
     with app.app_context():
         t = db.session.merge(tournament)

--- a/tests/integration/test_permissions.py
+++ b/tests/integration/test_permissions.py
@@ -1,0 +1,34 @@
+"""Integration tests for TO-guarded routes (HTTP-level permission checks)."""
+
+import pytest
+
+from models import TO, db
+from tests.utils import login_as
+
+
+@pytest.mark.integration
+def test_tournament_manage_requires_to(app, client, tournament, player, test_db):
+    """Non-TO players are redirected away from the manage page."""
+    # Not a TO -> redirect
+    with app.app_context():
+        t = db.session.merge(tournament)
+        p = db.session.merge(player)
+        login_as(client, p)
+
+    resp = client.get(f"/_api/{t.url}/export-schedule", follow_redirects=False)
+    assert resp.status_code in (301, 302, 303, 307, 308)
+
+
+@pytest.mark.integration
+def test_tournament_manage_allows_to(app, client, tournament, player, test_db):
+    """Tournament Organisers can access the manage page (HTTP 200)."""
+    with app.app_context():
+        t = db.session.merge(tournament)
+        p = db.session.merge(player)
+        db.session.add(TO(user_id=p.id, user_type="player", event=t.url))
+        db.session.commit()
+        login_as(client, p)
+        tournament_url = t.url
+
+    resp = client.get(f"/_api/{tournament_url}/export-schedule")
+    assert resp.status_code == 200

--- a/tests/integration/test_update_tags_recompute.py
+++ b/tests/integration/test_update_tags_recompute.py
@@ -8,7 +8,7 @@ from tests.utils import login_as
 
 
 @pytest.mark.integration
-def test_update_tags_recomputes_schedule(app, client, test_db, tournament, player):
+def test_update_tags_recomputes_schedule(app, client, test_db, tournament, player, seeded_teams):
     """After update_tags, recompute_all_match_times runs so match status can transition to READY_TO_START."""
     with app.app_context():
         t = db.session.merge(tournament)

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -8,7 +8,7 @@ from models import Match, db
 
 
 @pytest.mark.unit
-def test_apply_match_dependencies_substitutes_winner_loser_and_refs(test_db, tournament):
+def test_apply_match_dependencies_substitutes_winner_loser_and_refs(test_db, tournament, seeded_teams):
     """apply_match_dependencies replaces winner/loser placeholders in dependent matches."""
     tournament_url = tournament.url
     completed = Match(
@@ -46,7 +46,7 @@ def test_apply_match_dependencies_substitutes_winner_loser_and_refs(test_db, tou
 
 
 @pytest.mark.unit
-def test_apply_match_dependencies_noop_when_no_winner(test_db, tournament):
+def test_apply_match_dependencies_noop_when_no_winner(test_db, tournament, seeded_teams):
     tournament_url = tournament.url
     completed = Match(
         name="Match A",

--- a/tests/unit/test_match_start_eligibility.py
+++ b/tests/unit/test_match_start_eligibility.py
@@ -8,7 +8,7 @@ from models import Field, Match, db
 
 
 @pytest.mark.unit
-def test_can_start_true_when_ref_ready_no_conflict(app, test_db, tournament, head_ref_player):
+def test_can_start_true_when_ref_ready_no_conflict(app, test_db, tournament, head_ref_player, seeded_teams):
     """When user is ref, match is READY_TO_START, and no other match on field, can_start is True."""
     with app.app_context():
         t = db.session.merge(tournament)
@@ -35,7 +35,7 @@ def test_can_start_true_when_ref_ready_no_conflict(app, test_db, tournament, hea
 
 
 @pytest.mark.unit
-def test_can_start_false_field_busy(app, test_db, tournament, head_ref_player):
+def test_can_start_false_field_busy(app, test_db, tournament, head_ref_player, seeded_teams):
     """When another match is IN_PROGRESS on same field, can_start is False with field-busy reason."""
     with app.app_context():
         t = db.session.merge(tournament)
@@ -75,7 +75,7 @@ def test_can_start_false_field_busy(app, test_db, tournament, head_ref_player):
 
 
 @pytest.mark.unit
-def test_can_start_false_user_not_ref(app, test_db, tournament, player):
+def test_can_start_false_user_not_ref(app, test_db, tournament, player, seeded_teams):
     """When user is not in allowed refs list, can_start is False with perms reason."""
     with app.app_context():
         t = db.session.merge(tournament)
@@ -104,7 +104,7 @@ def test_can_start_false_user_not_ref(app, test_db, tournament, player):
 
 
 @pytest.mark.unit
-def test_can_start_false_status_not_ready(app, test_db, tournament, head_ref_player):
+def test_can_start_false_status_not_ready(app, test_db, tournament, head_ref_player, seeded_teams):
     """When match status is NOT_STARTED, can_start is False."""
     with app.app_context():
         t = db.session.merge(tournament)
@@ -131,7 +131,7 @@ def test_can_start_false_status_not_ready(app, test_db, tournament, head_ref_pla
 
 
 @pytest.mark.unit
-def test_can_start_completed_returns_false_no_reasons(app, test_db, tournament, head_ref_player):
+def test_can_start_completed_returns_false_no_reasons(app, test_db, tournament, head_ref_player, seeded_teams):
     """When match is COMPLETED, can_start is False and reasons are empty (match is over)."""
     with app.app_context():
         t = db.session.merge(tournament)

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -1,11 +1,12 @@
-"""Tests for PermissionService and TO-guarded routes."""
+"""Unit tests for PermissionService (no HTTP, no test client)."""
+
+from datetime import datetime, timezone
 
 import pytest
 
 from app.services.permission_service import PermissionService
 from models import TO, Tournament, db
-from datetime import datetime, timezone
-from tests.utils import login_as, make_registrable_config
+from tests.utils import make_registrable_config
 
 
 @pytest.mark.unit
@@ -45,35 +46,14 @@ def test_permission_service_can_view_unpublished_tournament_for_to(app, test_db,
             registrable_config_id=cfg.id,
         )
         db.session.add(t)
+        # Flush so the Tournament row is INSERTed before the TO row that
+        # references it. SQLAlchemy's unit of work only orders inserts via
+        # ``relationship()`` declarations; bare ``ForeignKey`` columns (which
+        # is what ``TO.event`` is) don't establish a dependency, so without
+        # this flush the TO insert can fire first and trip the FK pragma
+        # enabled in ``app.set_sqlite_pragmas``.
+        db.session.flush()
         db.session.add(TO(user_id=p.id, user_type="player", event=t.url))
         db.session.commit()
 
         assert PermissionService.can_view_tournament("private-tournament", p) is True
-
-
-@pytest.mark.integration
-def test_tournament_manage_requires_to(app, client, tournament, player, test_db):
-    """Non-TO players are redirected away from the manage page."""
-    # Not a TO -> redirect
-    with app.app_context():
-        t = db.session.merge(tournament)
-        p = db.session.merge(player)
-        login_as(client, p)
-
-    resp = client.get(f"/_api/{t.url}/export-schedule", follow_redirects=False)
-    assert resp.status_code in (301, 302, 303, 307, 308)
-
-
-@pytest.mark.integration
-def test_tournament_manage_allows_to(app, client, tournament, player, test_db):
-    """Tournament Organisers can access the manage page (HTTP 200)."""
-    with app.app_context():
-        t = db.session.merge(tournament)
-        p = db.session.merge(player)
-        db.session.add(TO(user_id=p.id, user_type="player", event=t.url))
-        db.session.commit()
-        login_as(client, p)
-        tournament_url = t.url
-
-    resp = client.get(f"/_api/{tournament_url}/export-schedule")
-    assert resp.status_code == 200

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -8,7 +8,7 @@ from models import Match, MatchNote, Player, db
 
 
 @pytest.mark.unit
-def test_match_note_serializer_includes_team_id_for_team_targets(test_db, tournament):
+def test_match_note_serializer_includes_team_id_for_team_targets(test_db, tournament, seeded_teams):
     """MatchNoteSerializer.to_dict resolves team_id from the match for team-targeted notes."""
     tournament_url = tournament.url
     p = Player(id="p1", name="Player One")

--- a/tests/unit/test_tag_resolution.py
+++ b/tests/unit/test_tag_resolution.py
@@ -15,7 +15,7 @@ from models import Field, Match, Tag, db
 
 
 @pytest.mark.unit
-def test_update_tags_preserves_explicit_teams_and_match_references(test_db, tournament, app):
+def test_update_tags_preserves_explicit_teams_and_match_references(test_db, tournament, app, seeded_teams):
     """update_tags should only update tag references, preserving explicit teams and match references."""
     tournament_url = tournament.url
 
@@ -119,7 +119,7 @@ def test_update_tags_preserves_explicit_teams_and_match_references(test_db, tour
 
 
 @pytest.mark.unit
-def test_apply_match_dependencies_preserves_explicit_teams_and_tag_resolutions(test_db, tournament, app):
+def test_apply_match_dependencies_preserves_explicit_teams_and_tag_resolutions(test_db, tournament, app, seeded_teams):
     """apply_match_dependencies should only resolve match references, preserving explicit teams and tag resolutions."""
     tournament_url = tournament.url
 
@@ -183,7 +183,7 @@ def test_apply_match_dependencies_preserves_explicit_teams_and_tag_resolutions(t
 
 
 @pytest.mark.unit
-def test_mixed_refs_all_three_types(test_db, tournament, app):
+def test_mixed_refs_all_three_types(test_db, tournament, app, seeded_teams):
     """Test refs_initial with all three types: explicit team, tag reference, and match reference."""
     tournament_url = tournament.url
 
@@ -402,7 +402,7 @@ def test_refs_cleared_when_refs_initial_changes(test_db, tournament, app):
 
 
 @pytest.mark.unit
-def test_team1_team2_with_mixed_references(test_db, tournament, app):
+def test_team1_team2_with_mixed_references(test_db, tournament, app, seeded_teams):
     """Test team1 and team2 fields with explicit teams, tag references, and match references."""
     tournament_url = tournament.url
 

--- a/tests/unit/test_tournament_service.py
+++ b/tests/unit/test_tournament_service.py
@@ -36,7 +36,7 @@ def test_homepage_context_includes_only_published_for_anonymous(test_db):
 
 
 @pytest.mark.unit
-def test_homepage_context_team_counts_grouped_query(test_db):
+def test_homepage_context_team_counts_grouped_query(test_db, seeded_teams):
     """team_counts only counts CONFIRMED registrations, not CANCELLED ones."""
     t_url = "counted"
     t = Tournament(
@@ -47,6 +47,11 @@ def test_homepage_context_team_counts_grouped_query(test_db):
         registrable_config_id=make_registrable_config().id,
     )
     db.session.add(t)
+    # Flush so the FK from team_registrations.event -> tournaments.url is
+    # satisfied when the TeamRegistration rows are inserted. SQLAlchemy does
+    # not auto-order bare-ForeignKey dependencies (only relationship() does),
+    # and the FK pragma in ``app.set_sqlite_pragmas`` enforces the constraint.
+    db.session.flush()
     db.session.add_all(
         [
             TeamRegistration(event=t_url, team="t1", pseudonym="T1", status="CONFIRMED"),
@@ -74,6 +79,10 @@ def test_homepage_context_includes_unpublished_for_to(test_db, player):
         registrable_config_id=make_registrable_config().id,
     )
     db.session.add(priv)
+    # SA does not auto-order bare-ForeignKey dependencies (only relationship()
+    # does), so the parent Tournament row must be INSERTed before the dependent
+    # TO row to satisfy the FK pragma in ``app.set_sqlite_pragmas``.
+    db.session.flush()
     db.session.add(TO(user_id=p.id, user_type="player", event=priv_url))
     db.session.commit()
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,10 +7,25 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "arctos"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "alembic" },
     { name = "authlib" },
     { name = "bcrypt" },
     { name = "bleach" },
@@ -45,6 +60,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.18.4" },
     { name = "authlib", specifier = "==1.6.5" },
     { name = "bcrypt", specifier = "==5.0.0" },
     { name = "bleach", specifier = "==6.3.0" },
@@ -785,6 +801,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
     { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
     { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Enforce Foreign Key Constraints at Runtime
- app/__init__.py: replaced the old _sqlite_pragma listener with a properly named set_sqlite_pragmas. It now applies journal_mode=WAL, busy_timeout=30000, and foreign_keys=ON. The function carries a long docstring spelling out why each pragma is set

Enable Alembic Baseline for future migrations
- Added alembic to dependencies
- New alembic.ini at the repo root with ruff post-write hook so generated migrations stay formatted.
- migrations/env.py boots without invoking create_app() (avoids boot-time schedule recompute and other side effects), resolves sqlite:///instance/tournament.db the same way Flask does, and forces PRAGMA foreign_keys = ON on the migration connection so DDL is checked the same way runtime is.
- migrations/script.py.mako enforces a real docstring placeholder for every generated migration.
- migrations/versions/0001_baseline.py is an explicit, well-documented no-op so existing databases can be brought under Alembic with alembic stamp head.
- migrations/README.md documents the day-to-day workflow.
- Makefile gained db-baseline, db-migrate, db-revision MSG=…, db-current, db-history.

Created backup script
- scripts/backup_db.sh uses the SQLite online .backup (per the doc), writes to backups/<basename>-<phase>-<unix_ts>.db, runs an integrity_check on the snapshot, refuses to clobber, and exits non-zero with a clear message if sqlite3 is missing.
- The module-level header explicitly states purpose, when to run it, what it does, configuration knobs, exit codes, and the recovery procedure (including removing the WAL/SHM sidecars).
- Added sqlite3 / sqlite to setup/apt-packages.txt and the Brewfile so fresh dev machines have it; added backups/ to .gitignore. Wired make db-backup.
Modified and moved tests to get things to work at this stage (since foreign keys werent enforced)

Duplicate Check Script
- scripts/check_duplicates.py runs every query declaratively from a typed DuplicateCheck table. 
= Skips tables that don't exist (so it works against fresh DBs), excludes NULL groups (which SQLite's UNIQUE allows and would be false positives), prints a copy-pasteable report, returns 0/1 for CI use, and accepts --db <path> or SQLALCHEMY_DATABASE_URI. Wired make db-check-duplicates.


Fixed / Move some tests
- Missing parent rows. Tests inserted Match.team1='team1', TeamRegistration.team='t1', etc. without ever creating the corresponding Team rows. Fixed by adding a seeded_teams opt-in fixture in tests/conftest.py that seeds the dummy team IDs legacy tests reference; failing tests now declare it.
- Insert-order race. Tests like test_permission_service_can_view_unpublished_tournament_for_to added a Tournament and a TO(event=t.url) in the same commit. SQLAlchemy's unit of work only orders inserts via relationship() declarations — bare ForeignKey columns establish no dependency — so SA was emitting the TO insert first, which now (correctly) fails. Fixed with explicit db.session.flush() calls between the parent and child adds.