### PR TITLE
[bugfix] stricter url validation requirements

### DIFF
--- a/app/models/validators.py
+++ b/app/models/validators.py
@@ -77,6 +77,7 @@ def _make_url_slug_validator(field_name: str) -> Callable[..., Any]:
 
     return _validate
 
+
 @event.listens_for(Mapper, "mapper_configured")
 def _install_string_length_validators(mapper: Mapper, cls: type) -> None:
     """Install per-column length validators on ``cls`` when its mapper is configured.

--- a/app/models/validators.py
+++ b/app/models/validators.py
@@ -1,12 +1,15 @@
-"""Automatic length validation for SQLAlchemy ``String(N)`` columns.
+"""Automatic validation hooks for SQLAlchemy string-backed model fields.
 
-Importing this module registers a single ``mapper_configured`` event
-listener. For every ORM mapper that is configured, the listener walks
-``mapper.column_attrs`` and, for each column whose type is a
+Importing this module registers ``mapper_configured`` listeners. For every ORM
+mapper that is configured, the length installer walks ``mapper.column_attrs``
+and, for each column whose type is a
 :class:`sqlalchemy.String` with a non-``None`` ``length``, installs a
 ``set`` event listener on the instrumented attribute. The ``set`` listener
 checks ``len(value)`` against the column's declared length and raises
 :class:`app.exceptions.ValidationError` if the value exceeds the limit.
+
+A second installer attaches shared URL-slug validation to the ORM fields that
+store league and event slugs.
 
 The module must be imported before any mapper is *configured* (mapper
 configuration is lazy and is normally triggered by the first query or by
@@ -26,12 +29,23 @@ Behaviour summary:
 
 from __future__ import annotations
 
+import re
 from typing import Any, Callable
 
 from sqlalchemy import String, event
 from sqlalchemy.orm import Mapper
 
 from app.exceptions import ValidationError
+from app.models.constants import URL_SLUG_LEN
+
+URL_SLUG_ALLOWED_HINT = "URL slugs may only contain letters, numbers, or -_~."
+_URL_SLUG_PATTERN = re.compile(r"^[A-Za-z0-9\.\_\~\-]+$")
+
+
+def is_valid_url_slug(value: str) -> bool:
+    """Return whether ``value`` is a non-empty slug with only allowed characters."""
+
+    return bool(_URL_SLUG_PATTERN.fullmatch(value))
 
 
 def _make_length_validator(field_name: str, max_length: int) -> Callable[..., Any]:
@@ -53,6 +67,16 @@ def _make_length_validator(field_name: str, max_length: int) -> Callable[..., An
     return _validate
 
 
+def _make_url_slug_validator(field_name: str) -> Callable[..., Any]:
+    """Build a ``set``-event handler that enforces the shared URL slug rules."""
+
+    def _validate(target: Any, value: Any, oldvalue: Any, initiator: Any) -> Any:
+        if isinstance(value, str) and value and not is_valid_url_slug(value):
+            raise ValidationError(f"{field_name} may only contain letters, numbers, or -_~.")
+        return value
+
+    return _validate
+
 @event.listens_for(Mapper, "mapper_configured")
 def _install_string_length_validators(mapper: Mapper, cls: type) -> None:
     """Install per-column length validators on ``cls`` when its mapper is configured.
@@ -72,5 +96,20 @@ def _install_string_length_validators(mapper: Mapper, cls: type) -> None:
                 getattr(cls, col_attr.key),
                 "set",
                 _make_length_validator(col_attr.key, col.type.length),
+                retval=True,
+            )
+
+
+@event.listens_for(Mapper, "mapper_configured")
+def _install_url_slug_validators(mapper: Mapper, cls: type) -> None:
+    """Install shared URL-slug validators on ``cls`` when its mapper is configured."""
+
+    for col_attr in mapper.column_attrs:
+        col = col_attr.columns[0]
+        if isinstance(col.type, String) and col_attr.key in {"url", "event", "league_id"}:
+            event.listen(
+                getattr(cls, col_attr.key),
+                "set",
+                _make_url_slug_validator(col_attr.key),
                 retval=True,
             )

--- a/app/routes/tournaments.py
+++ b/app/routes/tournaments.py
@@ -46,6 +46,7 @@ from app.utils.scheduling import (
     recompute_all_match_times,
 )
 from app.utils.name_validation import match_name_char_error
+from app.models.validators import URL_SLUG_ALLOWED_HINT, is_valid_url_slug
 from app.utils.decorators import require_tournament_organizer
 from app.utils.datetime_helpers import now_utc_naive
 
@@ -181,8 +182,21 @@ def create_tournament():
         JSON ``{"success": true, "url": "<slug>"}`` on success, or error
         with HTTP 400/403.
     """
-    name = request.form["name"]
-    url = request.form["url"]
+    name = request.form["name"].strip()
+    url = request.form["url"].strip()
+
+    if not name or not url:
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": f"Name and URL slug are required. {URL_SLUG_ALLOWED_HINT}",
+                }
+            ),
+            400,
+        )
+    if not is_valid_url_slug(url):
+        return jsonify({"success": False, "error": URL_SLUG_ALLOWED_HINT}), 400
 
     if Tournament.query.filter_by(url=url).first():
         return (
@@ -264,11 +278,13 @@ def create_league():
             jsonify(
                 {
                     "success": False,
-                    "error": "League name and URL slug are required.",
+                    "error": f"League name and URL slug are required. {URL_SLUG_ALLOWED_HINT}",
                 }
             ),
             400,
         )
+    if not is_valid_url_slug(league_url):
+        return jsonify({"success": False, "error": URL_SLUG_ALLOWED_HINT}), 400
 
     if League.query.filter_by(url=league_url).first():
         return jsonify({"success": False, "error": "League URL already exists"}), 400

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -4,6 +4,7 @@ mod api;
 mod components;
 mod pages;
 mod time_format;
+mod url_slug;
 
 #[cfg(target_arch = "wasm32")]
 mod record_idb;

--- a/frontend/src/pages/league_new_tournament.rs
+++ b/frontend/src/pages/league_new_tournament.rs
@@ -1,4 +1,5 @@
 use crate::api;
+use crate::url_slug::{is_valid_url_slug, URL_SLUG_ALLOWED_HINT};
 use crate::Route;
 use dioxus::prelude::*;
 use wasm_bindgen::JsCast;
@@ -9,14 +10,6 @@ fn get_form_value(id: &str) -> String {
         .and_then(|e| e.dyn_into::<web_sys::HtmlInputElement>().ok())
         .map(|e| e.value())
         .unwrap_or_default()
-}
-
-fn get_form_check(id: &str) -> bool {
-    let doc = web_sys::window().and_then(|w| w.document()).unwrap();
-    doc.get_element_by_id(id)
-        .and_then(|e| e.dyn_into::<web_sys::HtmlInputElement>().ok())
-        .map(|e| e.checked())
-        .unwrap_or(false)
 }
 
 #[component]
@@ -46,10 +39,14 @@ pub fn LeagueNewTournament(league_url: String) -> Element {
                                 onsubmit: move |ev| {
                                     ev.prevent_default();
                                     error.set(None);
-                                    let name = get_form_value("name");
-                                    let url_slug = get_form_value("url");
+                                    let name = get_form_value("name").trim().to_string();
+                                    let url_slug = get_form_value("url").trim().to_string();
                                     if name.is_empty() || url_slug.is_empty() {
                                         error.set(Some("Name and URL slug are required.".to_string()));
+                                        return;
+                                    }
+                                    if !is_valid_url_slug(&url_slug) {
+                                        error.set(Some(URL_SLUG_ALLOWED_HINT.to_string()));
                                         return;
                                     }
                                     let nav = navigator.clone();
@@ -78,8 +75,16 @@ pub fn LeagueNewTournament(league_url: String) -> Element {
                                 }
                                 div { class: "mb-3",
                                     label { r#for: "url", class: "form-label", "URL Slug" }
-                                    input { r#type: "text", class: "form-control", id: "url", name: "url", required: true }
-                                    div { class: "form-text", "This will be used in the URL (e.g., /my-event)" }
+                                    input {
+                                        r#type: "text",
+                                        class: "form-control",
+                                        id: "url",
+                                        name: "url",
+                                        required: true,
+                                        pattern: "[A-Za-z0-9_~-]+",
+                                        title: URL_SLUG_ALLOWED_HINT,
+                                    }
+                                    div { class: "form-text", "This will be used in the URL (e.g., /my-event). {URL_SLUG_ALLOWED_HINT}" }
                                 }
                                 div { class: "d-flex gap-2",
                                     Link { to: Route::LeagueHome { league_url: lu_for_cancel.clone() }, class: "btn btn-outline-secondary", "Cancel" }

--- a/frontend/src/pages/new_league.rs
+++ b/frontend/src/pages/new_league.rs
@@ -1,4 +1,5 @@
 use crate::api;
+use crate::url_slug::{is_valid_url_slug, URL_SLUG_ALLOWED_HINT};
 use crate::Route;
 use dioxus::prelude::*;
 use wasm_bindgen::JsCast;
@@ -31,10 +32,14 @@ pub fn NewLeague() -> Element {
                             onsubmit: move |ev| {
                                 ev.prevent_default();
                                 error.set(None);
-                                let league_name = get_form_value("league_name");
-                                let league_url = get_form_value("league_url");
+                                let league_name = get_form_value("league_name").trim().to_string();
+                                let league_url = get_form_value("league_url").trim().to_string();
                                 if league_name.is_empty() || league_url.is_empty() {
                                     error.set(Some("League name and URL slug are required.".to_string()));
+                                    return;
+                                }
+                                if !is_valid_url_slug(&league_url) {
+                                    error.set(Some(URL_SLUG_ALLOWED_HINT.to_string()));
                                     return;
                                 }
                                 let nav = navigator.clone();
@@ -63,8 +68,16 @@ pub fn NewLeague() -> Element {
                             }
                             div { class: "mb-3",
                                 label { r#for: "league_url", class: "form-label", "League URL Slug" }
-                                input { r#type: "text", class: "form-control", id: "league_url", name: "league_url", required: true }
-                                div { class: "form-text", "Used in the URL, e.g. /leagues/norcal-2025" }
+                                input {
+                                    r#type: "text",
+                                    class: "form-control",
+                                    id: "league_url",
+                                    name: "league_url",
+                                    required: true,
+                                    pattern: r"[A-Za-z0-9\.\_\~\-]+",
+                                    title: URL_SLUG_ALLOWED_HINT,
+                                }
+                                div { class: "form-text", "Used in the URL, e.g. /leagues/norcal-2025. {URL_SLUG_ALLOWED_HINT}" }
                             }
                             div { class: "d-grid",
                                 button { r#type: "submit", class: "btn btn-primary", "Create League" }

--- a/frontend/src/pages/new_tournament.rs
+++ b/frontend/src/pages/new_tournament.rs
@@ -1,4 +1,5 @@
 use crate::api;
+use crate::url_slug::{is_valid_url_slug, URL_SLUG_ALLOWED_HINT};
 use crate::Route;
 use dioxus::prelude::*;
 use wasm_bindgen::JsCast;
@@ -9,14 +10,6 @@ fn get_form_value(id: &str) -> String {
         .and_then(|e| e.dyn_into::<web_sys::HtmlInputElement>().ok())
         .map(|e| e.value())
         .unwrap_or_default()
-}
-
-fn get_form_check(id: &str) -> bool {
-    let doc = web_sys::window().and_then(|w| w.document()).unwrap();
-    doc.get_element_by_id(id)
-        .and_then(|e| e.dyn_into::<web_sys::HtmlInputElement>().ok())
-        .map(|e| e.checked())
-        .unwrap_or(false)
 }
 
 #[component]
@@ -39,10 +32,14 @@ pub fn NewTournament() -> Element {
                             onsubmit: move |ev| {
                                 ev.prevent_default();
                                 error.set(None);
-                                let name = get_form_value("name");
-                                let url_slug = get_form_value("url");
+                                let name = get_form_value("name").trim().to_string();
+                                let url_slug = get_form_value("url").trim().to_string();
                                 if name.is_empty() || url_slug.is_empty() {
                                     error.set(Some("Name and URL slug are required.".to_string()));
+                                    return;
+                                }
+                                if !is_valid_url_slug(&url_slug) {
+                                    error.set(Some(URL_SLUG_ALLOWED_HINT.to_string()));
                                     return;
                                 }
                                 let nav = navigator.clone();
@@ -70,8 +67,16 @@ pub fn NewTournament() -> Element {
                             }
                             div { class: "mb-3",
                                 label { r#for: "url", class: "form-label", "URL Slug" }
-                                input { r#type: "text", class: "form-control", id: "url", name: "url", required: true }
-                                div { class: "form-text", "This will be used in the URL (e.g., /my-tournament)" }
+                                input {
+                                    r#type: "text",
+                                    class: "form-control",
+                                    id: "url",
+                                    name: "url",
+                                    required: true,
+                                    pattern: r"[A-Za-z0-9\.\_\~\-]+",
+                                    title: URL_SLUG_ALLOWED_HINT,
+                                }
+                                div { class: "form-text", "This will be used in the URL (e.g., /my-tournament). {URL_SLUG_ALLOWED_HINT}" }
                             }
                             div { class: "d-grid",
                                 button { r#type: "submit", class: "btn btn-primary", "Create Tournament" }

--- a/frontend/src/url_slug.rs
+++ b/frontend/src/url_slug.rs
@@ -1,0 +1,8 @@
+pub const URL_SLUG_ALLOWED_HINT: &str = "URL slugs may only contain letters, numbers, or -_~.";
+
+pub fn is_valid_url_slug(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '~' | '.'))
+}

--- a/tests/test_create_tournament_errors.py
+++ b/tests/test_create_tournament_errors.py
@@ -52,3 +52,46 @@ def test_create_event_for_league(client, player_user):
     t = Tournament.query.get("ha")
     assert t is not None
     assert t.league_id == "lg"
+
+
+@pytest.mark.integration
+def test_create_standalone_tournament_rejects_invalid_url_slug(client, player_user):
+    login_as(client, player_user)
+    resp = client.post(
+        "/_api/create-tournament",
+        data={"name": "Standalone", "url": "/bad-slug"},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["success"] is False
+    assert "letters, numbers, or -_~." in body["error"]
+    assert Tournament.query.get("/bad-slug") is None
+    assert Tournament.query.get("bad-slug") is None
+
+
+@pytest.mark.integration
+def test_create_tournament_rejects_empty_cleaned_url_slug(client, player_user):
+    login_as(client, player_user)
+    resp = client.post(
+        "/_api/create-tournament",
+        data={"name": "Standalone", "url": " !!! "},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["success"] is False
+    assert "letters, numbers, or -_~." in body["error"]
+
+
+@pytest.mark.integration
+def test_create_league_rejects_invalid_url_slug(client, player_user):
+    login_as(client, player_user)
+    resp = client.post(
+        "/_api/create-league",
+        data={"league_name": "League", "league_url": "/league-slug"},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["success"] is False
+    assert "letters, numbers, or -_~." in body["error"]
+    assert League.query.get("/league-slug") is None
+    assert League.query.get("league-slug") is None

--- a/tests/unit/test_string_length_validation.py
+++ b/tests/unit/test_string_length_validation.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import pytest
 
 from app.exceptions import ValidationError
-from models import Player
+from models import League, Player, TO
 
 
 @pytest.mark.unit
@@ -100,3 +100,25 @@ def test_every_mapped_string_column_rejects_overflow(test_db):
             checked.append((cls.__name__, field, n))
 
     assert len(checked) >= 80, f"expected coverage sweep to hit many columns, got {checked!r}"
+
+
+@pytest.mark.unit
+def test_league_url_rejects_invalid_slug_characters(test_db):
+    """League.url rejects characters outside the shared slug allowlist."""
+    league = League()
+    with pytest.raises(ValidationError) as exc:
+        league.url = "/league-slug"
+    assert "url" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_event_and_league_fk_slugs_reject_invalid_characters(test_db):
+    """Foreign-key slug mirrors use the same validator as the primary slug fields."""
+    to_entry = TO()
+    with pytest.raises(ValidationError) as exc:
+        to_entry.event = "/event-slug"
+    assert "event" in str(exc.value)
+
+    with pytest.raises(ValidationError) as exc:
+        to_entry.league_id = "/league-slug"
+    assert "league_id" in str(exc.value)


### PR DESCRIPTION
im too lazy to write an issue but a user tried to register a tournament with a url that started with a `/`, which caused a bunch of problems. 
probably should update the explanation text to not have an example that starts with a slash, but the validation definitely needs to happen either way.