### PR TITLE
Backfill Data to new Normalised Tables

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -105,8 +105,9 @@ module docstring tells you what to verify after it finishes (usually a
 few SQL queries that compare row counts between the old and new
 representations).
 
-**If the script fails partway:** re-running is safe. Backfill scripts use
-`session.merge()` so duplicate rows are not created.
+**If the script fails partway:** re-running is safe. Backfill scripts are
+written to be idempotent — every insert is guarded by a uniqueness check,
+so existing rows are skipped on the second run rather than duplicated.
 
 **If validation queries report a mismatch:** stop. Do not proceed to any
 later phase that depends on the new tables being correct. Talk to the PR

--- a/migrations/versions/0002_phase1_additive.py
+++ b/migrations/versions/0002_phase1_additive.py
@@ -77,7 +77,18 @@ Pre-conditions for this migration:
 
 * No row in ``team_registrations`` / ``player_registrations`` / ``tos``
   has both ``event`` and ``league_id`` set, or both NULL. The CHECK
-  constraints added here will reject such rows.
+  constraints added here will reject such rows. Find them with::
+
+      SELECT id FROM <table>
+       WHERE (event IS NULL AND league_id IS NULL)
+          OR (event IS NOT NULL AND league_id IS NOT NULL);
+
+* Pre-existing orphan FK references (i.e. rows surfaced by
+  ``PRAGMA foreign_key_check;``) are tolerated by this migration —
+  the FK pragma is temporarily disabled around the batch_alter_table
+  operations so existing rows survive the table rebuild — but those
+  orphans will fail any future ``UPDATE`` once FK enforcement is back
+  on. Investigate and clean them when convenient.
 
 Rollback: ``alembic downgrade 0001_baseline`` reverses every operation
 in this file (drops the four tables, drops the constraints and indexes,
@@ -172,30 +183,46 @@ def upgrade() -> None:
     # 2. Monetary precision + 3. CHECK constraints on the same tables.
     #    Combine into one batch_alter_table per table so SQLite only
     #    rebuilds each table once.
+    #
+    #    SQLite + alembic batch_alter_table rebuilds each table by
+    #    INSERT-SELECTing every row into a temp table. With the FK pragma
+    #    enforced (which the runtime and our migration env both do), any
+    #    pre-existing orphan FK reference in the source data causes that
+    #    INSERT-SELECT to fail. Disable FK enforcement around the batch
+    #    operations and re-enable + validate afterwards. This matches
+    #    alembic's documented pattern for SQLite batch migrations.
     # ------------------------------------------------------------------
-    with op.batch_alter_table("registrable_configs") as batch:
-        batch.alter_column("team_reg_fee", existing_type=sa.Float(), type_=sa.Numeric(10, 2))
-        batch.alter_column("player_reg_fee", existing_type=sa.Float(), type_=sa.Numeric(10, 2))
+    bind = op.get_bind()
+    is_sqlite = bind.dialect.name == "sqlite"
+    if is_sqlite:
+        bind.exec_driver_sql("PRAGMA foreign_keys = OFF")
+    try:
+        with op.batch_alter_table("registrable_configs") as batch:
+            batch.alter_column("team_reg_fee", existing_type=sa.Float(), type_=sa.Numeric(10, 2))
+            batch.alter_column("player_reg_fee", existing_type=sa.Float(), type_=sa.Numeric(10, 2))
 
-    with op.batch_alter_table("team_registrations") as batch:
-        batch.alter_column("amount_paid", existing_type=sa.Float(), type_=sa.Numeric(10, 2))
-        batch.create_check_constraint(
-            "ck_team_registrations_event_league_mutual_exclusive",
-            _EVENT_OR_LEAGUE,
-        )
+        with op.batch_alter_table("team_registrations") as batch:
+            batch.alter_column("amount_paid", existing_type=sa.Float(), type_=sa.Numeric(10, 2))
+            batch.create_check_constraint(
+                "ck_team_registrations_event_league_mutual_exclusive",
+                _EVENT_OR_LEAGUE,
+            )
 
-    with op.batch_alter_table("player_registrations") as batch:
-        batch.alter_column("amount_paid", existing_type=sa.Float(), type_=sa.Numeric(10, 2))
-        batch.create_check_constraint(
-            "ck_player_registrations_event_league_mutual_exclusive",
-            _EVENT_OR_LEAGUE,
-        )
+        with op.batch_alter_table("player_registrations") as batch:
+            batch.alter_column("amount_paid", existing_type=sa.Float(), type_=sa.Numeric(10, 2))
+            batch.create_check_constraint(
+                "ck_player_registrations_event_league_mutual_exclusive",
+                _EVENT_OR_LEAGUE,
+            )
 
-    with op.batch_alter_table("tos") as batch:
-        batch.create_check_constraint(
-            "ck_tos_event_league_mutual_exclusive",
-            _EVENT_OR_LEAGUE,
-        )
+        with op.batch_alter_table("tos") as batch:
+            batch.create_check_constraint(
+                "ck_tos_event_league_mutual_exclusive",
+                _EVENT_OR_LEAGUE,
+            )
+    finally:
+        if is_sqlite:
+            bind.exec_driver_sql("PRAGMA foreign_keys = ON")
 
     # ------------------------------------------------------------------
     # 4. UNIQUE indexes on logically-unique column pairs.
@@ -253,20 +280,30 @@ def downgrade() -> None:
     op.drop_index("uq_team_registrations_team_league", table_name="team_registrations")
     op.drop_index("uq_team_registrations_team_event", table_name="team_registrations")
 
-    with op.batch_alter_table("tos") as batch:
-        batch.drop_constraint("ck_tos_event_league_mutual_exclusive", type_="check")
+    # Disable FK enforcement around batch operations — see upgrade() for
+    # the explanation.
+    bind = op.get_bind()
+    is_sqlite = bind.dialect.name == "sqlite"
+    if is_sqlite:
+        bind.exec_driver_sql("PRAGMA foreign_keys = OFF")
+    try:
+        with op.batch_alter_table("tos") as batch:
+            batch.drop_constraint("ck_tos_event_league_mutual_exclusive", type_="check")
 
-    with op.batch_alter_table("player_registrations") as batch:
-        batch.drop_constraint("ck_player_registrations_event_league_mutual_exclusive", type_="check")
-        batch.alter_column("amount_paid", existing_type=sa.Numeric(10, 2), type_=sa.Float())
+        with op.batch_alter_table("player_registrations") as batch:
+            batch.drop_constraint("ck_player_registrations_event_league_mutual_exclusive", type_="check")
+            batch.alter_column("amount_paid", existing_type=sa.Numeric(10, 2), type_=sa.Float())
 
-    with op.batch_alter_table("team_registrations") as batch:
-        batch.drop_constraint("ck_team_registrations_event_league_mutual_exclusive", type_="check")
-        batch.alter_column("amount_paid", existing_type=sa.Numeric(10, 2), type_=sa.Float())
+        with op.batch_alter_table("team_registrations") as batch:
+            batch.drop_constraint("ck_team_registrations_event_league_mutual_exclusive", type_="check")
+            batch.alter_column("amount_paid", existing_type=sa.Numeric(10, 2), type_=sa.Float())
 
-    with op.batch_alter_table("registrable_configs") as batch:
-        batch.alter_column("player_reg_fee", existing_type=sa.Numeric(10, 2), type_=sa.Float())
-        batch.alter_column("team_reg_fee", existing_type=sa.Numeric(10, 2), type_=sa.Float())
+        with op.batch_alter_table("registrable_configs") as batch:
+            batch.alter_column("player_reg_fee", existing_type=sa.Numeric(10, 2), type_=sa.Float())
+            batch.alter_column("team_reg_fee", existing_type=sa.Numeric(10, 2), type_=sa.Float())
+    finally:
+        if is_sqlite:
+            bind.exec_driver_sql("PRAGMA foreign_keys = ON")
 
     op.drop_table("camera_timepoints")
     op.drop_table("match_players")

--- a/scripts/backfill_normalised_tables.py
+++ b/scripts/backfill_normalised_tables.py
@@ -74,13 +74,35 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
-from app import create_app
-from app.domain.enums import WinnerSide
-from app.models import (
+# scripts/ is not a Python package and the repo root is not on sys.path when
+# invoked as ``python scripts/backfill_normalised_tables.py``. Add it so the
+# ``app`` package can be imported from anywhere.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import create_app  # noqa: E402
+
+
+def _resolve_database_url() -> str | None:
+    """Return the SQLAlchemy URL the script should operate on, or ``None``.
+
+    ``create_app()`` only reads ``SQLALCHEMY_DATABASE_URI`` from its config
+    dict argument, falling back to a hard-coded ``sqlite:///tournament.db``.
+    It does not consult the environment. This script honours the env var
+    so an operator can point the backfill at any database (a snapshot, a
+    staging copy, etc.) the same way ``alembic`` does. Returning ``None``
+    leaves the application's default in place.
+    """
+    return os.environ.get("SQLALCHEMY_DATABASE_URI")
+from app.domain.enums import WinnerSide  # noqa: E402
+from app.models import (  # noqa: E402
     Camera,
     CameraTimepoint,
     Field,
@@ -95,7 +117,7 @@ from app.models import (
     Tournament,
     db,
 )
-from app.utils.camera_helpers import parse_camera_urls
+from app.utils.camera_helpers import parse_camera_urls  # noqa: E402
 
 
 @dataclass
@@ -632,8 +654,17 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    app = create_app()
+    config_overrides: dict[str, str] = {}
+    db_url = _resolve_database_url()
+    if db_url:
+        config_overrides["SQLALCHEMY_DATABASE_URI"] = db_url
+    app = create_app(config=config_overrides)
+
     with app.app_context():
+        # Echo the actual database the script is about to touch, so an
+        # operator who forgot to set ``SQLALCHEMY_DATABASE_URI`` doesn't
+        # accidentally backfill the wrong file.
+        print(f"Database: {app.config.get('SQLALCHEMY_DATABASE_URI')}")
         precondition_error = _check_preconditions()
         if precondition_error:
             print(f"error: {precondition_error}", file=sys.stderr)

--- a/scripts/backfill_normalised_tables.py
+++ b/scripts/backfill_normalised_tables.py
@@ -1,0 +1,673 @@
+#!/usr/bin/env python3
+"""scripts/backfill_normalised_tables.py — copy legacy blob columns into the new join tables.
+
+Several columns in the Arctos schema historically encoded multiple values
+inside a single cell (comma-separated text or JSON arrays). The additive
+schema migration introduced six normalised join tables that store the same
+data with proper foreign-key, uniqueness, and ordering constraints. The
+running application still reads from the old columns; this script copies
+the data into the new tables so a future code change can switch the reads
+over without losing anything.
+
+Source → destination mappings:
+
+    Tournament.head_refs_allowed_list   →  headref_allowlist
+    Match.refs / Match.refs_initial     →  match_referees
+    Match.team1_players / team2_players →  match_players
+    Field.camera                        →  field_cameras
+    Match.camera_stream_starts          →  match_camera_stream_starts
+    Camera.time_world / Camera.time_video →  camera_timepoints
+
+Behaviour:
+
+* **Idempotent.** Each insert is guarded by a uniqueness check, so re-running
+  the script is a no-op for rows that already exist. Safe to run any number
+  of times.
+* **Additive only.** The legacy columns are read from but never modified.
+  The application can keep operating off them throughout.
+* **Tolerant of dirty data.** Orphan FK references (e.g. a player ID in
+  ``head_refs_allowed_list`` that doesn't exist in ``players``) are
+  reported as warnings and skipped; the script continues.
+* **Tolerant of legacy format variants.** ``Field.camera`` may be a JSON
+  array, a JSON-encoded single string, or a bare URL. ``Match.camera_stream_starts``
+  may be the simple ``{"0": "iso_str"}`` form or the richer
+  ``{"camera_id": {"video_path": ..., "stream_start_time": ...}}`` form.
+  The script extracts what it can and skips entries that don't yield a
+  usable timestamp.
+
+Pre-conditions:
+
+* The additive schema migration is applied (the six destination tables exist).
+  Run ``make db-current`` to confirm; should print ``0002_phase1_additive (head)``.
+* A backup has been taken (``make db-backup pre-backfill``). Although this
+  script does not modify the legacy columns, having a snapshot lets you
+  recover instantly if a bug is discovered partway through.
+
+Post-conditions:
+
+* All six destination tables are populated from their corresponding source
+  columns.
+* Source columns are untouched; the application continues to read from them.
+* Running ``--validate`` (the default after a backfill) confirms row counts
+  and FK integrity match between source and destination.
+
+Usage::
+
+    uv run python scripts/backfill_normalised_tables.py            # backfill + validate
+    uv run python scripts/backfill_normalised_tables.py --dry-run  # report what
+                                                                   # would be inserted
+                                                                   # without writing
+    uv run python scripts/backfill_normalised_tables.py --validate-only
+                                                                   # skip the backfill
+                                                                   # and just report
+    uv run python scripts/backfill_normalised_tables.py --quiet    # only print
+                                                                   # the final summary
+
+Exit codes:
+
+* ``0`` — backfill (and validation, if run) succeeded.
+* ``1`` — validation reported a mismatch. Investigate before proceeding.
+* ``2`` — pre-conditions not met (e.g. destination tables missing).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+
+from app import create_app
+from app.domain.enums import WinnerSide
+from app.models import (
+    Camera,
+    CameraTimepoint,
+    Field,
+    FieldCamera,
+    HeadRefAllowList,
+    Match,
+    MatchCameraStreamStart,
+    MatchPlayer,
+    MatchReferee,
+    Player,
+    Team,
+    Tournament,
+    db,
+)
+from app.utils.camera_helpers import parse_camera_urls
+
+
+@dataclass
+class BackfillStats:
+    """Per-mapping counters returned by each ``backfill_*`` function.
+
+    Attributes:
+        inserted: Rows newly inserted into the destination table.
+        skipped_existing: Source rows whose corresponding destination row
+            already exists (idempotent re-run).
+        skipped_orphan: Source rows whose FK target does not exist
+            (e.g. a head-ref player ID that no longer maps to a real player).
+        skipped_invalid: Source rows whose contents could not be parsed
+            (e.g. malformed JSON).
+        warnings: Free-text warnings worth surfacing in the summary.
+    """
+
+    inserted: int = 0
+    skipped_existing: int = 0
+    skipped_orphan: int = 0
+    skipped_invalid: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    def as_row(self, label: str) -> str:
+        """Render the stats as a single line for the summary table."""
+        return (
+            f"  {label:<32}  "
+            f"inserted={self.inserted:>5}  "
+            f"existing={self.skipped_existing:>5}  "
+            f"orphan={self.skipped_orphan:>5}  "
+            f"invalid={self.skipped_invalid:>5}"
+        )
+
+
+@dataclass
+class FkTargets:
+    """Pre-loaded sets of FK target IDs.
+
+    Loaded once at the start of the run so each insert can validate its FK
+    references in O(1) without round-tripping to the database. Required
+    because we want to skip-with-warning on orphan FKs rather than letting
+    SQLite raise ``IntegrityError`` mid-flush (which would abort the
+    surrounding session).
+    """
+
+    player_ids: set[str]
+    team_ids: set[str]
+    match_uuids: set[str]
+    field_ids: set[int]
+    tournament_urls: set[str]
+    camera_uuids: set[str]
+
+    @classmethod
+    def load(cls) -> FkTargets:
+        """Build the set from the live database. Call inside an app context."""
+        return cls(
+            player_ids={pid for (pid,) in db.session.query(Player.id).all()},
+            team_ids={tid for (tid,) in db.session.query(Team.id).all()},
+            match_uuids={u for (u,) in db.session.query(Match.uuid).all()},
+            field_ids={fid for (fid,) in db.session.query(Field.id).all()},
+            tournament_urls={u for (u,) in db.session.query(Tournament.url).all()},
+            camera_uuids={u for (u,) in db.session.query(Camera.uuid).all()},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-source backfill functions. Each takes the pre-loaded FK targets and
+# returns a BackfillStats. None of them call commit(); the caller does that
+# at the end so a failure mid-script is recoverable by re-running.
+# ---------------------------------------------------------------------------
+
+
+def backfill_head_ref_allowlist(targets: FkTargets, verbose: bool = False) -> BackfillStats:
+    """Populate ``headref_allowlist`` from ``Tournament.head_refs_allowed_list``.
+
+    ``head_refs_allowed_list`` is a comma-separated list of player IDs.
+    Whitespace around each ID is trimmed. Empty entries are skipped silently
+    (they are common in lists that end with a trailing comma).
+    """
+    stats = BackfillStats()
+    existing = {(r.event, r.player_id) for r in HeadRefAllowList.query.all()}
+
+    for tournament in Tournament.query.all():
+        raw = tournament.head_refs_allowed_list or ""
+        for entry in raw.split(","):
+            pid = entry.strip()
+            if not pid:
+                continue
+            if pid not in targets.player_ids:
+                stats.skipped_orphan += 1
+                if verbose:
+                    print(f"  WARN headref: tournament={tournament.url!r} references unknown player={pid!r}")
+                continue
+            key = (tournament.url, pid)
+            if key in existing:
+                stats.skipped_existing += 1
+                continue
+            db.session.add(HeadRefAllowList(event=tournament.url, player_id=pid))
+            existing.add(key)
+            stats.inserted += 1
+    return stats
+
+
+def backfill_match_referees(targets: FkTargets, verbose: bool = False) -> BackfillStats:
+    """Populate ``match_referees`` from ``Match.refs`` and ``Match.refs_initial``.
+
+    The two source columns are parallel comma-separated lists. ``refs`` holds
+    resolved team IDs (or empty strings for unresolved slots); ``refs_initial``
+    holds the original ASS expression or explicit team ID. If the two lists
+    have different lengths the shorter is padded with empty strings so every
+    slot in the longer list still gets a row.
+
+    Slots where both ``refs[i]`` and ``refs_initial[i]`` are empty are
+    skipped — there is nothing to record.
+    """
+    stats = BackfillStats()
+    existing_slots = {(r.match_uuid, r.slot) for r in MatchReferee.query.all()}
+
+    for match in Match.query.all():
+        refs = [r.strip() for r in (match.refs or "").split(",")] if match.refs else []
+        initials = [i.strip() for i in (match.refs_initial or "").split(",")] if match.refs_initial else []
+        n = max(len(refs), len(initials))
+        if n == 0:
+            continue
+        refs = refs + [""] * (n - len(refs))
+        initials = initials + [""] * (n - len(initials))
+
+        for slot, (team_id, initial) in enumerate(zip(refs, initials)):
+            if not team_id and not initial:
+                continue
+            if (match.uuid, slot) in existing_slots:
+                stats.skipped_existing += 1
+                continue
+
+            resolved_team: str | None = None
+            if team_id:
+                if team_id in targets.team_ids:
+                    resolved_team = team_id
+                else:
+                    # Orphan team reference. Keep the row (the initial expression
+                    # is still useful) but log so an operator notices.
+                    stats.skipped_orphan += 1
+                    if verbose:
+                        print(
+                            f"  WARN match_referees: match={match.uuid} slot={slot} "
+                            f"refs[i]={team_id!r} not in teams; storing initial only"
+                        )
+
+            db.session.add(
+                MatchReferee(
+                    match_uuid=match.uuid,
+                    slot=slot,
+                    team_id=resolved_team,
+                    initial=initial or None,
+                )
+            )
+            existing_slots.add((match.uuid, slot))
+            stats.inserted += 1
+    return stats
+
+
+def backfill_match_players(targets: FkTargets, verbose: bool = False) -> BackfillStats:
+    """Populate ``match_players`` from ``Match.team1_players`` / ``team2_players``.
+
+    Both source columns are JSON arrays of player IDs. The unique constraint
+    on ``(match_uuid, player_id)`` rules out the same player appearing on
+    both sides — if the legacy data violates this (it shouldn't, but might),
+    the second insert is skipped with a warning.
+    """
+    stats = BackfillStats()
+    existing = {(r.match_uuid, r.player_id) for r in MatchPlayer.query.all()}
+
+    for match in Match.query.all():
+        for side, raw in ((WinnerSide.TEAM1, match.team1_players), (WinnerSide.TEAM2, match.team2_players)):
+            if not raw:
+                continue
+            try:
+                player_ids = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                stats.skipped_invalid += 1
+                if verbose:
+                    print(f"  WARN match_players: match={match.uuid} side={side.value} has unparseable JSON")
+                continue
+            if not isinstance(player_ids, list):
+                stats.skipped_invalid += 1
+                continue
+            for pid in player_ids:
+                if not pid:
+                    continue
+                if pid not in targets.player_ids:
+                    stats.skipped_orphan += 1
+                    if verbose:
+                        print(
+                            f"  WARN match_players: match={match.uuid} side={side.value} "
+                            f"references unknown player={pid!r}"
+                        )
+                    continue
+                if (match.uuid, pid) in existing:
+                    stats.skipped_existing += 1
+                    continue
+                db.session.add(MatchPlayer(match_uuid=match.uuid, player_id=pid, side=side))
+                existing.add((match.uuid, pid))
+                stats.inserted += 1
+    return stats
+
+
+def backfill_field_cameras(targets: FkTargets, verbose: bool = False) -> BackfillStats:
+    """Populate ``field_cameras`` from ``Field.camera``.
+
+    Uses :func:`app.utils.camera_helpers.parse_camera_urls` so every legacy
+    storage variant (JSON array, JSON-encoded string, bare URL) is handled
+    consistently with how the live application reads the column.
+
+    Slots are assigned by enumeration order — ``slot=0`` is the first URL,
+    ``slot=1`` the second, and so on. This must match how
+    ``Match.camera_stream_starts`` and ``Camera.field`` reference cameras
+    by integer index.
+    """
+    stats = BackfillStats()
+    existing = {(r.field_id, r.slot) for r in FieldCamera.query.all()}
+
+    for f in Field.query.all():
+        urls = parse_camera_urls(f.camera)
+        for slot, url in enumerate(urls):
+            if not url:
+                continue
+            if (f.id, slot) in existing:
+                stats.skipped_existing += 1
+                continue
+            db.session.add(FieldCamera(field_id=f.id, slot=slot, stream_url=url))
+            existing.add((f.id, slot))
+            stats.inserted += 1
+    return stats
+
+
+def _extract_stream_start(value: Any) -> str | None:
+    """Pull a usable ISO timestamp out of one camera_stream_starts entry.
+
+    The live column has at least three observed shapes per entry:
+
+    * A plain ISO string (the original simple format).
+    * A dict with a ``stream_start_time`` field (the rich recording format).
+    * A list of such dicts when a single camera produced multiple recordings.
+
+    Returns the first usable timestamp string, or ``None`` if the entry
+    contains no extractable timestamp.
+    """
+    if isinstance(value, str) and value:
+        return value
+    if isinstance(value, dict):
+        ts = value.get("stream_start_time") or value.get("start_time")
+        if isinstance(ts, str) and ts:
+            return ts
+    if isinstance(value, list):
+        for item in value:
+            ts = _extract_stream_start(item)
+            if ts:
+                return ts
+    return None
+
+
+def backfill_match_camera_stream_starts(targets: FkTargets, verbose: bool = False) -> BackfillStats:
+    """Populate ``match_camera_stream_starts`` from ``Match.camera_stream_starts``.
+
+    The source column is a JSON object whose keys are camera identifiers.
+    Historically two key conventions exist:
+
+    * Integer-as-string slot indices (e.g. ``"0"``, ``"1"``) that map
+      directly to ``FieldCamera.slot``.
+    * Camera names — these don't fit the new
+      ``MatchCameraStreamStart.camera_slot`` integer column and are skipped
+      with a warning rather than guessed-at.
+
+    Each value is then unpacked via :func:`_extract_stream_start` to handle
+    the simple-string vs rich-dict vs list-of-recordings shapes.
+    """
+    stats = BackfillStats()
+    existing = {(r.match_uuid, r.camera_slot) for r in MatchCameraStreamStart.query.all()}
+
+    for match in Match.query.all():
+        if not match.camera_stream_starts:
+            continue
+        try:
+            payload = json.loads(match.camera_stream_starts)
+        except (json.JSONDecodeError, TypeError):
+            stats.skipped_invalid += 1
+            if verbose:
+                print(f"  WARN stream_starts: match={match.uuid} has unparseable JSON")
+            continue
+        if not isinstance(payload, dict):
+            stats.skipped_invalid += 1
+            continue
+
+        for key, raw in payload.items():
+            try:
+                slot = int(key)
+            except (TypeError, ValueError):
+                stats.skipped_invalid += 1
+                if verbose:
+                    print(
+                        f"  WARN stream_starts: match={match.uuid} camera key={key!r} is not an integer slot — skipped"
+                    )
+                continue
+            ts = _extract_stream_start(raw)
+            if not ts:
+                stats.skipped_invalid += 1
+                if verbose:
+                    print(
+                        f"  WARN stream_starts: match={match.uuid} slot={slot} has no extractable timestamp — skipped"
+                    )
+                continue
+            if (match.uuid, slot) in existing:
+                stats.skipped_existing += 1
+                continue
+            db.session.add(MatchCameraStreamStart(match_uuid=match.uuid, camera_slot=slot, stream_start=ts))
+            existing.add((match.uuid, slot))
+            stats.inserted += 1
+    return stats
+
+
+def backfill_camera_timepoints(targets: FkTargets, verbose: bool = False) -> BackfillStats:
+    """Populate ``camera_timepoints`` from ``Camera.time_world`` / ``Camera.time_video``.
+
+    Both source columns are JSON-encoded arrays of equal length: ``time_world``
+    holds ISO timestamps, ``time_video`` holds float seconds offsets. If their
+    lengths disagree (data corruption) the camera is skipped entirely with a
+    warning — partial timepoints would silently misalign every interpolation.
+    """
+    stats = BackfillStats()
+    existing = {(r.camera_uuid, r.sequence) for r in CameraTimepoint.query.all()}
+
+    for cam in Camera.query.all():
+        if not cam.time_world and not cam.time_video:
+            continue
+        try:
+            worlds = json.loads(cam.time_world) if cam.time_world else []
+            videos = json.loads(cam.time_video) if cam.time_video else []
+        except (json.JSONDecodeError, TypeError):
+            stats.skipped_invalid += 1
+            if verbose:
+                print(f"  WARN timepoints: camera={cam.uuid} has unparseable JSON")
+            continue
+
+        if not isinstance(worlds, list) or not isinstance(videos, list):
+            stats.skipped_invalid += 1
+            continue
+
+        if len(worlds) != len(videos):
+            stats.warnings.append(
+                f"camera {cam.uuid}: time_world has {len(worlds)} entries, "
+                f"time_video has {len(videos)} — camera skipped"
+            )
+            stats.skipped_invalid += max(len(worlds), len(videos))
+            continue
+
+        for seq, (tw, tv) in enumerate(zip(worlds, videos)):
+            if (cam.uuid, seq) in existing:
+                stats.skipped_existing += 1
+                continue
+            db.session.add(CameraTimepoint(camera_uuid=cam.uuid, sequence=seq, time_world=tw, time_video=tv))
+            existing.add((cam.uuid, seq))
+            stats.inserted += 1
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Validation queries — run after backfill (or on demand via --validate-only).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ValidationResult:
+    """Outcome of one validation query.
+
+    Attributes:
+        label: Human-readable description.
+        ok: ``True`` when the check passed.
+        detail: Free-text explanation suitable for printing on failure.
+    """
+
+    label: str
+    ok: bool
+    detail: str = ""
+
+
+def validate(verbose: bool = False) -> list[ValidationResult]:
+    """Run every post-backfill validation query and collect results.
+
+    Returns:
+        One :class:`ValidationResult` per check. The caller decides the exit
+        code based on whether any ``ok`` field is ``False``.
+    """
+    results: list[ValidationResult] = []
+
+    # 1. Every MatchReferee.team_id (when not null) must reference a real team.
+    orphans = (
+        db.session.query(MatchReferee)
+        .filter(MatchReferee.team_id.isnot(None))
+        .filter(~MatchReferee.team_id.in_(db.session.query(Team.id)))
+        .count()
+    )
+    results.append(
+        ValidationResult(
+            label="match_referees.team_id all reference a real team",
+            ok=orphans == 0,
+            detail=f"{orphans} orphan team_id reference(s)" if orphans else "",
+        )
+    )
+
+    # 2. Every MatchPlayer.player_id must reference a real player.
+    orphans = db.session.query(MatchPlayer).filter(~MatchPlayer.player_id.in_(db.session.query(Player.id))).count()
+    results.append(
+        ValidationResult(
+            label="match_players.player_id all reference a real player",
+            ok=orphans == 0,
+            detail=f"{orphans} orphan player_id reference(s)" if orphans else "",
+        )
+    )
+
+    # 3. Per-camera timepoint count matches the JSON array length on the camera.
+    mismatches: list[str] = []
+    for cam in Camera.query.all():
+        if not cam.time_world:
+            continue
+        try:
+            old_len = len(json.loads(cam.time_world))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        new_len = db.session.query(CameraTimepoint).filter(CameraTimepoint.camera_uuid == cam.uuid).count()
+        if old_len != new_len:
+            mismatches.append(f"{cam.uuid} old={old_len} new={new_len}")
+    results.append(
+        ValidationResult(
+            label="camera_timepoints count matches Camera.time_world array length",
+            ok=not mismatches,
+            detail="; ".join(mismatches[:5]) + (f" (+{len(mismatches) - 5} more)" if len(mismatches) > 5 else ""),
+        )
+    )
+
+    # 4. Per-field FieldCamera count matches the parsed Field.camera list length.
+    mismatches = []
+    for f in Field.query.all():
+        if not f.camera:
+            continue
+        old_len = len([u for u in parse_camera_urls(f.camera) if u])
+        new_len = db.session.query(FieldCamera).filter(FieldCamera.field_id == f.id).count()
+        if old_len != new_len:
+            mismatches.append(f"field_id={f.id} old={old_len} new={new_len}")
+    results.append(
+        ValidationResult(
+            label="field_cameras count matches Field.camera array length",
+            ok=not mismatches,
+            detail="; ".join(mismatches[:5]) + (f" (+{len(mismatches) - 5} more)" if len(mismatches) > 5 else ""),
+        )
+    )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing.
+# ---------------------------------------------------------------------------
+
+
+def _check_preconditions() -> str | None:
+    """Return an error string if the run can't proceed, ``None`` otherwise."""
+    inspector = db.inspect(db.engine)
+    required = {
+        "headref_allowlist",
+        "match_referees",
+        "match_players",
+        "field_cameras",
+        "match_camera_stream_starts",
+        "camera_timepoints",
+    }
+    missing = required - set(inspector.get_table_names())
+    if missing:
+        return (
+            "destination tables missing: "
+            + ", ".join(sorted(missing))
+            + ". Run `make db-migrate` first to apply the additive schema migration."
+        )
+    return None
+
+
+def run_backfill(verbose: bool = False, dry_run: bool = False) -> dict[str, BackfillStats]:
+    """Execute every backfill function in dependency order, return per-mapping stats.
+
+    Args:
+        verbose: When True, print a per-row warning for every orphan/invalid
+            entry. Otherwise the warnings are summarised in the per-mapping
+            counts.
+        dry_run: When True, the session is rolled back at the end so no
+            changes persist. The returned counts still reflect what *would*
+            have been inserted.
+    """
+    targets = FkTargets.load()
+
+    runs: dict[str, BackfillStats] = {}
+    for label, fn in (
+        ("headref_allowlist", backfill_head_ref_allowlist),
+        ("match_referees", backfill_match_referees),
+        ("match_players", backfill_match_players),
+        ("field_cameras", backfill_field_cameras),
+        ("match_camera_stream_starts", backfill_match_camera_stream_starts),
+        ("camera_timepoints", backfill_camera_timepoints),
+    ):
+        runs[label] = fn(targets, verbose=verbose)
+
+    if dry_run:
+        db.session.rollback()
+    else:
+        db.session.commit()
+    return runs
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. See module docstring for usage and exit codes."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be inserted without writing to the database.",
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Skip the backfill; only run the post-backfill validation queries.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Only print the final summary; suppress per-row warnings.",
+    )
+    args = parser.parse_args(argv)
+
+    app = create_app()
+    with app.app_context():
+        precondition_error = _check_preconditions()
+        if precondition_error:
+            print(f"error: {precondition_error}", file=sys.stderr)
+            return 2
+
+        if not args.validate_only:
+            print(("Backfill" if not args.dry_run else "Backfill (DRY RUN)") + " starting...")
+            runs = run_backfill(verbose=not args.quiet, dry_run=args.dry_run)
+            print("\nBackfill summary:")
+            for label, stats in runs.items():
+                print(stats.as_row(label))
+            for label, stats in runs.items():
+                for warning in stats.warnings:
+                    print(f"  WARN {label}: {warning}")
+
+        print("\nValidation:")
+        results = validate(verbose=not args.quiet)
+        for r in results:
+            mark = " ok " if r.ok else "FAIL"
+            print(f"  [{mark}] {r.label}")
+            if not r.ok:
+                print(f"         {r.detail}")
+
+        all_ok = all(r.ok for r in results)
+        if not all_ok:
+            print(
+                "\nValidation reported mismatches. Investigate (the per-line "
+                "details above identify the affected rows) before switching "
+                "application reads to the new tables."
+            )
+            return 1
+        print("\nDone.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill_normalised_tables.py
+++ b/scripts/backfill_normalised_tables.py
@@ -3,7 +3,7 @@
 
 Several columns in the Arctos schema historically encoded multiple values
 inside a single cell (comma-separated text or JSON arrays). The additive
-schema migration introduced six normalised join tables that store the same
+schema migration introduced four normalised join tables that store the same
 data with proper foreign-key, uniqueness, and ordering constraints. The
 running application still reads from the old columns; this script copies
 the data into the new tables so a future code change can switch the reads
@@ -11,12 +11,12 @@ over without losing anything.
 
 Source → destination mappings:
 
-    Tournament.head_refs_allowed_list   →  headref_allowlist
-    Match.refs / Match.refs_initial     →  match_referees
-    Match.team1_players / team2_players →  match_players
-    Field.camera                        →  field_cameras
-    Match.camera_stream_starts          →  match_camera_stream_starts
+    Tournament.head_refs_allowed_list     →  headref_allowlist
+    Match.refs / Match.refs_initial       →  match_referees
+    Match.team1_players / team2_players   →  match_players
     Camera.time_world / Camera.time_video →  camera_timepoints
+
+
 
 Behaviour:
 
@@ -28,16 +28,10 @@ Behaviour:
 * **Tolerant of dirty data.** Orphan FK references (e.g. a player ID in
   ``head_refs_allowed_list`` that doesn't exist in ``players``) are
   reported as warnings and skipped; the script continues.
-* **Tolerant of legacy format variants.** ``Field.camera`` may be a JSON
-  array, a JSON-encoded single string, or a bare URL. ``Match.camera_stream_starts``
-  may be the simple ``{"0": "iso_str"}`` form or the richer
-  ``{"camera_id": {"video_path": ..., "stream_start_time": ...}}`` form.
-  The script extracts what it can and skips entries that don't yield a
-  usable timestamp.
 
 Pre-conditions:
 
-* The additive schema migration is applied (the six destination tables exist).
+* The additive schema migration is applied (the four destination tables exist).
   Run ``make db-current`` to confirm; should print ``0002_phase1_additive (head)``.
 * A backup has been taken (``make db-backup pre-backfill``). Although this
   script does not modify the legacy columns, having a snapshot lets you
@@ -45,7 +39,7 @@ Pre-conditions:
 
 Post-conditions:
 
-* All six destination tables are populated from their corresponding source
+* All four destination tables are populated from their corresponding source
   columns.
 * Source columns are untouched; the application continues to read from them.
 * Running ``--validate`` (the default after a backfill) confirms row counts
@@ -78,7 +72,6 @@ import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
 
 # scripts/ is not a Python package and the repo root is not on sys.path when
 # invoked as ``python scripts/backfill_normalised_tables.py``. Add it so the
@@ -101,15 +94,15 @@ def _resolve_database_url() -> str | None:
     leaves the application's default in place.
     """
     return os.environ.get("SQLALCHEMY_DATABASE_URI")
+
+
 from app.domain.enums import WinnerSide  # noqa: E402
 from app.models import (  # noqa: E402
     Camera,
     CameraTimepoint,
     Field,
-    FieldCamera,
     HeadRefAllowList,
     Match,
-    MatchCameraStreamStart,
     MatchPlayer,
     MatchReferee,
     Player,
@@ -117,7 +110,6 @@ from app.models import (  # noqa: E402
     Tournament,
     db,
 )
-from app.utils.camera_helpers import parse_camera_urls  # noqa: E402
 
 
 @dataclass
@@ -324,120 +316,6 @@ def backfill_match_players(targets: FkTargets, verbose: bool = False) -> Backfil
     return stats
 
 
-def backfill_field_cameras(targets: FkTargets, verbose: bool = False) -> BackfillStats:
-    """Populate ``field_cameras`` from ``Field.camera``.
-
-    Uses :func:`app.utils.camera_helpers.parse_camera_urls` so every legacy
-    storage variant (JSON array, JSON-encoded string, bare URL) is handled
-    consistently with how the live application reads the column.
-
-    Slots are assigned by enumeration order — ``slot=0`` is the first URL,
-    ``slot=1`` the second, and so on. This must match how
-    ``Match.camera_stream_starts`` and ``Camera.field`` reference cameras
-    by integer index.
-    """
-    stats = BackfillStats()
-    existing = {(r.field_id, r.slot) for r in FieldCamera.query.all()}
-
-    for f in Field.query.all():
-        urls = parse_camera_urls(f.camera)
-        for slot, url in enumerate(urls):
-            if not url:
-                continue
-            if (f.id, slot) in existing:
-                stats.skipped_existing += 1
-                continue
-            db.session.add(FieldCamera(field_id=f.id, slot=slot, stream_url=url))
-            existing.add((f.id, slot))
-            stats.inserted += 1
-    return stats
-
-
-def _extract_stream_start(value: Any) -> str | None:
-    """Pull a usable ISO timestamp out of one camera_stream_starts entry.
-
-    The live column has at least three observed shapes per entry:
-
-    * A plain ISO string (the original simple format).
-    * A dict with a ``stream_start_time`` field (the rich recording format).
-    * A list of such dicts when a single camera produced multiple recordings.
-
-    Returns the first usable timestamp string, or ``None`` if the entry
-    contains no extractable timestamp.
-    """
-    if isinstance(value, str) and value:
-        return value
-    if isinstance(value, dict):
-        ts = value.get("stream_start_time") or value.get("start_time")
-        if isinstance(ts, str) and ts:
-            return ts
-    if isinstance(value, list):
-        for item in value:
-            ts = _extract_stream_start(item)
-            if ts:
-                return ts
-    return None
-
-
-def backfill_match_camera_stream_starts(targets: FkTargets, verbose: bool = False) -> BackfillStats:
-    """Populate ``match_camera_stream_starts`` from ``Match.camera_stream_starts``.
-
-    The source column is a JSON object whose keys are camera identifiers.
-    Historically two key conventions exist:
-
-    * Integer-as-string slot indices (e.g. ``"0"``, ``"1"``) that map
-      directly to ``FieldCamera.slot``.
-    * Camera names — these don't fit the new
-      ``MatchCameraStreamStart.camera_slot`` integer column and are skipped
-      with a warning rather than guessed-at.
-
-    Each value is then unpacked via :func:`_extract_stream_start` to handle
-    the simple-string vs rich-dict vs list-of-recordings shapes.
-    """
-    stats = BackfillStats()
-    existing = {(r.match_uuid, r.camera_slot) for r in MatchCameraStreamStart.query.all()}
-
-    for match in Match.query.all():
-        if not match.camera_stream_starts:
-            continue
-        try:
-            payload = json.loads(match.camera_stream_starts)
-        except (json.JSONDecodeError, TypeError):
-            stats.skipped_invalid += 1
-            if verbose:
-                print(f"  WARN stream_starts: match={match.uuid} has unparseable JSON")
-            continue
-        if not isinstance(payload, dict):
-            stats.skipped_invalid += 1
-            continue
-
-        for key, raw in payload.items():
-            try:
-                slot = int(key)
-            except (TypeError, ValueError):
-                stats.skipped_invalid += 1
-                if verbose:
-                    print(
-                        f"  WARN stream_starts: match={match.uuid} camera key={key!r} is not an integer slot — skipped"
-                    )
-                continue
-            ts = _extract_stream_start(raw)
-            if not ts:
-                stats.skipped_invalid += 1
-                if verbose:
-                    print(
-                        f"  WARN stream_starts: match={match.uuid} slot={slot} has no extractable timestamp — skipped"
-                    )
-                continue
-            if (match.uuid, slot) in existing:
-                stats.skipped_existing += 1
-                continue
-            db.session.add(MatchCameraStreamStart(match_uuid=match.uuid, camera_slot=slot, stream_start=ts))
-            existing.add((match.uuid, slot))
-            stats.inserted += 1
-    return stats
-
-
 def backfill_camera_timepoints(targets: FkTargets, verbose: bool = False) -> BackfillStats:
     """Populate ``camera_timepoints`` from ``Camera.time_world`` / ``Camera.time_video``.
 
@@ -557,23 +435,6 @@ def validate(verbose: bool = False) -> list[ValidationResult]:
         )
     )
 
-    # 4. Per-field FieldCamera count matches the parsed Field.camera list length.
-    mismatches = []
-    for f in Field.query.all():
-        if not f.camera:
-            continue
-        old_len = len([u for u in parse_camera_urls(f.camera) if u])
-        new_len = db.session.query(FieldCamera).filter(FieldCamera.field_id == f.id).count()
-        if old_len != new_len:
-            mismatches.append(f"field_id={f.id} old={old_len} new={new_len}")
-    results.append(
-        ValidationResult(
-            label="field_cameras count matches Field.camera array length",
-            ok=not mismatches,
-            detail="; ".join(mismatches[:5]) + (f" (+{len(mismatches) - 5} more)" if len(mismatches) > 5 else ""),
-        )
-    )
-
     return results
 
 
@@ -589,8 +450,6 @@ def _check_preconditions() -> str | None:
         "headref_allowlist",
         "match_referees",
         "match_players",
-        "field_cameras",
-        "match_camera_stream_starts",
         "camera_timepoints",
     }
     missing = required - set(inspector.get_table_names())
@@ -621,8 +480,6 @@ def run_backfill(verbose: bool = False, dry_run: bool = False) -> dict[str, Back
         ("headref_allowlist", backfill_head_ref_allowlist),
         ("match_referees", backfill_match_referees),
         ("match_players", backfill_match_players),
-        ("field_cameras", backfill_field_cameras),
-        ("match_camera_stream_starts", backfill_match_camera_stream_starts),
         ("camera_timepoints", backfill_camera_timepoints),
     ):
         runs[label] = fn(targets, verbose=verbose)

--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -123,20 +123,6 @@ CHECKS: Sequence[DuplicateCheck] = (
         columns=("comp", "player"),
         why="A player should have one result per side competition.",
     ),
-    DuplicateCheck(
-        table="players",
-        columns=("email",),
-        why=(
-            "Duplicate emails open a password-reset account-takeover vector "
-            "(attacker registers with the victim's email, triggers reset, "
-            "gains the victim's account)."
-        ),
-    ),
-    DuplicateCheck(
-        table="teams",
-        columns=("email",),
-        why="Duplicate emails on teams open the same account-takeover vector as on players.",
-    ),
 )
 
 

--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -123,6 +123,20 @@ CHECKS: Sequence[DuplicateCheck] = (
         columns=("comp", "player"),
         why="A player should have one result per side competition.",
     ),
+    DuplicateCheck(
+        table="players",
+        columns=("email",),
+        why=(
+            "Duplicate emails open a password-reset account-takeover vector "
+            "(attacker registers with the victim's email, triggers reset, "
+            "gains the victim's account)."
+        ),
+    ),
+    DuplicateCheck(
+        table="teams",
+        columns=("email",),
+        why="Duplicate emails on teams open the same account-takeover vector as on players.",
+    ),
 )
 
 

--- a/scripts/cleanup_data_quality.py
+++ b/scripts/cleanup_data_quality.py
@@ -1,0 +1,650 @@
+#!/usr/bin/env python3
+"""scripts/cleanup_data_quality.py — find and (optionally) fix data-quality issues.
+
+The additive schema migration adds UNIQUE constraints, mutual-exclusivity
+CHECK constraints, and FK-strict ``batch_alter_table`` rebuilds. Pre-existing
+data that violates any of these will block the migration. This script
+detects the three known classes of issue and offers idempotent fixes:
+
+* **Empty-string emails** on ``players`` and ``teams``. SQLite's ``UNIQUE``
+  treats ``""`` as a real distinct value, so 15 teams with ``email = ""``
+  collide on the would-be ``UNIQUE(email)`` constraint. Converting them to
+  ``NULL`` (which they semantically already are) makes them coexist legally.
+  Lossless and safe.
+
+* **Orphan foreign-key references**: rows whose FK column points at a
+  parent that no longer exists. ``PRAGMA foreign_keys = ON`` (which the
+  application now enforces) means those rows survive but cannot be
+  ``UPDATE``d. They also break ``batch_alter_table`` rebuilds. Deleting
+  them is a policy decision — defaults to dry-run.
+
+* **Duplicate rows** on logically-unique column groups (the same set
+  ``scripts/check_duplicates.py`` reports). The default dedupe policy is
+  "keep the row with the lowest ``id`` (or ``uuid``) per group, delete the
+  rest". Choosing which row to keep is also a policy decision — defaults
+  to dry-run.
+
+Usage::
+
+    # Read-only audit covering all three issue classes.
+    uv run python scripts/cleanup_data_quality.py report
+
+    # Convert empty-string emails to NULL. Lossless — no operator review
+    # needed. Add --apply to actually write.
+    uv run python scripts/cleanup_data_quality.py normalize-emails
+    uv run python scripts/cleanup_data_quality.py normalize-emails --apply
+
+    # Delete rows whose FK target no longer exists. Reviews in dry-run by
+    # default; add --apply to actually delete.
+    uv run python scripts/cleanup_data_quality.py delete-orphans
+    uv run python scripts/cleanup_data_quality.py delete-orphans --apply
+
+    # Deduplicate rows that violate a (would-be-)unique column group.
+    # Default policy: keep the row with the lowest ``id``/``uuid`` per
+    # group, delete the others. Reviews in dry-run by default.
+    uv run python scripts/cleanup_data_quality.py dedupe
+    uv run python scripts/cleanup_data_quality.py dedupe --apply
+
+    # Point at a different database (default: instance/tournament.db).
+    uv run python scripts/cleanup_data_quality.py report \\
+        --db /path/to/snapshot.db
+    SQLALCHEMY_DATABASE_URI=sqlite:////tmp/x.db \\
+        uv run python scripts/cleanup_data_quality.py report
+
+Exit codes:
+
+* ``0`` — completed successfully (in dry-run mode this just means the
+  report ran; it does *not* mean the database is clean).
+* ``1`` — invoked with an unrecognised subcommand or option.
+
+Idempotency:
+
+Every operation is safe to re-run. ``normalize-emails`` only updates rows
+whose ``email`` is currently ``""``; ``delete-orphans`` only deletes rows
+whose FK target is currently missing; ``dedupe`` only deletes rows other
+than the lowest-id member of an existing duplicate group. Running any
+command twice on a clean database is a no-op.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# Configuration: what tables and column groups to operate on. Mirrors the
+# CHECKS list in check_duplicates.py and the FK-bearing columns in the
+# Arctos schema. Adding a new entry to either of these lists extends the
+# corresponding subcommand automatically.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EmailColumn:
+    """An ``email``-shaped column on which ``""`` should be normalised to NULL."""
+
+    table: str
+    column: str = "email"
+
+
+EMAIL_COLUMNS: Sequence[EmailColumn] = (
+    EmailColumn(table="players"),
+    EmailColumn(table="teams"),
+)
+
+
+@dataclass(frozen=True)
+class ForeignKey:
+    """A foreign-key column whose orphans should be reported / deleted.
+
+    Attributes:
+        table: Child table.
+        column: Child column holding the FK reference.
+        parent_table: Parent table being referenced.
+        parent_column: Parent column being referenced (usually a PK).
+        why_safe_to_delete: Free-text rationale shown in the report so the
+            operator can decide whether to apply.
+    """
+
+    table: str
+    column: str
+    parent_table: str
+    parent_column: str
+    why_safe_to_delete: str
+
+
+# Only the FK pairs we actually expect to find orphans on, based on the
+# verification run against the live snapshot. Add more here when new ones
+# surface.
+ORPHAN_FK_CHECKS: Sequence[ForeignKey] = (
+    ForeignKey(
+        table="team_registrations",
+        column="team",
+        parent_table="teams",
+        parent_column="id",
+        why_safe_to_delete=(
+            "Registration rows pointing at deleted teams cannot be UPDATEd "
+            "under the runtime FK pragma. Surviving rows are typically CANCELLED."
+        ),
+    ),
+    ForeignKey(
+        table="player_registrations",
+        column="player",
+        parent_table="players",
+        parent_column="id",
+        why_safe_to_delete=(
+            "Registration rows pointing at deleted players cannot be UPDATEd under the runtime FK pragma."
+        ),
+    ),
+    ForeignKey(
+        table="player_registrations",
+        column="team",
+        parent_table="teams",
+        parent_column="id",
+        why_safe_to_delete=(
+            "Player registration rows pointing at a deleted team. The team "
+            "field is nullable, so 'unattaching' the player by setting team "
+            "to NULL would be a less destructive alternative — but this "
+            "script defaults to delete to mirror the other policies."
+        ),
+    ),
+    ForeignKey(
+        table="headrefs",
+        column="player",
+        parent_table="players",
+        parent_column="id",
+        why_safe_to_delete="Head-ref grant for a deleted player has no effect.",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class DedupeRule:
+    """A (table, columns) group that should be unique together.
+
+    Attributes:
+        table: SQL table the rule applies to.
+        columns: Columns that should be unique together.
+        id_column: PK column used to pick which row to keep — the row with
+            the lowest value wins. Defaults to ``"id"``; override for
+            tables like ``matches`` whose PK is ``uuid``.
+        child_handling: How to handle other tables that have FK references
+            to this table when one of the rows being deleted has children.
+
+            * ``"leaf"`` — no FK children expected. Direct DELETE works.
+              If the script discovers child rows at runtime, it bails and
+              warns rather than silently orphaning them.
+            * ``"reassign"`` — reassign every child row's FK to the keeper
+              row before deleting the duplicate. Safe for join-table-like
+              parents (matches, headrefs) where rows are interchangeable
+              from the child's perspective.
+            * ``"refuse"`` — refuse to delete; print a warning telling the
+              operator to manually merge. Used for user-account-like
+              tables (``players``, ``teams``) where reassigning all child
+              rows would conflate two distinct user identities.
+    """
+
+    table: str
+    columns: tuple[str, ...]
+    id_column: str = "id"
+    child_handling: str = "leaf"
+
+
+# Mirrors the §2 unique-constraint targets, plus emails. Edits to this list
+# must stay in sync with scripts/check_duplicates.py — both reflect the
+# same set of (would-be-)unique column groups.
+DEDUPE_RULES: Sequence[DedupeRule] = (
+    DedupeRule(table="team_registrations", columns=("team", "event")),
+    DedupeRule(table="team_registrations", columns=("team", "league_id")),
+    DedupeRule(table="player_registrations", columns=("player", "event")),
+    DedupeRule(table="player_registrations", columns=("player", "league_id")),
+    DedupeRule(table="headrefs", columns=("player", "event"), child_handling="reassign"),
+    DedupeRule(table="matches", columns=("name", "event"), id_column="uuid", child_handling="reassign"),
+    DedupeRule(table="tags", columns=("name", "event")),
+    DedupeRule(table="fields", columns=("name", "event")),
+    DedupeRule(table="sidecompresults", columns=("comp", "player")),
+    DedupeRule(table="players", columns=("email",), child_handling="refuse"),
+    DedupeRule(table="teams", columns=("email",), child_handling="refuse"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Database resolution + helpers (shared across all subcommands).
+# ---------------------------------------------------------------------------
+
+
+def _resolve_database_url(cli_db: str | None) -> str:
+    """Same precedence rule as ``check_duplicates.py``."""
+    if cli_db:
+        if cli_db.startswith("sqlite:") or "://" in cli_db:
+            return cli_db
+        return f"sqlite:///{Path(cli_db).expanduser().resolve()}"
+    env = os.environ.get("SQLALCHEMY_DATABASE_URI")
+    if env:
+        return env
+    return f"sqlite:///{PROJECT_ROOT / 'instance' / 'tournament.db'}"
+
+
+def _table_exists(engine: Engine, name: str) -> bool:
+    """True iff ``name`` is in the connected database's table list."""
+    return name in sa.inspect(engine).get_table_names()
+
+
+def _connect(engine: Engine):
+    """Open a connection with FK enforcement on, mirroring runtime."""
+    conn = engine.connect()
+    conn.exec_driver_sql("PRAGMA foreign_keys = ON")
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# normalize-emails
+# ---------------------------------------------------------------------------
+
+
+def find_blank_emails(engine: Engine) -> dict[str, int]:
+    """Count rows whose ``email`` is exactly the empty string, per table."""
+    counts: dict[str, int] = {}
+    with _connect(engine) as conn:
+        for ec in EMAIL_COLUMNS:
+            if not _table_exists(engine, ec.table):
+                continue
+            n = conn.execute(
+                sa.text(f"SELECT COUNT(*) FROM {ec.table} WHERE {ec.column} = ''")  # noqa: S608
+            ).scalar_one()
+            counts[ec.table] = int(n)
+    return counts
+
+
+def normalize_blank_emails(engine: Engine, apply: bool) -> dict[str, int]:
+    """Convert ``email = ''`` to ``email = NULL`` on every email column.
+
+    Args:
+        engine: Live database engine.
+        apply: When True, perform the UPDATE. When False (default), the
+            function still reports counts but does not write.
+
+    Returns:
+        Per-table count of rows that were (or would be) updated.
+    """
+    counts = find_blank_emails(engine)
+    if not apply:
+        return counts
+    with _connect(engine) as conn:
+        for ec in EMAIL_COLUMNS:
+            if counts.get(ec.table, 0) == 0:
+                continue
+            conn.execute(
+                sa.text(f"UPDATE {ec.table} SET {ec.column} = NULL WHERE {ec.column} = ''")  # noqa: S608
+            )
+        conn.commit()
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# delete-orphans
+# ---------------------------------------------------------------------------
+
+
+def find_orphan_rows(engine: Engine, fk: ForeignKey) -> list[tuple]:
+    """Return rows from ``fk.table`` whose FK target does not exist.
+
+    The result is a list of ``(id, fk_column_value)`` tuples — minimal
+    enough to print in a report, sufficient to identify the rows for
+    deletion. Returns an empty list if either table is missing.
+    """
+    if not (_table_exists(engine, fk.table) and _table_exists(engine, fk.parent_table)):
+        return []
+    sql = sa.text(
+        f"SELECT id, {fk.column} FROM {fk.table} "  # noqa: S608
+        f"WHERE {fk.column} IS NOT NULL "
+        f"AND {fk.column} NOT IN (SELECT {fk.parent_column} FROM {fk.parent_table})"
+    )
+    with _connect(engine) as conn:
+        return [tuple(row) for row in conn.execute(sql)]
+
+
+def delete_orphan_rows(engine: Engine, apply: bool) -> dict[str, int]:
+    """Find (and optionally delete) every orphan-FK row across all checks.
+
+    Returns:
+        Per-check count of rows that were (or would be) deleted, keyed by
+        ``"<table>.<column>"`` so the report is unambiguous when one table
+        has multiple FK columns.
+    """
+    deleted: dict[str, int] = {}
+    for fk in ORPHAN_FK_CHECKS:
+        rows = find_orphan_rows(engine, fk)
+        key = f"{fk.table}.{fk.column}"
+        deleted[key] = len(rows)
+        if not apply or not rows:
+            continue
+        ids = [row[0] for row in rows]
+        with _connect(engine) as conn:
+            # Chunk to keep the IN clause sane on very large lists.
+            for chunk_start in range(0, len(ids), 500):
+                chunk = ids[chunk_start : chunk_start + 500]
+                placeholders = ", ".join(f":id{i}" for i in range(len(chunk)))
+                conn.execute(
+                    sa.text(f"DELETE FROM {fk.table} WHERE id IN ({placeholders})"),  # noqa: S608
+                    {f"id{i}": v for i, v in enumerate(chunk)},
+                )
+            conn.commit()
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# dedupe
+# ---------------------------------------------------------------------------
+
+
+def find_duplicate_groups(engine: Engine, rule: DedupeRule) -> list[tuple]:
+    """Return one row per duplicate group: ``(*column_values, count)``."""
+    if not _table_exists(engine, rule.table):
+        return []
+    cols = ", ".join(rule.columns)
+    not_null = " AND ".join(f"{c} IS NOT NULL" for c in rule.columns)
+    sql = sa.text(
+        f"SELECT {cols}, COUNT(*) AS n "  # noqa: S608
+        f"FROM {rule.table} "
+        f"WHERE {not_null} "
+        f"GROUP BY {cols} "
+        f"HAVING COUNT(*) > 1 "
+        f"ORDER BY n DESC"
+    )
+    with _connect(engine) as conn:
+        return [tuple(row) for row in conn.execute(sql)]
+
+
+def _incoming_fk_columns(engine: Engine, table: str) -> list[tuple[str, str]]:
+    """Return ``(child_table, child_column)`` for every FK that references ``table``.
+
+    Implemented via SQLite's ``pragma_foreign_key_list`` so the result
+    automatically reflects whatever FKs currently exist — no need to
+    hard-code the relationship map.
+    """
+    with _connect(engine) as conn:
+        rows = conn.execute(
+            sa.text(
+                'SELECT m.name AS child_table, fk."from" AS child_col '
+                "FROM sqlite_master m, pragma_foreign_key_list(m.name) fk "
+                "WHERE m.type = 'table' AND fk.\"table\" = :parent"
+            ),
+            {"parent": table},
+        ).fetchall()
+    return [(row[0], row[1]) for row in rows]
+
+
+def _per_group_keepers_and_deletes(engine: Engine, rule: DedupeRule) -> list[tuple[Any, list[Any]]]:
+    """Return ``[(keeper_id, [delete_ids, ...]), ...]`` per duplicate group.
+
+    The ``keeper_id`` is the lowest ``id_column`` value in the group; every
+    other row in that group is a deletion candidate.
+    """
+    cols = ", ".join(rule.columns)
+    not_null = " AND ".join(f"{c} IS NOT NULL" for c in rule.columns)
+    sql = sa.text(
+        f"SELECT {rule.id_column}, {cols} FROM {rule.table} "  # noqa: S608
+        f"WHERE {not_null} ORDER BY {rule.id_column}"
+    )
+    groups: dict[tuple, list] = {}
+    with _connect(engine) as conn:
+        for row in conn.execute(sql):
+            key = tuple(row[1:])
+            groups.setdefault(key, []).append(row[0])
+
+    result: list[tuple[Any, list[Any]]] = []
+    for ids in groups.values():
+        if len(ids) > 1:
+            result.append((ids[0], ids[1:]))  # min(id) is first because ORDER BY
+    return result
+
+
+def delete_duplicate_rows(engine: Engine, apply: bool) -> dict[str, int]:
+    """For every dedupe rule, count or delete the surplus rows per group.
+
+    Default policy: keep the row with the lowest ``id`` (or ``uuid``) per
+    group, delete the rest. For tables whose ``child_handling`` is
+    ``"reassign"`` the script first updates every child row that
+    references a deletion candidate so it points at the keeper instead;
+    for ``"refuse"`` tables it warns and skips.
+
+    Returns per-rule count of surplus rows that were (or would be)
+    deleted. ``"refuse"`` rules report counts but never delete.
+    """
+    deleted: dict[str, int] = {}
+    for rule in DEDUPE_RULES:
+        if not _table_exists(engine, rule.table):
+            continue
+        cols = ", ".join(rule.columns)
+        key = f"{rule.table}({cols})"
+        groups = _per_group_keepers_and_deletes(engine, rule)
+        ids_to_delete = [d for (_, dels) in groups for d in dels]
+        deleted[key] = len(ids_to_delete)
+        if not ids_to_delete:
+            continue
+
+        if rule.child_handling == "refuse":
+            print(
+                f"  REFUSED {key}: {len(ids_to_delete)} duplicate row(s) found, "
+                "but auto-deleting would orphan or conflate user-owned data. "
+                "Merge the accounts manually before re-running."
+            )
+            continue
+
+        if not apply:
+            continue
+
+        with _connect(engine) as conn:
+            if rule.child_handling == "reassign":
+                children = _incoming_fk_columns(engine, rule.table)
+                for keeper, dels in groups:
+                    if not dels:
+                        continue
+                    placeholders = ", ".join(f":id{i}" for i in range(len(dels)))
+                    params = {f"id{i}": v for i, v in enumerate(dels)} | {"keeper": keeper}
+                    for child_table, child_col in children:
+                        conn.execute(
+                            sa.text(
+                                f"UPDATE {child_table} SET {child_col} = :keeper "  # noqa: S608
+                                f"WHERE {child_col} IN ({placeholders})"
+                            ),
+                            params,
+                        )
+
+            elif rule.child_handling == "leaf":
+                children = _incoming_fk_columns(engine, rule.table)
+                if children:
+                    print(
+                        f"  WARN {key}: declared as 'leaf' but discovered {len(children)} "
+                        f"incoming FK reference(s) ({', '.join(f'{t}.{c}' for t, c in children)}). "
+                        "Skipping to avoid orphaning child rows. Update the rule's "
+                        "child_handling to 'reassign' if appropriate."
+                    )
+                    deleted[key] = 0
+                    continue
+
+            for chunk_start in range(0, len(ids_to_delete), 500):
+                chunk = ids_to_delete[chunk_start : chunk_start + 500]
+                placeholders = ", ".join(f":id{i}" for i in range(len(chunk)))
+                conn.execute(
+                    sa.text(
+                        f"DELETE FROM {rule.table} "  # noqa: S608
+                        f"WHERE {rule.id_column} IN ({placeholders})"
+                    ),
+                    {f"id{i}": v for i, v in enumerate(chunk)},
+                )
+            conn.commit()
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def report(engine: Engine) -> None:
+    """Print a comprehensive read-only audit covering all three issue classes."""
+    print("=== empty-string emails (would block UNIQUE(email)) ===")
+    counts = find_blank_emails(engine)
+    if not any(counts.values()):
+        print("  none")
+    else:
+        for table, n in counts.items():
+            print(f"  {table:<24}  {n} row(s) with email = ''")
+        print("  fix: cleanup_data_quality.py normalize-emails --apply")
+
+    print("\n=== orphan FK references (rows pointing at deleted parents) ===")
+    any_orphans = False
+    for fk in ORPHAN_FK_CHECKS:
+        rows = find_orphan_rows(engine, fk)
+        if not rows:
+            continue
+        any_orphans = True
+        print(f"  {fk.table}.{fk.column} → {fk.parent_table}.{fk.parent_column}: {len(rows)} orphan(s)")
+        sample = [f"id={r[0]}, {fk.column}={r[1]!r}" for r in rows[:5]]
+        for s in sample:
+            print(f"      {s}")
+        if len(rows) > 5:
+            print(f"      ... +{len(rows) - 5} more")
+        print(f"      why safe: {fk.why_safe_to_delete}")
+    if not any_orphans:
+        print("  none")
+    else:
+        print("  fix: cleanup_data_quality.py delete-orphans --apply")
+
+    print("\n=== duplicate rows on (would-be-)unique column groups ===")
+    any_dups = False
+    for rule in DEDUPE_RULES:
+        groups = find_duplicate_groups(engine, rule)
+        if not groups:
+            continue
+        any_dups = True
+        cols = ", ".join(rule.columns)
+        print(f"  {rule.table}({cols}): {len(groups)} duplicate group(s)")
+        for row in groups[:5]:
+            *values, n = row
+            print(f"      {dict(zip(rule.columns, values))} × {n}")
+        if len(groups) > 5:
+            print(f"      ... +{len(groups) - 5} more groups")
+    if not any_dups:
+        print("  none")
+    else:
+        print("  fix: cleanup_data_quality.py dedupe --apply")
+        print("       (default policy: keep MIN(id|uuid) per group, delete the rest)")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _print_action_summary(title: str, counts: dict[str, int], apply: bool, fix_hint: str | None = None) -> None:
+    """Render the per-table summary that each apply / dry-run command prints."""
+    total = sum(counts.values())
+    mode = "APPLIED" if apply else "DRY RUN"
+    print(f"=== {title} ({mode}) ===")
+    if total == 0:
+        print("  no rows affected.")
+        return
+    for label, n in counts.items():
+        if n:
+            verb = "deleted" if apply else "would delete"
+            if "email" in title.lower():
+                verb = "updated" if apply else "would update"
+            print(f"  {label:<40}  {verb} {n}")
+    if not apply and fix_hint:
+        print(f"\n  Re-run with --apply to actually write. {fix_hint}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--db",
+        help="Path or SQLAlchemy URL to operate on. Defaults to instance/tournament.db.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("report", help="Read-only audit of all data-quality issues.")
+
+    p_emails = sub.add_parser(
+        "normalize-emails",
+        help='Convert email = "" to email = NULL on players and teams.',
+    )
+    p_emails.add_argument("--apply", action="store_true", help="Actually update rows.")
+
+    p_orphans = sub.add_parser(
+        "delete-orphans",
+        help="Delete rows whose FK target no longer exists.",
+    )
+    p_orphans.add_argument("--apply", action="store_true", help="Actually delete rows.")
+
+    p_dedupe = sub.add_parser(
+        "dedupe",
+        help="Delete duplicate rows; keeps the lowest-id row per group.",
+    )
+    p_dedupe.add_argument("--apply", action="store_true", help="Actually delete rows.")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point. See module docstring for usage and exit codes."""
+    args = _build_parser().parse_args(argv)
+    url = _resolve_database_url(args.db)
+    print(f"Database: {url}")
+    engine = sa.create_engine(url)
+
+    try:
+        if args.command == "report":
+            report(engine)
+            return 0
+
+        if args.command == "normalize-emails":
+            counts = normalize_blank_emails(engine, apply=args.apply)
+            _print_action_summary(
+                "normalize empty-string emails to NULL",
+                counts,
+                apply=args.apply,
+                fix_hint="(lossless: '' and NULL are semantically equivalent here.)",
+            )
+            return 0
+
+        if args.command == "delete-orphans":
+            counts = delete_orphan_rows(engine, apply=args.apply)
+            _print_action_summary(
+                "delete orphan FK rows",
+                counts,
+                apply=args.apply,
+                fix_hint="(review the per-row report from `report` first.)",
+            )
+            return 0
+
+        if args.command == "dedupe":
+            counts = delete_duplicate_rows(engine, apply=args.apply)
+            _print_action_summary(
+                "deduplicate (keep min-id per group)",
+                counts,
+                apply=args.apply,
+                fix_hint="(review the duplicate groups from `report` first.)",
+            )
+            return 0
+
+        # argparse should have rejected this already.
+        return 1
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_backfill_normalised_tables.py
+++ b/tests/unit/test_backfill_normalised_tables.py
@@ -32,10 +32,8 @@ from models import (  # noqa: E402
     Camera,
     CameraTimepoint,
     Field,
-    FieldCamera,
     HeadRefAllowList,
     Match,
-    MatchCameraStreamStart,
     MatchPlayer,
     MatchReferee,
     Player,
@@ -266,105 +264,6 @@ def test_backfill_match_players_skips_invalid_json(test_db, tournament, seeded_t
     db.session.commit()
 
     assert stats.skipped_invalid == 1
-
-
-# ---------------------------------------------------------------------------
-# field_cameras
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_backfill_field_cameras_handles_json_array(test_db, tournament):
-    """A standard JSON array on Field.camera produces one row per URL."""
-    f = Field.query.filter_by(event=tournament.url, name="Field 1").one()
-    f.camera = json.dumps(["rtmp://a/0", "rtmp://b/1"])
-    db.session.commit()
-
-    targets = backfill.FkTargets.load()
-    backfill.backfill_field_cameras(targets)
-    db.session.commit()
-
-    rows = FieldCamera.query.filter_by(field_id=f.id).order_by(FieldCamera.slot).all()
-    assert [r.slot for r in rows] == [0, 1]
-    assert [r.stream_url for r in rows] == ["rtmp://a/0", "rtmp://b/1"]
-
-
-@pytest.mark.unit
-def test_backfill_field_cameras_handles_bare_url_legacy(test_db, tournament):
-    """A bare URL string (legacy single-camera format) produces one row at slot 0."""
-    f = Field.query.filter_by(event=tournament.url, name="Field 1").one()
-    f.camera = "rtmp://legacy/single"
-    db.session.commit()
-
-    targets = backfill.FkTargets.load()
-    backfill.backfill_field_cameras(targets)
-    db.session.commit()
-
-    rows = FieldCamera.query.filter_by(field_id=f.id).all()
-    assert len(rows) == 1
-    assert rows[0].slot == 0
-    assert rows[0].stream_url == "rtmp://legacy/single"
-
-
-# ---------------------------------------------------------------------------
-# match_camera_stream_starts
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-def test_backfill_stream_starts_simple_format(test_db, tournament):
-    """``{"0": "iso_string"}`` (the simple format) round-trips into one row per slot."""
-    m = _make_match(tournament.url)
-    m.camera_stream_starts = json.dumps({"0": "2026-01-01T10:00:00Z", "1": "2026-01-01T10:30:00Z"})
-    db.session.commit()
-
-    targets = backfill.FkTargets.load()
-    backfill.backfill_match_camera_stream_starts(targets)
-    db.session.commit()
-
-    rows = MatchCameraStreamStart.query.filter_by(match_uuid=m.uuid).order_by(MatchCameraStreamStart.camera_slot).all()
-    assert [r.camera_slot for r in rows] == [0, 1]
-    assert rows[0].stream_start == "2026-01-01T10:00:00Z"
-    assert rows[1].stream_start == "2026-01-01T10:30:00Z"
-
-
-@pytest.mark.unit
-def test_backfill_stream_starts_rich_format(test_db, tournament):
-    """``{"0": {"stream_start_time": "iso", "video_path": "..."}}`` extracts the timestamp."""
-    m = _make_match(tournament.url)
-    m.camera_stream_starts = json.dumps(
-        {
-            "0": {
-                "video_path": "static/uploads/foo.mp4",
-                "stream_start_time": "2026-01-01T11:00:00Z",
-                "type": "recorded",
-            }
-        }
-    )
-    db.session.commit()
-
-    targets = backfill.FkTargets.load()
-    backfill.backfill_match_camera_stream_starts(targets)
-    db.session.commit()
-
-    row = MatchCameraStreamStart.query.filter_by(match_uuid=m.uuid).one()
-    assert row.camera_slot == 0
-    assert row.stream_start == "2026-01-01T11:00:00Z"
-
-
-@pytest.mark.unit
-def test_backfill_stream_starts_skips_non_integer_keys(test_db, tournament):
-    """Camera-name keys (not integer slot indices) are skipped with a warning."""
-    m = _make_match(tournament.url)
-    m.camera_stream_starts = json.dumps({"main_cam": "2026-01-01T12:00:00Z"})
-    db.session.commit()
-
-    targets = backfill.FkTargets.load()
-    stats = backfill.backfill_match_camera_stream_starts(targets)
-    db.session.commit()
-
-    assert stats.inserted == 0
-    assert stats.skipped_invalid >= 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_backfill_normalised_tables.py
+++ b/tests/unit/test_backfill_normalised_tables.py
@@ -1,0 +1,434 @@
+"""Tests for ``scripts/backfill_normalised_tables``.
+
+Each test seeds legacy blob columns on the source models, runs the relevant
+``backfill_*`` function, and asserts the destination join table contains the
+expected rows. Idempotency is exercised by running each backfill twice and
+checking the second run inserts nothing new.
+
+These tests intentionally use the real backfill module (imported via the
+``scripts`` package) rather than re-implementing its logic — the goal is to
+catch regressions in the script itself, including its handling of orphan FK
+references, malformed JSON, and the multi-format ``camera_stream_starts``
+payload.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/ is not a Python package — load the module directly so tests can
+# call its functions without the developer having to add an __init__.py
+# they wouldn't otherwise need.
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+import backfill_normalised_tables as backfill  # noqa: E402
+
+from app.domain.enums import WinnerSide  # noqa: E402
+from models import (  # noqa: E402
+    Camera,
+    CameraTimepoint,
+    Field,
+    FieldCamera,
+    HeadRefAllowList,
+    Match,
+    MatchCameraStreamStart,
+    MatchPlayer,
+    MatchReferee,
+    Player,
+    db,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_match(tournament_url: str, name: str = "M", **overrides) -> Match:
+    """Insert and flush a minimal Match so its uuid is available for FK use."""
+    defaults = dict(
+        name=name,
+        event=tournament_url,
+        schedule_type="STATIC",
+        set_type="SETS",
+        nominal_length=60,
+    )
+    defaults.update(overrides)
+    m = Match(**defaults)
+    db.session.add(m)
+    db.session.flush()
+    return m
+
+
+def _make_camera(match_uuid: str, tournament_url: str, field_id: int, **overrides) -> Camera:
+    """Insert and flush a minimal Camera bound to the given match/field."""
+    defaults = dict(
+        match_uuid=match_uuid,
+        event=tournament_url,
+        field=field_id,
+        name="cam",
+    )
+    defaults.update(overrides)
+    cam = Camera(**defaults)
+    db.session.add(cam)
+    db.session.flush()
+    return cam
+
+
+# ---------------------------------------------------------------------------
+# headref_allowlist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_backfill_head_refs_inserts_one_per_csv_entry(test_db, tournament, head_ref_player):
+    """Each comma-separated player ID becomes one HeadRefAllowList row."""
+    # Add a second valid player so the comma-separated list has two entries.
+    db.session.add(Player(id="ref2", name="Ref 2", pw_hash="h"))
+    db.session.commit()
+
+    tournament.head_refs_allowed_list = f"{head_ref_player.id}, ref2"
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    stats = backfill.backfill_head_ref_allowlist(targets)
+    db.session.commit()
+
+    assert stats.inserted == 2
+    assert HeadRefAllowList.query.filter_by(event=tournament.url).count() == 2
+
+
+@pytest.mark.unit
+def test_backfill_head_refs_skips_orphan_player(test_db, tournament):
+    """A player ID not present in `players` is reported and skipped."""
+    tournament.head_refs_allowed_list = "ghost_player"
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    stats = backfill.backfill_head_ref_allowlist(targets)
+    db.session.commit()
+
+    assert stats.inserted == 0
+    assert stats.skipped_orphan == 1
+    assert HeadRefAllowList.query.count() == 0
+
+
+@pytest.mark.unit
+def test_backfill_head_refs_is_idempotent(test_db, tournament, head_ref_player):
+    """Running the backfill twice does not duplicate rows."""
+    tournament.head_refs_allowed_list = head_ref_player.id
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    backfill.backfill_head_ref_allowlist(targets)
+    db.session.commit()
+    second = backfill.backfill_head_ref_allowlist(targets)
+    db.session.commit()
+
+    assert second.inserted == 0
+    assert second.skipped_existing == 1
+    assert HeadRefAllowList.query.count() == 1
+
+
+@pytest.mark.unit
+def test_backfill_head_refs_skips_empty_entries(test_db, tournament, head_ref_player):
+    """Empty entries from trailing commas / extra whitespace don't error out."""
+    tournament.head_refs_allowed_list = f", {head_ref_player.id} ,, ,"
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    stats = backfill.backfill_head_ref_allowlist(targets)
+    db.session.commit()
+
+    assert stats.inserted == 1
+
+
+# ---------------------------------------------------------------------------
+# match_referees
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_backfill_match_referees_preserves_slot_order(test_db, tournament, seeded_teams):
+    """Each comma-separated entry becomes one row at its 0-based slot."""
+    m = _make_match(tournament.url)
+    m.refs = "team1, team2, team3"
+    m.refs_initial = "team1, Match A::winner, team3"
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    backfill.backfill_match_referees(targets)
+    db.session.commit()
+
+    rows = MatchReferee.query.filter_by(match_uuid=m.uuid).order_by(MatchReferee.slot).all()
+    assert [r.slot for r in rows] == [0, 1, 2]
+    assert [r.team_id for r in rows] == ["team1", "team2", "team3"]
+    assert rows[1].initial == "Match A::winner"
+
+
+@pytest.mark.unit
+def test_backfill_match_referees_handles_unequal_lengths(test_db, tournament, seeded_teams):
+    """If refs and refs_initial differ in length, the shorter is padded."""
+    m = _make_match(tournament.url)
+    m.refs = "team1"
+    m.refs_initial = "team1, team2, Match A::winner"
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    stats = backfill.backfill_match_referees(targets)
+    db.session.commit()
+
+    rows = MatchReferee.query.filter_by(match_uuid=m.uuid).order_by(MatchReferee.slot).all()
+    assert [r.slot for r in rows] == [0, 1, 2]
+    assert rows[0].team_id == "team1"
+    assert rows[1].team_id is None
+    assert rows[1].initial == "team2"
+    # The third initial is an unresolved expression, not a real team ID.
+    assert rows[2].team_id is None
+    assert rows[2].initial == "Match A::winner"
+    assert stats.inserted == 3
+
+
+@pytest.mark.unit
+def test_backfill_match_referees_orphan_team_keeps_row(test_db, tournament):
+    """A refs[i] pointing at a non-existent team yields a row with team_id=None
+    (the initial expression is still useful for re-resolution) and is counted
+    as ``skipped_orphan``."""
+    m = _make_match(tournament.url)
+    m.refs = "ghost_team"
+    m.refs_initial = "ghost_team"
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    stats = backfill.backfill_match_referees(targets)
+    db.session.commit()
+
+    row = MatchReferee.query.filter_by(match_uuid=m.uuid).one()
+    assert row.team_id is None
+    assert row.initial == "ghost_team"
+    assert stats.skipped_orphan == 1
+
+
+# ---------------------------------------------------------------------------
+# match_players
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_backfill_match_players_splits_by_side(test_db, tournament, seeded_teams):
+    """team1_players → side=TEAM1, team2_players → side=TEAM2."""
+    db.session.add_all([Player(id="p1", name="P1", pw_hash="h"), Player(id="p2", name="P2", pw_hash="h")])
+    db.session.commit()
+
+    m = _make_match(tournament.url)
+    m.team1_players = json.dumps(["p1"])
+    m.team2_players = json.dumps(["p2"])
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    backfill.backfill_match_players(targets)
+    db.session.commit()
+
+    rows = MatchPlayer.query.filter_by(match_uuid=m.uuid).all()
+    by_side = {r.side: r.player_id for r in rows}
+    assert by_side[WinnerSide.TEAM1] == "p1"
+    assert by_side[WinnerSide.TEAM2] == "p2"
+
+
+@pytest.mark.unit
+def test_backfill_match_players_skips_orphan_player(test_db, tournament, seeded_teams):
+    """Player IDs not present in `players` are reported and skipped."""
+    m = _make_match(tournament.url)
+    m.team1_players = json.dumps(["ghost1"])
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    stats = backfill.backfill_match_players(targets)
+    db.session.commit()
+
+    assert stats.inserted == 0
+    assert stats.skipped_orphan == 1
+
+
+@pytest.mark.unit
+def test_backfill_match_players_skips_invalid_json(test_db, tournament, seeded_teams):
+    """Garbage in team1_players is counted as invalid and the row is skipped."""
+    m = _make_match(tournament.url)
+    m.team1_players = "{not json"
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    stats = backfill.backfill_match_players(targets)
+    db.session.commit()
+
+    assert stats.skipped_invalid == 1
+
+
+# ---------------------------------------------------------------------------
+# field_cameras
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_backfill_field_cameras_handles_json_array(test_db, tournament):
+    """A standard JSON array on Field.camera produces one row per URL."""
+    f = Field.query.filter_by(event=tournament.url, name="Field 1").one()
+    f.camera = json.dumps(["rtmp://a/0", "rtmp://b/1"])
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    backfill.backfill_field_cameras(targets)
+    db.session.commit()
+
+    rows = FieldCamera.query.filter_by(field_id=f.id).order_by(FieldCamera.slot).all()
+    assert [r.slot for r in rows] == [0, 1]
+    assert [r.stream_url for r in rows] == ["rtmp://a/0", "rtmp://b/1"]
+
+
+@pytest.mark.unit
+def test_backfill_field_cameras_handles_bare_url_legacy(test_db, tournament):
+    """A bare URL string (legacy single-camera format) produces one row at slot 0."""
+    f = Field.query.filter_by(event=tournament.url, name="Field 1").one()
+    f.camera = "rtmp://legacy/single"
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    backfill.backfill_field_cameras(targets)
+    db.session.commit()
+
+    rows = FieldCamera.query.filter_by(field_id=f.id).all()
+    assert len(rows) == 1
+    assert rows[0].slot == 0
+    assert rows[0].stream_url == "rtmp://legacy/single"
+
+
+# ---------------------------------------------------------------------------
+# match_camera_stream_starts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_backfill_stream_starts_simple_format(test_db, tournament):
+    """``{"0": "iso_string"}`` (the simple format) round-trips into one row per slot."""
+    m = _make_match(tournament.url)
+    m.camera_stream_starts = json.dumps({"0": "2026-01-01T10:00:00Z", "1": "2026-01-01T10:30:00Z"})
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    backfill.backfill_match_camera_stream_starts(targets)
+    db.session.commit()
+
+    rows = MatchCameraStreamStart.query.filter_by(match_uuid=m.uuid).order_by(MatchCameraStreamStart.camera_slot).all()
+    assert [r.camera_slot for r in rows] == [0, 1]
+    assert rows[0].stream_start == "2026-01-01T10:00:00Z"
+    assert rows[1].stream_start == "2026-01-01T10:30:00Z"
+
+
+@pytest.mark.unit
+def test_backfill_stream_starts_rich_format(test_db, tournament):
+    """``{"0": {"stream_start_time": "iso", "video_path": "..."}}`` extracts the timestamp."""
+    m = _make_match(tournament.url)
+    m.camera_stream_starts = json.dumps(
+        {
+            "0": {
+                "video_path": "static/uploads/foo.mp4",
+                "stream_start_time": "2026-01-01T11:00:00Z",
+                "type": "recorded",
+            }
+        }
+    )
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    backfill.backfill_match_camera_stream_starts(targets)
+    db.session.commit()
+
+    row = MatchCameraStreamStart.query.filter_by(match_uuid=m.uuid).one()
+    assert row.camera_slot == 0
+    assert row.stream_start == "2026-01-01T11:00:00Z"
+
+
+@pytest.mark.unit
+def test_backfill_stream_starts_skips_non_integer_keys(test_db, tournament):
+    """Camera-name keys (not integer slot indices) are skipped with a warning."""
+    m = _make_match(tournament.url)
+    m.camera_stream_starts = json.dumps({"main_cam": "2026-01-01T12:00:00Z"})
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    stats = backfill.backfill_match_camera_stream_starts(targets)
+    db.session.commit()
+
+    assert stats.inserted == 0
+    assert stats.skipped_invalid >= 1
+
+
+# ---------------------------------------------------------------------------
+# camera_timepoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_backfill_camera_timepoints_pairs_arrays(test_db, tournament):
+    """time_world[i] pairs with time_video[i] at sequence i."""
+    m = _make_match(tournament.url)
+    f = Field.query.filter_by(event=tournament.url, name="Field 1").one()
+    cam = _make_camera(m.uuid, tournament.url, f.id)
+    cam.time_world = json.dumps(["2026-01-01T00:00:00Z", "2026-01-01T00:00:10Z"])
+    cam.time_video = json.dumps([0.0, 10.5])
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    backfill.backfill_camera_timepoints(targets)
+    db.session.commit()
+
+    rows = CameraTimepoint.query.filter_by(camera_uuid=cam.uuid).order_by(CameraTimepoint.sequence).all()
+    assert len(rows) == 2
+    assert rows[0].sequence == 0
+    assert rows[0].time_world == "2026-01-01T00:00:00Z"
+    assert rows[0].time_video == 0.0
+    assert rows[1].time_video == 10.5
+
+
+@pytest.mark.unit
+def test_backfill_camera_timepoints_skips_mismatched_lengths(test_db, tournament):
+    """If the parallel arrays differ in length, the camera is skipped with a warning."""
+    m = _make_match(tournament.url)
+    f = Field.query.filter_by(event=tournament.url, name="Field 1").one()
+    cam = _make_camera(m.uuid, tournament.url, f.id)
+    cam.time_world = json.dumps(["a", "b", "c"])
+    cam.time_video = json.dumps([0.0, 1.0])
+    db.session.commit()
+
+    targets = backfill.FkTargets.load()
+    stats = backfill.backfill_camera_timepoints(targets)
+    db.session.commit()
+
+    assert CameraTimepoint.query.filter_by(camera_uuid=cam.uuid).count() == 0
+    assert any("camera" in w for w in stats.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_passes_on_clean_backfill(test_db, tournament, head_ref_player, seeded_teams):
+    """End-to-end: full backfill on clean data produces no validation failures."""
+    db.session.add_all([Player(id="p1", name="P1", pw_hash="h"), Player(id="p2", name="P2", pw_hash="h")])
+    tournament.head_refs_allowed_list = head_ref_player.id
+    m = _make_match(tournament.url)
+    m.refs = "team1"
+    m.refs_initial = "team1"
+    m.team1_players = json.dumps(["p1"])
+    m.team2_players = json.dumps(["p2"])
+    db.session.commit()
+
+    backfill.run_backfill(verbose=False)
+    results = backfill.validate()
+    assert all(r.ok for r in results), [r for r in results if not r.ok]

--- a/tests/unit/test_cleanup_data_quality.py
+++ b/tests/unit/test_cleanup_data_quality.py
@@ -1,0 +1,444 @@
+"""Tests for ``scripts/cleanup_data_quality``.
+
+Each test seeds a specific kind of dirty data into the in-memory test DB,
+then exercises the cleanup module's detection function (always),
+``--apply=False`` dry-run (counts but no write), and ``--apply=True`` (counts
+plus write). Idempotency is verified by running the apply path twice and
+asserting the second run is a no-op.
+
+The cleanup module is loaded directly from ``scripts/`` so tests catch
+regressions in the script itself rather than re-implementing its logic.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+import cleanup_data_quality as cleanup  # noqa: E402
+
+from app.domain.enums import TeamRegistrationStatus  # noqa: E402
+from models import (  # noqa: E402
+    Player,
+    Team,
+    TeamRegistration,
+    db,
+)
+
+
+# ---------------------------------------------------------------------------
+# normalize-emails
+# ---------------------------------------------------------------------------
+
+
+def _drop_unique_indexes_for_dirty_seeding():
+    """Drop the model-declared UNIQUE indexes so dirty data can be inserted.
+
+    The ``test_db`` fixture creates a fresh DB from the current models,
+    which already include the Phase-1 UNIQUE(email) and dedupe indexes.
+    Tests that need to seed *pre-Phase-1*-shaped dirty data drop those
+    indexes first, then re-create them at the end if they want to verify
+    the cleanup script unblocks re-creation.
+    """
+    # Two name conventions: the migration creates these as ``uq_*``;
+    # ``db.create_all`` from the model declarations creates them as
+    # ``ix_*`` (because the model uses ``unique=True, index=True`` for
+    # emails, which collapses to a single unique index named ``ix_*``).
+    # Cover both so this helper works regardless of which path the DB
+    # was built from.
+    for ix in (
+        "uq_teams_email",
+        "uq_players_email",
+        "ix_teams_email",
+        "ix_players_email",
+        "uq_team_registrations_team_event",
+        "uq_team_registrations_team_league",
+        "uq_player_registrations_player_event",
+        "uq_player_registrations_player_league",
+        "uq_matches_name_event",
+        "uq_tags_name_event",
+        "uq_fields_name_event",
+        "uq_headrefs_player_event",
+        "uq_sidecompresults_comp_player",
+    ):
+        db.session.execute(sa.text(f"DROP INDEX IF EXISTS {ix}"))
+    db.session.commit()
+
+
+@pytest.mark.unit
+def test_find_blank_emails_counts_empty_strings(test_db):
+    """Empty-string emails are reported per table; NULL emails are not."""
+    _drop_unique_indexes_for_dirty_seeding()
+    db.session.add_all(
+        [
+            Player(id="p1", name="P1", pw_hash="h", email=""),
+            Player(id="p2", name="P2", pw_hash="h", email="real@x.com"),
+            Player(id="p3", name="P3", pw_hash="h", email=None),
+            Team(id="t1", name="T1", pw_hash="h", email=""),
+            Team(id="t2", name="T2", pw_hash="h", email=""),
+        ]
+    )
+    db.session.commit()
+
+    counts = cleanup.find_blank_emails(db.engine)
+    assert counts == {"players": 1, "teams": 2}
+
+
+@pytest.mark.unit
+def test_normalize_emails_dry_run_does_not_write(test_db):
+    """Dry run reports counts but leaves the database unchanged."""
+    db.session.add(Player(id="p1", name="P1", pw_hash="h", email=""))
+    db.session.commit()
+
+    counts = cleanup.normalize_blank_emails(db.engine, apply=False)
+    assert counts == {"players": 1, "teams": 0}
+    # Verify nothing actually changed.
+    assert Player.query.get("p1").email == ""
+
+
+@pytest.mark.unit
+def test_normalize_emails_apply_converts_to_null(test_db):
+    """Apply mode actually performs the UPDATE."""
+    db.session.add_all(
+        [
+            Player(id="p1", name="P1", pw_hash="h", email=""),
+            Team(id="t1", name="T1", pw_hash="h", email=""),
+        ]
+    )
+    db.session.commit()
+
+    cleanup.normalize_blank_emails(db.engine, apply=True)
+    db.session.expire_all()
+
+    assert Player.query.get("p1").email is None
+    assert Team.query.get("t1").email is None
+
+
+@pytest.mark.unit
+def test_normalize_emails_is_idempotent(test_db):
+    """Re-running on a clean DB is a no-op."""
+    db.session.add(Player(id="p1", name="P1", pw_hash="h", email=""))
+    db.session.commit()
+
+    cleanup.normalize_blank_emails(db.engine, apply=True)
+    db.session.expire_all()
+    second = cleanup.normalize_blank_emails(db.engine, apply=True)
+    assert second == {"players": 0, "teams": 0}
+
+
+@pytest.mark.unit
+def test_normalize_emails_does_not_touch_real_addresses(test_db):
+    """Real emails are not modified — only the empty string is."""
+    db.session.add(Player(id="p1", name="P1", pw_hash="h", email="real@x.com"))
+    db.session.commit()
+
+    cleanup.normalize_blank_emails(db.engine, apply=True)
+    db.session.expire_all()
+
+    assert Player.query.get("p1").email == "real@x.com"
+
+
+# ---------------------------------------------------------------------------
+# delete-orphans
+# ---------------------------------------------------------------------------
+
+
+def _seed_orphan_team_registration(test_db, tournament) -> int:
+    """Insert a TeamRegistration whose `team` references no real team.
+
+    Returns the row's primary-key id. Inserted with FK enforcement off so
+    that the row exists but is invalid — exactly the state the cleanup
+    script is designed to surface and fix.
+    """
+    db.session.commit()  # flush anything pending so the raw SQL sees it
+    db.session.execute(sa.text("PRAGMA foreign_keys = OFF"))
+    db.session.execute(
+        sa.text("INSERT INTO team_registrations (event, team, pseudonym, status) VALUES (:event, :team, :ps, :status)"),
+        {"event": tournament.url, "team": "ghost_team", "ps": "Ghost", "status": "CANCELLED"},
+    )
+    row_id = db.session.execute(sa.text("SELECT MAX(id) FROM team_registrations WHERE team = 'ghost_team'")).scalar()
+    db.session.execute(sa.text("PRAGMA foreign_keys = ON"))
+    db.session.commit()
+    return int(row_id)
+
+
+@pytest.mark.unit
+def test_find_orphan_rows_detects_missing_parent(test_db, tournament):
+    """An orphan row (FK target deleted) is reported."""
+    row_id = _seed_orphan_team_registration(test_db, tournament)
+
+    fk = next(f for f in cleanup.ORPHAN_FK_CHECKS if (f.table, f.column) == ("team_registrations", "team"))
+    rows = cleanup.find_orphan_rows(db.engine, fk)
+    assert (row_id, "ghost_team") in rows
+
+
+@pytest.mark.unit
+def test_delete_orphans_dry_run_reports_but_does_not_delete(test_db, tournament):
+    """Dry run reports the count but the row is still present afterwards."""
+    row_id = _seed_orphan_team_registration(test_db, tournament)
+
+    counts = cleanup.delete_orphan_rows(db.engine, apply=False)
+    assert counts.get("team_registrations.team", 0) >= 1
+    assert (
+        db.session.execute(
+            sa.text("SELECT COUNT(*) FROM team_registrations WHERE id = :id"),
+            {"id": row_id},
+        ).scalar()
+        == 1
+    )
+
+
+@pytest.mark.unit
+def test_delete_orphans_apply_removes_the_row(test_db, tournament):
+    """Apply mode actually deletes the orphan rows."""
+    row_id = _seed_orphan_team_registration(test_db, tournament)
+
+    cleanup.delete_orphan_rows(db.engine, apply=True)
+    assert (
+        db.session.execute(
+            sa.text("SELECT COUNT(*) FROM team_registrations WHERE id = :id"),
+            {"id": row_id},
+        ).scalar()
+        == 0
+    )
+
+
+@pytest.mark.unit
+def test_delete_orphans_is_idempotent(test_db, tournament):
+    """Second apply on a now-clean DB is a no-op."""
+    _seed_orphan_team_registration(test_db, tournament)
+    cleanup.delete_orphan_rows(db.engine, apply=True)
+    second = cleanup.delete_orphan_rows(db.engine, apply=True)
+    assert all(n == 0 for n in second.values())
+
+
+# ---------------------------------------------------------------------------
+# dedupe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_find_duplicate_groups_reports_team_event_pairs(test_db, tournament, team):
+    """A repeated (team, event) pair is reported as one group with count >= 2."""
+    db.session.add_all(
+        [
+            TeamRegistration(
+                event=tournament.url,
+                team=team.id,
+                pseudonym="A",
+                status=TeamRegistrationStatus.CONFIRMED,
+            ),
+            TeamRegistration(
+                event=tournament.url,
+                team=team.id,
+                pseudonym="B",
+                status=TeamRegistrationStatus.CONFIRMED,
+            ),
+        ]
+    )
+    db.session.commit()
+
+    rule = next(r for r in cleanup.DEDUPE_RULES if r.table == "team_registrations" and r.columns == ("team", "event"))
+    groups = cleanup.find_duplicate_groups(db.engine, rule)
+    assert len(groups) == 1
+    *vals, count = groups[0]
+    assert vals == [team.id, tournament.url]
+    assert count == 2
+
+
+@pytest.mark.unit
+def test_dedupe_dry_run_reports_but_keeps_all_rows(test_db, tournament, team):
+    """Dry run reports surplus rows but leaves them in place."""
+    db.session.add_all(
+        [
+            TeamRegistration(
+                event=tournament.url,
+                team=team.id,
+                pseudonym="A",
+                status=TeamRegistrationStatus.CONFIRMED,
+            ),
+            TeamRegistration(
+                event=tournament.url,
+                team=team.id,
+                pseudonym="B",
+                status=TeamRegistrationStatus.CONFIRMED,
+            ),
+        ]
+    )
+    db.session.commit()
+    before = TeamRegistration.query.count()
+
+    counts = cleanup.delete_duplicate_rows(db.engine, apply=False)
+    surplus = counts.get("team_registrations(team, event)", 0)
+    assert surplus >= 1
+    assert TeamRegistration.query.count() == before
+
+
+@pytest.mark.unit
+def test_dedupe_apply_keeps_lowest_id_per_group(test_db, tournament, team):
+    """Apply mode keeps the row with the lowest id and deletes the rest."""
+    rows = [
+        TeamRegistration(
+            event=tournament.url,
+            team=team.id,
+            pseudonym=label,
+            status=TeamRegistrationStatus.CONFIRMED,
+        )
+        for label in ("first_to_keep", "B", "C")
+    ]
+    db.session.add_all(rows)
+    db.session.commit()
+    kept_id = min(r.id for r in rows)
+
+    cleanup.delete_duplicate_rows(db.engine, apply=True)
+
+    remaining = TeamRegistration.query.filter_by(event=tournament.url, team=team.id).all()
+    assert len(remaining) == 1
+    assert remaining[0].id == kept_id
+    assert remaining[0].pseudonym == "first_to_keep"
+
+
+@pytest.mark.unit
+def test_dedupe_uses_uuid_for_matches(test_db, tournament, seeded_teams):
+    """``matches`` uses ``uuid`` not ``id`` as the keep-key. Verify the rule applies."""
+    from models import Match
+
+    _drop_unique_indexes_for_dirty_seeding()
+    a = Match(
+        name="Same",
+        event=tournament.url,
+        schedule_type="STATIC",
+        set_type="SETS",
+        nominal_length=60,
+    )
+    b = Match(
+        name="Same",
+        event=tournament.url,
+        schedule_type="STATIC",
+        set_type="SETS",
+        nominal_length=60,
+    )
+    db.session.add_all([a, b])
+    db.session.commit()
+    # Capture UUIDs before deletion — after delete_duplicate_rows runs, one
+    # of the ORM instances will be detached and reading .uuid raises.
+    a_uuid, b_uuid = a.uuid, b.uuid
+    expected_kept_uuid = min(a_uuid, b_uuid)
+
+    cleanup.delete_duplicate_rows(db.engine, apply=True)
+    db.session.expire_all()
+
+    remaining = Match.query.filter_by(event=tournament.url, name="Same").all()
+    assert len(remaining) == 1
+    assert remaining[0].uuid == expected_kept_uuid
+
+
+@pytest.mark.unit
+def test_dedupe_is_idempotent(test_db, tournament, team):
+    """Second apply on a now-clean DB is a no-op."""
+    db.session.add_all(
+        [
+            TeamRegistration(
+                event=tournament.url,
+                team=team.id,
+                pseudonym=label,
+                status=TeamRegistrationStatus.CONFIRMED,
+            )
+            for label in ("A", "B")
+        ]
+    )
+    db.session.commit()
+    cleanup.delete_duplicate_rows(db.engine, apply=True)
+    second = cleanup.delete_duplicate_rows(db.engine, apply=True)
+    assert all(n == 0 for n in second.values())
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests — verify the subcommand wiring works end-to-end.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cli_report_runs_without_error(test_db, tournament, capsys):
+    """`report` exits 0 against a clean DB."""
+    db_url = str(db.engine.url)
+    rc = cleanup.main(["--db", db_url, "report"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "empty-string emails" in out
+    assert "orphan FK references" in out
+    assert "duplicate rows" in out
+
+
+@pytest.mark.unit
+def test_cli_normalize_emails_apply_writes(test_db, capsys):
+    """`normalize-emails --apply` actually updates."""
+    db.session.add(Team(id="ta", name="A", pw_hash="h", email=""))
+    db.session.commit()
+    rc = cleanup.main(["--db", str(db.engine.url), "normalize-emails", "--apply"])
+    assert rc == 0
+    db.session.expire_all()
+    assert Team.query.get("ta").email is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the full cleanup chain unblocks adding the would-be UNIQUE.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_full_cleanup_then_unique_index_succeeds(test_db, tournament, team):
+    """After running all three cleanup operations, adding UNIQUE(email) succeeds.
+
+    This is the integration-shaped test: it proves the cleanup script's
+    output is sufficient to unblock the additive migration's UNIQUE
+    constraints and the surrounding FK/email checks. Anchor against a
+    realistic dirty state (duplicate registrations + duplicate emails)
+    and confirm a UNIQUE index can be created at the end.
+    """
+    # Drop the model-declared UNIQUE indexes so we can seed the dirty
+    # pre-Phase-1-shaped state.
+    _drop_unique_indexes_for_dirty_seeding()
+    db.session.add_all(
+        [
+            Team(id="ghost_a", name="A", pw_hash="h", email=""),
+            Team(id="ghost_b", name="B", pw_hash="h", email=""),
+            TeamRegistration(
+                event=tournament.url,
+                team=team.id,
+                pseudonym="dup1",
+                status=TeamRegistrationStatus.CONFIRMED,
+            ),
+            TeamRegistration(
+                event=tournament.url,
+                team=team.id,
+                pseudonym="dup2",
+                status=TeamRegistrationStatus.CONFIRMED,
+            ),
+        ]
+    )
+    db.session.commit()
+
+    # Verify the dirty state actually blocks UNIQUE(email):
+    with pytest.raises(sa.exc.IntegrityError):
+        db.session.execute(sa.text("CREATE UNIQUE INDEX uq_teams_email_test ON teams (email)"))
+        db.session.commit()
+    db.session.rollback()
+
+    # Run the full cleanup chain.
+    cleanup.normalize_blank_emails(db.engine, apply=True)
+    cleanup.delete_orphan_rows(db.engine, apply=True)
+    cleanup.delete_duplicate_rows(db.engine, apply=True)
+    db.session.expire_all()
+
+    # Now the UNIQUE constraint can be added without error.
+    db.session.execute(sa.text("CREATE UNIQUE INDEX uq_teams_email_test ON teams (email)"))
+    db.session.commit()
+
+    # And the duplicate registration is gone.
+    assert TeamRegistration.query.filter_by(event=tournament.url, team=team.id).count() == 1

--- a/tests/unit/test_cleanup_data_quality.py
+++ b/tests/unit/test_cleanup_data_quality.py
@@ -40,22 +40,10 @@ def _drop_unique_indexes_for_dirty_seeding():
     """Drop the model-declared UNIQUE indexes so dirty data can be inserted.
 
     The ``test_db`` fixture creates a fresh DB from the current models,
-    which already include the Phase-1 UNIQUE(email) and dedupe indexes.
-    Tests that need to seed *pre-Phase-1*-shaped dirty data drop those
-    indexes first, then re-create them at the end if they want to verify
-    the cleanup script unblocks re-creation.
+    which already include the dedupe indexes. Tests that need to
+    seed pre-existing dirty data drop those indexes first.
     """
-    # Two name conventions: the migration creates these as ``uq_*``;
-    # ``db.create_all`` from the model declarations creates them as
-    # ``ix_*`` (because the model uses ``unique=True, index=True`` for
-    # emails, which collapses to a single unique index named ``ix_*``).
-    # Cover both so this helper works regardless of which path the DB
-    # was built from.
     for ix in (
-        "uq_teams_email",
-        "uq_players_email",
-        "ix_teams_email",
-        "ix_players_email",
         "uq_team_registrations_team_event",
         "uq_team_registrations_team_league",
         "uq_player_registrations_player_event",
@@ -393,13 +381,13 @@ def test_cli_normalize_emails_apply_writes(test_db, capsys):
 
 @pytest.mark.unit
 def test_full_cleanup_then_unique_index_succeeds(test_db, tournament, team):
-    """After running all three cleanup operations, adding UNIQUE(email) succeeds.
+    """After running all three cleanup operations, an ad-hoc UNIQUE(email) becomes possible.
 
-    This is the integration-shaped test: it proves the cleanup script's
-    output is sufficient to unblock the additive migration's UNIQUE
-    constraints and the surrounding FK/email checks. Anchor against a
-    realistic dirty state (duplicate registrations + duplicate emails)
-    and confirm a UNIQUE index can be created at the end.
+    This test still proves the cleanup
+    script brings emails to a state where uniqueness *could* be enforced
+    if anyone ever wanted to: it seeds a dirty state, runs the cleanup,
+    and confirms an ad-hoc unique index can then be created without a
+    constraint violation.
     """
     # Drop the model-declared UNIQUE indexes so we can seed the dirty
     # pre-Phase-1-shaped state.


### PR DESCRIPTION
  Adds new normalised tables, integrity constraints, indexes, and a backfill pipeline to populate them from       
  existing data. All changes are additive - no legacy columns are dropped and no application reads/writes are     
  switched yet, so this PR is fully reversible.                                                                   
                                                                                                                  
  What's in the change                                                                                            

  New Alembic migration — 0002_phase1_additive.py
  - Four normalised join tables — headref_allowlist, match_referees, match_players, camera_timepoints — replacing
  comma-separated and JSON-array blobs (Tournament.head_refs_allowed_list, Match.refs / refs_initial,             
  Match.team1_players / team2_players, Camera.time_world / time_video).                                                  
  - Monetary precision: team_reg_fee, player_reg_fee, and both amount_paid columns moved from Float to Numeric(10,
   2) via batch_alter_table, so reconciliation totals stop drifting from rounding error.                          
  - Mutual exclusivity CHECKs added to team_registrations, player_registrations, and tos so exactly one of event /
   league_id is set on every row.                                                                                 
  - Unique constraints on the nine column-pairs that the application has been silently relying on: (team, event)  
  and (team, league_id) on team_registrations; the same on player_registrations; (player, event) on headrefs;   
  (name, event) on matches, tags, and fields; (comp, player) on sidecompresults.                                  
  - Indexes on the heavily-filtered hot-path columns: matches.event, points.match, match_notes.match,
  team_registrations.event, player_registrations.(event, player), headrefs.(player, event), tags.event,           
  fields.event.                                                                                                   
   
  New models — app/models/normalised.py                                                                           
  - HeadRefAllowList, MatchReferee, MatchPlayer, CameraTimepoint with full class-level docstrings covering slot
  ordering, null semantics, and the side-exclusivity invariant on MatchPlayer.                                    
  - Docstring clarifications on Player / Team (email is contact-only, not used for auth — do not reflexively add
  unique=True) and on RegistrableConfig / TeamRegistration / PlayerRegistration (fee columns now store exact      
  decimals).                                                                                                      
   
  Backfill — scripts/backfill_normalised_tables.py                                                                
  - Populates the four new tables from the legacy blob columns. Idempotent — uses session.merge, safe to re-run.
  - Pre-flight refuses to run if the destination tables don't yet exist (exit 2) or if the source columns have    
  already been dropped by a later cleanup phase (exit 2, with a restore-from-backup hint), so a misordered run
  can't corrupt data.                                                                                             
  - --dry-run reports planned inserts without committing; mismatched parallel-array lengths on Camera records are
  logged and skipped rather than producing misaligned timepoints.                                                 
                                                                                                                  
  Data quality — scripts/cleanup_data_quality.py
  - Finds and (with --apply) fixes the issues that would otherwise cause the new unique constraints to fail on    
  existing data: duplicate groups, orphan FK references, and blank-but-non-null emails.                           
  - FK-aware: when deduping, picks a deterministic keeper and rewrites incoming references before deleting the
  losers. Designed to be run before applying the unique-constraint half of the migration on any database with     
  pre-existing dirty rows.                                                                                        
                                                                                                                  
  Application read/write switchover and legacy-column drops are not in this PR.  