### PR TITLE
[bugfix] deploy script explicitly source specified bashrc

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,10 @@ jobs:
         REPO_ROOT: "/home/reid/arctos"
         FRONTEND_SERVER_ROOT: "/var/www/reid/arctos/"
         CARGO_ENV_FILE: "/home/reid/.cargo/env"
+        BASHRC_PATH: "/home/reid/.bashrc"
       with:
         host: ${{ secrets.PROD_SERVER_HOST }}
         username: ${{ secrets.PROD_SERVER_USER }}
         key: ${{ secrets.PROD_SERVER_SSH_KEY }}
         script: ~/arctos/update.sh
-        envs: GIT_BRANCH,BUILD_DOCS,REPO_ROOT,FRONTEND_SERVER_ROOT,CARGO_ENV_FILE
+        envs: GIT_BRANCH,BUILD_DOCS,REPO_ROOT,FRONTEND_SERVER_ROOT,CARGO_ENV_FILE,BASHRC_PATH

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -21,10 +21,11 @@ jobs:
         FRONTEND_SERVER_ROOT: "/var/www/html/"
         DOCS_SERVER_ROOT: "/var/www/docs/"
         CARGO_ENV_FILE: "/home/reid/.cargo/env"
+        BASHRC_PATH: "/home/reid/.bashrc"
       with:
         host: ${{ secrets.DEV_SERVER_HOST}}
         username: ${{ secrets.DEV_SERVER_USER }}
         key: ${{ secrets.DEV_SERVER_SSH_KEY }}
         port: ${{ secrets.DEV_SERVER_SSH_PORT }}
         script: ~/arctos/update.sh
-        envs: GIT_BRANCH,BUILD_DOCS,REPO_ROOT,FRONTEND_SERVER_ROOT,DOCS_SERVER_ROOT,CARGO_ENV_FILE
+        envs: GIT_BRANCH,BUILD_DOCS,REPO_ROOT,FRONTEND_SERVER_ROOT,DOCS_SERVER_ROOT,CARGO_ENV_FILE,BASHRC_PATH

--- a/update.sh
+++ b/update.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+. $BASHRC_PATH
+
 cd $REPO_ROOT
 
 


### PR DESCRIPTION
prod deploy action failed since prod runs zsh which has a more sophisticated mechanism for not running the zshrc file than bash