### PR TITLE
[Feature] String Length Validation

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,6 +7,7 @@ compatibility layer that re-exports from here.
 """
 
 from app.models.base import db, init_db
+from app.models import validators  # noqa: F401 - registers length validators before any mapper is configured
 from app.models import (
     constants,
 )  # noqa: F401 — re-export for ``from app.models import constants``

--- a/app/models/validators.py
+++ b/app/models/validators.py
@@ -1,0 +1,79 @@
+"""Automatic length validation for SQLAlchemy ``String(N)`` columns.
+
+Importing this module registers a single ``mapper_configured`` event
+listener. For every ORM mapper that is configured, the listener walks
+``mapper.column_attrs`` and, for each column whose type is a
+:class:`sqlalchemy.String` with a non-``None`` ``length``, installs a
+``set`` event listener on the instrumented attribute. The ``set`` listener
+checks ``len(value)`` against the column's declared length and raises
+:class:`app.exceptions.ValidationError` if the value exceeds the limit.
+
+The module must be imported before any mapper is *configured* (mapper
+configuration is lazy and is normally triggered by the first query or by
+``configure_mappers()``). Importing it at the top of
+:mod:`app.models.__init__` - before the individual model modules are
+imported - is sufficient.
+
+Behaviour summary:
+
+* ``str`` values longer than the column length -> ``ValidationError``.
+* ``str`` values shorter than or exactly equal to the column length -> pass.
+* ``None`` -> pass (nullability is enforced separately by the DB column).
+* Non-string values -> pass through; SQLAlchemy's own type handling owns
+  type coercion.
+* ``Text`` columns -> pass; ``Text`` has no declared length.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from sqlalchemy import String, event
+from sqlalchemy.orm import Mapper
+
+from app.exceptions import ValidationError
+
+
+def _make_length_validator(field_name: str, max_length: int) -> Callable[..., Any]:
+    """Build a ``set``-event handler that rejects over-long string values.
+
+    Args:
+        field_name: The SQLAlchemy attribute key, used in the error message.
+        max_length: The declared column length to enforce.
+
+    Returns:
+        A callable suitable for use with ``event.listen(..., 'set', ..., retval=True)``.
+    """
+
+    def _validate(target: Any, value: Any, oldvalue: Any, initiator: Any) -> Any:
+        if isinstance(value, str) and len(value) > max_length:
+            raise ValidationError(
+                f"{field_name} exceeds maximum length of {max_length} "
+                f"characters (got {len(value)})"
+            )
+        return value
+
+    return _validate
+
+
+@event.listens_for(Mapper, "mapper_configured")
+def _install_string_length_validators(mapper: Mapper, cls: type) -> None:
+    """Install per-column length validators on ``cls`` when its mapper is configured.
+
+    Scans every column-mapped attribute on the mapper; for each one backed by a
+    ``String`` column with a non-``None`` ``length``, attaches a ``set`` event
+    listener to the instrumented attribute.
+
+    Args:
+        mapper: The SQLAlchemy ``Mapper`` that has just finished configuring.
+        cls: The mapped class (the ORM model).
+    """
+    for col_attr in mapper.column_attrs:
+        col = col_attr.columns[0]
+        if isinstance(col.type, String) and col.type.length:
+            event.listen(
+                getattr(cls, col_attr.key),
+                "set",
+                _make_length_validator(col_attr.key, col.type.length),
+                retval=True,
+            )

--- a/tests/unit/test_string_length_validation.py
+++ b/tests/unit/test_string_length_validation.py
@@ -25,54 +25,55 @@ def test_player_name_rejects_value_longer_than_short_name_len(test_db):
 
 @pytest.mark.unit
 def test_player_name_accepts_value_exactly_at_short_name_len(test_db):
-    """A 100-char name (exactly SHORT_NAME_LEN) is accepted."""
+    """A 100-char name (exactly SHORT_NAME_LEN) is accepted.
+
+    Guards against an off-by-one regression that changes ``len(value) > N``
+    to ``>=`` in the validator.
+    """
     player = Player(id="lenok1", pw_hash="dummy")
-    player.name = "x" * 100  # should not raise
-    assert player.name == "x" * 100
-
-
-@pytest.mark.unit
-def test_player_name_accepts_value_shorter_than_short_name_len(test_db):
-    """A short name is accepted unchanged."""
-    player = Player(id="lenok2", pw_hash="dummy")
-    player.name = "Alice"
-    assert player.name == "Alice"
+    player.name = "x" * 100  # must not raise ValidationError
 
 
 @pytest.mark.unit
 def test_nullable_string_accepts_none(test_db):
-    """Assigning None to a nullable String column does not raise."""
+    """Assigning None to a nullable String column does not raise.
+
+    Exercises the ``isinstance(value, str)`` guard: without it, ``len(None)``
+    would raise ``TypeError`` from inside the validator.
+    """
     player = Player(id="lennone", name="N", pw_hash="dummy")
-    player.location = None  # Player.location is nullable String(SHORT_NAME_LEN)
-    assert player.location is None
+    player.location = None  # must not raise ValidationError or TypeError
 
 
 @pytest.mark.unit
 def test_validator_passes_through_non_string_values(test_db):
-    """The length validator only checks strings; other types are not its concern."""
+    """Non-string values bypass the validator entirely.
+
+    Exercises the ``isinstance(value, str)`` guard for non-None, non-str
+    inputs. SQLAlchemy's own type handling owns the error path for type
+    misuse; the length validator is not it.
+    """
     player = Player(id="lenint", name="N", pw_hash="dummy")
-    # Assigning an int to a String column is a type misuse, but the length
-    # validator should not be what catches it - it should be a no-op so that
-    # SQLAlchemy's own type handling owns the error path.
     player.location = 12345  # must not raise ValidationError
-    assert player.location == 12345
 
 
 @pytest.mark.unit
 def test_text_columns_are_not_length_limited(test_db):
-    """Text columns have no declared length and are never rejected by the validator."""
+    """Columns without a declared length (db.Text) are never wired up.
+
+    Exercises the ``col.type.length`` skip in the mapper-walking installer.
+    """
     player = Player(id="lentext", name="N", pw_hash="dummy")
-    long_bio = "x" * 100_000  # Player.bio is db.Text - no length
-    player.bio = long_bio  # must not raise
-    assert player.bio == long_bio
+    player.bio = "x" * 100_000  # must not raise ValidationError
 
 
 @pytest.mark.unit
 def test_every_mapped_string_column_rejects_overflow(test_db):
     """Sweep every registered mapper and confirm each String(N) column rejects N+1 chars.
 
-    This is the future-proofing guard: any String column added to a model in
+    Any String column added to a model in
     future will be covered automatically without per-column test maintenance.
+
     The test does not write to the database - it only assigns to an in-memory
     instance and asserts the validator fires.
     """
@@ -98,6 +99,4 @@ def test_every_mapped_string_column_rejects_overflow(test_db):
             assert str(n) in msg, f"{cls.__name__}.{field}: max length missing from error"
             checked.append((cls.__name__, field, n))
 
-    # Sanity floor: the codebase has ~103 String(N) columns; a regression that
-    # silently dropped a large chunk should fail here, not just an empty sweep.
     assert len(checked) >= 80, f"expected coverage sweep to hit many columns, got {checked!r}"

--- a/tests/unit/test_string_length_validation.py
+++ b/tests/unit/test_string_length_validation.py
@@ -1,0 +1,23 @@
+"""Tests for automatic string length validation on SQLAlchemy String columns.
+
+These tests verify that assigning an over-long value to any String(N) ORM
+attribute raises ValidationError before the value can reach the database.
+The validators are installed once, at import time, by app/models/validators.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.exceptions import ValidationError
+from models import Player
+
+
+@pytest.mark.unit
+def test_player_name_rejects_value_longer_than_short_name_len(test_db):
+    """Assigning a 101-char name to Player.name (SHORT_NAME_LEN=100) raises ValidationError."""
+    player = Player(id="lenchk", pw_hash="dummy")
+    with pytest.raises(ValidationError) as exc:
+        player.name = "x" * 101
+    assert "name" in str(exc.value)
+    assert "100" in str(exc.value)

--- a/tests/unit/test_string_length_validation.py
+++ b/tests/unit/test_string_length_validation.py
@@ -55,6 +55,7 @@ def test_validator_passes_through_non_string_values(test_db):
     # validator should not be what catches it - it should be a no-op so that
     # SQLAlchemy's own type handling owns the error path.
     player.location = 12345  # must not raise ValidationError
+    assert player.location == 12345
 
 
 @pytest.mark.unit
@@ -97,5 +98,6 @@ def test_every_mapped_string_column_rejects_overflow(test_db):
             assert str(n) in msg, f"{cls.__name__}.{field}: max length missing from error"
             checked.append((cls.__name__, field, n))
 
-    # Sanity floor: if this drops to zero, the sweep is silently a no-op.
-    assert len(checked) >= 20, f"expected coverage sweep to hit many columns, got {checked!r}"
+    # Sanity floor: the codebase has ~103 String(N) columns; a regression that
+    # silently dropped a large chunk should fail here, not just an empty sweep.
+    assert len(checked) >= 80, f"expected coverage sweep to hit many columns, got {checked!r}"

--- a/tests/unit/test_string_length_validation.py
+++ b/tests/unit/test_string_length_validation.py
@@ -21,3 +21,81 @@ def test_player_name_rejects_value_longer_than_short_name_len(test_db):
         player.name = "x" * 101
     assert "name" in str(exc.value)
     assert "100" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_player_name_accepts_value_exactly_at_short_name_len(test_db):
+    """A 100-char name (exactly SHORT_NAME_LEN) is accepted."""
+    player = Player(id="lenok1", pw_hash="dummy")
+    player.name = "x" * 100  # should not raise
+    assert player.name == "x" * 100
+
+
+@pytest.mark.unit
+def test_player_name_accepts_value_shorter_than_short_name_len(test_db):
+    """A short name is accepted unchanged."""
+    player = Player(id="lenok2", pw_hash="dummy")
+    player.name = "Alice"
+    assert player.name == "Alice"
+
+
+@pytest.mark.unit
+def test_nullable_string_accepts_none(test_db):
+    """Assigning None to a nullable String column does not raise."""
+    player = Player(id="lennone", name="N", pw_hash="dummy")
+    player.location = None  # Player.location is nullable String(SHORT_NAME_LEN)
+    assert player.location is None
+
+
+@pytest.mark.unit
+def test_validator_passes_through_non_string_values(test_db):
+    """The length validator only checks strings; other types are not its concern."""
+    player = Player(id="lenint", name="N", pw_hash="dummy")
+    # Assigning an int to a String column is a type misuse, but the length
+    # validator should not be what catches it - it should be a no-op so that
+    # SQLAlchemy's own type handling owns the error path.
+    player.location = 12345  # must not raise ValidationError
+
+
+@pytest.mark.unit
+def test_text_columns_are_not_length_limited(test_db):
+    """Text columns have no declared length and are never rejected by the validator."""
+    player = Player(id="lentext", name="N", pw_hash="dummy")
+    long_bio = "x" * 100_000  # Player.bio is db.Text - no length
+    player.bio = long_bio  # must not raise
+    assert player.bio == long_bio
+
+
+@pytest.mark.unit
+def test_every_mapped_string_column_rejects_overflow(test_db):
+    """Sweep every registered mapper and confirm each String(N) column rejects N+1 chars.
+
+    This is the future-proofing guard: any String column added to a model in
+    future will be covered automatically without per-column test maintenance.
+    The test does not write to the database - it only assigns to an in-memory
+    instance and asserts the validator fires.
+    """
+    from sqlalchemy import String
+    from sqlalchemy.orm import instrumentation as sa_instrumentation
+
+    from app.models import db
+
+    checked: list[tuple[str, str, int]] = []
+    for mapper in db.Model.registry.mappers:
+        cls = mapper.class_
+        for col_attr in mapper.column_attrs:
+            col = col_attr.columns[0]
+            if not (isinstance(col.type, String) and col.type.length):
+                continue
+            instance = sa_instrumentation.manager_of_class(cls).new_instance()
+            field = col_attr.key
+            n = col.type.length
+            with pytest.raises(ValidationError) as exc:
+                setattr(instance, field, "x" * (n + 1))
+            msg = str(exc.value)
+            assert field in msg, f"{cls.__name__}.{field}: field name missing from error"
+            assert str(n) in msg, f"{cls.__name__}.{field}: max length missing from error"
+            checked.append((cls.__name__, field, n))
+
+    # Sanity floor: if this drops to zero, the sweep is silently a no-op.
+    assert len(checked) >= 20, f"expected coverage sweep to hit many columns, got {checked!r}"


### PR DESCRIPTION
Adds automatic Python-side length validation for every SQLAlchemy `String(N)` column in the ORM. Over-long values now raise `app.exceptions.ValidationError` (HTTP 400 with field name + limit) instead of failing at the DB driver level.

## What changed

- New module `app/models/validators.py` registers a single `mapper_configured` event listener. On every mapper configuration it walks `mapper.column_attrs`; for each `String` column whose `length` is non-None it installs a `set`-event listener that compares `len(value)` against the declared length and raises `ValidationError(f"{field} exceeds maximum length of {N} characters (got {M})")` on overflow.
- `app/models/__init__.py` imports the new module *before* any model module, so the listener is in place before any mapper is configured.
- New test file `tests/unit/test_string_length_validation.py` with six tests:
    - over-limit assignment raises and the error names the field + limit
    - exact-at-limit assignment passes (off-by-one guard)
    - None passes (isinstance guard)
    - non-string passes (isinstance guard)
    - `Text` columns are not wired up (`col.type.length` skip)
    - Every registered `String(N)` column rejects `N+1` chars; sanity floor of 80 catches a silent regression where chunks of mappers fail to register

Zero per-model code changes. Future `String` columns auto-enroll on import.

## Other considerations

When using @validates, we need to explicitly mark model with the @validates decorator, and each column would have to be enumerated by name. If one is missed (say, by user error), it goes unvalidated

If we add a new model or column, it is auto validated

This has wider / easier coverage, but explicitly using a @validates decorator would be an argument for readability

## Migrations

None