### PR TITLE
[bugfix] table creation on init

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -171,13 +171,6 @@ def create_app(config: dict | None = None) -> Flask:
 
     except Exception:
         pass
-    # Ensure tables exist (safe to call on startup)
-    try:
-        with app.app_context():
-            db.create_all()
-    except Exception:
-        # If creation fails, continue; errors will surface when accessed
-        pass
 
     # Initialize login manager
     login_manager.init_app(app)


### PR DESCRIPTION
this way the app doesn't create empty tables when we add new things, which is good since we should have all db structure changes be explicit. If we don't have a table that we expect, the app should not start.

fixes the issue where alembic migrations fail due to new tables already existing because the app was started.