### PR TITLE
Fix create-tournament: stale registration_open kwarg and TO FK ordering

### DIFF
--- a/app/routes/tournaments.py
+++ b/app/routes/tournaments.py
@@ -234,13 +234,13 @@ def create_tournament():
         rc = RegistrableConfig(
             team_reg_fee=0.0,
             player_reg_fee=0.0,
-            registration_open=False,
         )
         db.session.add(rc)
         db.session.flush()
         tournament.registrable_config_id = rc.id
 
     db.session.add(tournament)
+    db.session.flush()
 
     to_entry = TO(
         user_id=current_user.id,

--- a/tests/test_create_tournament_errors.py
+++ b/tests/test_create_tournament_errors.py
@@ -1,0 +1,58 @@
+"""Reproduction tests for create-tournament errors documented in Ideas.md."""
+
+import pytest
+
+from models import League, RegistrableConfig, TO, Tournament, db
+from tests.utils import login_as, make_registrable_config
+
+
+@pytest.fixture
+def player_user(test_db):
+    from models import Player
+
+    p = Player(id="coolcatmona", name="Mona", pw_hash="x", phone="1")
+    p.set_password("pw")
+    db.session.add(p)
+    db.session.commit()
+    db.session.refresh(p)
+    return p
+
+
+@pytest.mark.integration
+def test_create_standalone_tournament(client, player_user):
+    """Standalone tournament creation should succeed (Error #1 reproduction)."""
+    login_as(client, player_user)
+    resp = client.post(
+        "/_api/create-tournament",
+        data={"name": "Standalone", "url": "ha-standalone"},
+    )
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert Tournament.query.get("ha-standalone") is not None
+    rc = RegistrableConfig.query.filter_by(
+        id=Tournament.query.get("ha-standalone").registrable_config_id
+    ).one()
+    assert rc.team_registration_open is False
+    assert rc.player_registration_open is False
+
+
+@pytest.mark.integration
+def test_create_event_for_league(client, player_user):
+    """Tournament attached to a league should commit cleanly (Error #2 reproduction)."""
+    rc = make_registrable_config()
+    league = League(url="lg", name="Test League", registrable_config_id=rc.id)
+    db.session.add(league)
+    db.session.flush()
+    db.session.add(
+        TO(user_id=player_user.id, user_type="player", event=None, league_id="lg")
+    )
+    db.session.commit()
+
+    login_as(client, player_user)
+    resp = client.post(
+        "/_api/create-tournament",
+        data={"name": "League Event", "url": "ha", "league_id": "lg"},
+    )
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    t = Tournament.query.get("ha")
+    assert t is not None
+    assert t.league_id == "lg"


### PR DESCRIPTION
Two bugs surfaced when creating tournaments via POST /_api/create-tournament.

1. Standalone tournament creation raised `TypeError: 'registration_open' is an invalid keyword argument for RegistrableConfig`. The schema-cleanup commit (d0d7eb6) split the single `registration_open` column into `team_registration_open` and `player_registration_open` and dropped the old field, but missed the call site in `create_tournament`. Removed the stale kwarg; both new columns already default to False.

2. After fix `1`, the same route raised `sqlite3.IntegrityError: FOREIGN KEY constraint failed` on the TO insert. SQLAlchemy did not order the Tournament insert before the TO insert because there is no relationship() connecting `TO.event` to `Tournament.url`, only a bare FK column - so the dependency wasn't visible to the unit-of-work topological sort. Added `db.session.flush()` after adding the tournament, matching the pattern already used in `create_league` and the `tournament` test fixture.

Added `tests/test_create_tournament_errors.py` covering both the standalone and league-attached creation paths end-to-end.