### PR TITLE
[Bugfix] Fix eligible-players endpoint for league-scoped registrations

### DIFF
--- a/app/models/validators.py
+++ b/app/models/validators.py
@@ -47,10 +47,7 @@ def _make_length_validator(field_name: str, max_length: int) -> Callable[..., An
 
     def _validate(target: Any, value: Any, oldvalue: Any, initiator: Any) -> Any:
         if isinstance(value, str) and len(value) > max_length:
-            raise ValidationError(
-                f"{field_name} exceeds maximum length of {max_length} "
-                f"characters (got {len(value)})"
-            )
+            raise ValidationError(f"{field_name} exceeds maximum length of {max_length} characters (got {len(value)})")
         return value
 
     return _validate

--- a/app/routes/sidecomps.py
+++ b/app/routes/sidecomps.py
@@ -249,12 +249,15 @@ def deregister_player_as_to(comp_id: int):
 def eligible_players(comp_id: int):
     """TO-only: list players registered for the event but not yet in this side comp."""
     from app.domain.enums import RegistrationStatus
+    from app.services.registration_resolver import (
+        player_registrations_for_tournament,
+        team_registrations_for_tournament,
+    )
     from models import (
         Player,
-        PlayerRegistration,
         SideComp,
         SideCompRegistration,
-        TeamRegistration,
+        Tournament,
     )
 
     sc = SideComp.query.get(comp_id)
@@ -265,12 +268,11 @@ def eligible_players(comp_id: int):
     if auth_check.is_err():
         return json_from_result(auth_check)
 
+    tournament = Tournament.query.get(sc.event)
+
     already_in = {r.player for r in SideCompRegistration.query.filter_by(comp=comp_id).all()}
 
-    event_regs = PlayerRegistration.query.filter_by(
-        event=sc.event,
-        status=RegistrationStatus.CONFIRMED,
-    ).all()
+    event_regs = player_registrations_for_tournament(tournament, statuses=[RegistrationStatus.CONFIRMED])
 
     eligible = [er for er in event_regs if er.player not in already_in]
     player_ids = [er.player for er in eligible]
@@ -278,13 +280,7 @@ def eligible_players(comp_id: int):
 
     players_by_id = {p.id: p for p in Player.query.filter(Player.id.in_(player_ids)).all()} if player_ids else {}
     team_pseudonyms = (
-        {
-            tr.team: tr.pseudonym
-            for tr in TeamRegistration.query.filter(
-                TeamRegistration.event == sc.event,
-                TeamRegistration.team.in_(team_ids),
-            ).all()
-        }
+        {tr.team: tr.pseudonym for tr in team_registrations_for_tournament(tournament) if tr.team in team_ids}
         if team_ids
         else {}
     )

--- a/app/utils/decorators.py
+++ b/app/utils/decorators.py
@@ -151,9 +151,7 @@ def require_json_body():
         @wraps(fn)
         def wrapper(*args, **kwargs):
             if not request.is_json:
-                return json_error(
-                    "Content-Type must be application/json", status_code=415
-                )
+                return json_error("Content-Type must be application/json", status_code=415)
             parsed = request.get_json(silent=True)
             # Distinguish empty body (parsed is None AND no data) from malformed JSON
             # (parsed is None BUT data is present).

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -4,10 +4,7 @@ Anything that has a clearly named workflow belongs in a service; this
 module is the home for small, generally-applicable helpers that don't.
 """
 
-import hmac
-import hashlib
 import re
-from flask import current_app
 from flask_login import current_user
 from app.domain.enums import RegistrationStatus
 from app.services._common import current_user_type

--- a/tests/test_sidecomp_entry_number_race.py
+++ b/tests/test_sidecomp_entry_number_race.py
@@ -70,7 +70,5 @@ def test_register_player_retries_on_entry_number_collision(comp_setup):
         res1 = SideCompService.register_player(comp_id, player_id=p1.id)
     assert isinstance(res1, Ok), repr(res1)
 
-    rows = SideCompRegistration.query.filter_by(comp=comp_id).order_by(
-        SideCompRegistration.entry_number
-    ).all()
+    rows = SideCompRegistration.query.filter_by(comp=comp_id).order_by(SideCompRegistration.entry_number).all()
     assert [r.entry_number for r in rows] == [1, 2]

--- a/tests/test_sidecomps.py
+++ b/tests/test_sidecomps.py
@@ -1110,3 +1110,74 @@ def test_route_eligible_players_excludes_already_registered(app, client, tournam
     ids = {row["player_id"] for row in resp.get_json()}
     assert "p2" in ids
     assert "p1" not in ids
+
+
+def test_route_eligible_players_returns_league_scoped_registrations(app, client, test_db):
+    """A side comp on a league-linked tournament must surface league-scoped registrations.
+
+    For league tournaments, PlayerRegistration rows have league_id set and event NULL,
+    and team pseudonyms live on league-scoped TeamRegistration rows. The endpoint must
+    resolve registrations through the tournament's scope rather than filtering by event
+    directly.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from app.domain.enums import TeamRegistrationStatus
+    from models import League, Team, TeamRegistration, Tournament
+    from tests.utils import make_registrable_config
+
+    with app.app_context():
+        cfg = make_registrable_config(team_registration_open=True, player_registration_open=True)
+        league = League(url="lg", name="LG", registrable_config_id=cfg.id)
+        db.session.add(league)
+        db.session.flush()
+        tourn = Tournament(
+            url="lg-evt",
+            name="League Event",
+            start_date=datetime.now(timezone.utc),
+            end_date=datetime.now(timezone.utc) + timedelta(days=1),
+            league_id="lg",
+        )
+        db.session.add(tourn)
+        db.session.flush()
+
+        to_user = _make_player("lg_to", "LG TO")
+        db.session.add(TO(user_id=to_user.id, user_type="player", event=None, league_id="lg"))
+
+        team = Team(id="lg_team", name="LG Team", pw_hash="dummy_hash")
+        db.session.add(team)
+        db.session.flush()
+        db.session.add(
+            TeamRegistration(
+                event=None,
+                league_id="lg",
+                team=team.id,
+                pseudonym="LG Pseudonym",
+                status=TeamRegistrationStatus.CONFIRMED,
+            )
+        )
+
+        p1 = _make_player("lg_p1", "LG P1")
+        db.session.add(
+            PlayerRegistration(
+                event=None,
+                league_id="lg",
+                player=p1.id,
+                team=team.id,
+                jersey_number="7",
+                jersey_name="P1",
+                status=RegistrationStatus.CONFIRMED,
+            )
+        )
+
+        sc = SideComp(event=tourn.url, name="LG SC", type="DUELING")
+        db.session.add(sc)
+        db.session.commit()
+        comp_id = sc.id
+        login_as(client, to_user)
+
+    resp = client.get(f"/_api/sidecomps/{comp_id}/eligible-players")
+    assert resp.status_code == 200
+    rows = resp.get_json()
+    assert [row["player_id"] for row in rows] == ["lg_p1"]
+    assert rows[0]["team_pseudonym"] == "LG Pseudonym"

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -7,12 +7,14 @@ import pytest
 # wants_json helper tests  (use the session-scoped ``app`` - no HTTP requests)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 def test_wants_json_for_json_content_type(app):
     from app.utils.decorators import wants_json
 
     with app.test_request_context("/foo", json={"a": 1}):
         from flask import request
+
         assert wants_json(request) is True
 
 
@@ -22,6 +24,7 @@ def test_wants_json_for_api_path(app):
 
     with app.test_request_context("/_api/something"):
         from flask import request
+
         assert wants_json(request) is True
 
 
@@ -31,6 +34,7 @@ def test_wants_json_for_accept_header(app):
 
     with app.test_request_context("/foo", headers={"Accept": "application/json"}):
         from flask import request
+
         assert wants_json(request) is True
 
 
@@ -40,6 +44,7 @@ def test_wants_json_false_for_html_request(app):
 
     with app.test_request_context("/foo", headers={"Accept": "text/html"}):
         from flask import request
+
         assert wants_json(request) is False
 
 
@@ -52,6 +57,7 @@ def test_wants_json_false_for_no_accept_header(app):
 
     with app.test_request_context("/foo"):
         from flask import request
+
         assert wants_json(request) is False
 
 
@@ -63,6 +69,7 @@ def test_wants_json_false_for_no_accept_header(app):
 # ``app``.  This avoids Flask's "no new routes after first request" guard
 # when running under pytest-xdist.
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 def test_require_tournament_organizer_html_redirects_when_not_to(fresh_app):


### PR DESCRIPTION
Closes #180 

<img width="1617" height="488" alt="image" src="https://github.com/user-attachments/assets/88f31f92-a665-4b03-a8a0-6b00e38d69ea" />

```
$ curl 'http://127.0.0.1:5006/_api/sidecomps/1/eligible-players' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.6' \
  -H 'Connection: keep-alive' \
  -b 'session=<this is where my cookie is> \
  -H 'Origin: http://127.0.0.1:8080' \
  -H 'Referer: http://127.0.0.1:8080/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-site' \
  -H 'Sec-GPC: 1' \
  -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36' \
  -H 'sec-ch-ua: "Chromium";v="148", "Brave";v="148", "Not/A)Brand";v="99"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "Windows"'
```
```
[{"jersey_name":"Zen","player_id":"coolcatmona","player_name":"Zen","team_id":"Firewatch","team_pseudonym":"Firewatch"},{"jersey_name":"SomeJugger","player_id":"SomeJugger","player_name":"SomeJugger","team_id":null,"team_pseudonym":null}]
```