### PR TITLE
remove `EXTERNAL_BASE_URL`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ S3_ENDPOINT_URL=https://s3.us-east-005.backblazeb2.com
 AWS_REGION=us-east-005
 AWS_ACCESS_KEY_ID="[25 char censored string]"
 AWS_SECRET_ACCESS_KEY="[31 char censored string]"
-EXTERNAL_BASE_URL=https://events.californiajugger.org
 YOUTUBE_API_KEY="[39 char censored string]"
 GOOGLE_CLIENT_SECRET="[35 char censored string]"
 GOOGLE_CLIENT_ID="[45 char censored string].apps.googleusercontent.com"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ make certs
 ```bash
 ARCTOS_CORS_DEV=1
 ARCTOS_API_BASE=http://127.0.0.1:8081
-EXTERNAL_BASE_URL=your_public_domain_or_ip
 YOUTUBE_API_KEY=your_youtube_api_key
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 GOOGLE_CLIENT_ID=your_google_client_id
@@ -140,7 +139,7 @@ python -c "import os; print(os.urandom(12).hex())"
 > traffic and are thus hosting the frontend and backend on different
 > ports.
 
-4. Start the app:
+1. Start the app:
 
 ```bash
 make run

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -116,11 +116,6 @@ def create_app(config: dict | None = None) -> Flask:
     app.config["GOOGLE_CLIENT_ID"] = os.environ.get("GOOGLE_CLIENT_ID", "")
     app.config["GOOGLE_CLIENT_SECRET"] = os.environ.get("GOOGLE_CLIENT_SECRET", "")
 
-    # Public base URL for OAuth and redirects (e.g. https://example.com). When set, used for
-    # Google redirect_uri and post-login redirects so they work behind proxies and match
-    # the authorized redirect URI in Google Cloud Console. No trailing slash.
-    app.config["EXTERNAL_BASE_URL"] = os.environ.get("EXTERNAL_BASE_URL", "").rstrip("/")
-
     # S3 video storage: when S3_VIDEO_BUCKET is set, finalization uploads finished videos to S3.
     app.config["S3_VIDEO_BUCKET"] = os.environ.get("S3_VIDEO_BUCKET", "").strip() or None
     app.config["S3_ENDPOINT_URL"] = os.environ.get("S3_ENDPOINT_URL", "").strip() or None

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -3,8 +3,6 @@ Authentication routes: logout, check-username, Google OAuth (login + callback on
 Login and register are handled by the SPA and _api.
 """
 
-import os
-
 from flask import (
     Blueprint,
     request,
@@ -12,7 +10,6 @@ from flask import (
     flash,
     jsonify,
     session,
-    current_app,
     url_for,
 )
 from flask_login import login_user, logout_user, login_required
@@ -28,25 +25,16 @@ oauth = OAuth()
 _SPA_BASE = "/"
 
 
-def _frontend_base() -> str | None:
-    """Return the configured external frontend base URL without a trailing slash.
+def _frontend_path(path: str = "") -> str:
+    """Return a same-host frontend path, preserving any deployment subpath."""
 
-    Reads ``EXTERNAL_BASE_URL`` from the Flask application config.
-
-    Returns:
-        The stripped base URL, or ``None`` if not configured.
-    """
-    base = current_app.config.get("EXTERNAL_BASE_URL", "").strip()
-    if base:
-        return base.rstrip("/")
-    return None
+    base = request.script_root.rstrip("/") or _SPA_BASE.rstrip("/")
+    suffix = f"/{path.lstrip('/')}" if path else ""
+    return f"{base}{suffix}" or _SPA_BASE
 
 
 def _redirect_to_frontend(path: str = ""):
     """Build a Flask redirect response targeting the frontend SPA.
-
-    When ``EXTERNAL_BASE_URL`` is configured the redirect points there;
-    otherwise it falls back to the SPA base path (``/``).
 
     Args:
         path: Frontend path to append, should begin with ``/``
@@ -55,27 +43,20 @@ def _redirect_to_frontend(path: str = ""):
     Returns:
         A Flask :func:`~flask.redirect` response.
     """
-    base = _frontend_base()
-    if base:
-        return redirect(f"{base}{path}" if path.startswith("/") else f"{base}/{path}")
-    return redirect(_SPA_BASE + path.lstrip("/") if path else _SPA_BASE)
+    return redirect(_frontend_path(path))
 
 
 def _google_callback_uri() -> str:
     """Return the Google OAuth callback URI registered in Google Cloud Console.
 
-    Prefers an externally configured base URL so that the URI matches
-    exactly what was registered; falls back to Flask's ``url_for``
-    generation.
+    The callback host/scheme is derived from the current request so the same
+    server can answer on multiple public domains, provided each callback URI
+    is authorized in Google Cloud Console.
 
     Returns:
         Absolute callback URL string.
     """
-    base = _frontend_base()
-    if base:
-        script = os.environ.get("SCRIPT_NAME", "").rstrip("/")
-        return f"{base}{script}/_api/auth/google/callback"
-    return url_for("auth.google_callback", _external=True)
+    return f"{request.url_root.rstrip('/')}{url_for('auth.google_callback')}"
 
 
 @bp.route("/check-username", methods=["GET"])

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -13,10 +13,6 @@ configure Arctos.
 `ARCTOS_PORT`
 : (default `5006`) port to run the backend on. 
 
-`EXTERNAL_BASE_URL`
-: url of the root, accessible from the internet. used for the oauth
-redirect url.
-
 `SQLALCHEMY_DATABASE_URI`
 : fairly self explanatory. URI to db.
 
@@ -49,6 +45,11 @@ go to google cloud console for these
 
 `GOOGLE_CLIENT_SECRET`
 : client secret.
+
+Google OAuth callback URLs are derived from the incoming request host. If the
+same server is reachable on multiple public domains, add each domain's
+`/_api/auth/google/callback` URL to the authorized redirect URIs in Google
+Cloud Console.
 
 
 ## S3 Bucket Config

--- a/frontend/src/pages/layout.rs
+++ b/frontend/src/pages/layout.rs
@@ -283,7 +283,7 @@ pub fn Layout() -> Element {
                     " - "
                     Link { to: Route::Terms {}, "Terms" }
                 }
-                p { style: "font-size: 0.8em;", "Arctos is an independent project and does not belong to nor represent CAJA in any way." }
+                p { style: "font-size: 0.8em;", "Arctos is an independent project and does not belong to nor represent CAJA or the US NJA in any way." }
             }
         }
     }

--- a/tests/unit/test_auth_urls.py
+++ b/tests/unit/test_auth_urls.py
@@ -1,0 +1,24 @@
+"""Unit tests for auth redirect and callback URL helpers."""
+
+import pytest
+
+
+@pytest.mark.unit
+def test_google_callback_uri_uses_request_host(app, test_db):
+    from app.routes.auth import _google_callback_uri
+
+    with app.test_request_context("/_api/auth/google/login", base_url="https://events-a.example"):
+        assert _google_callback_uri() == "https://events-a.example/_api/auth/google/callback"
+
+
+@pytest.mark.unit
+def test_redirect_to_frontend_preserves_script_root(app, test_db):
+    from app.routes.auth import _redirect_to_frontend
+
+    with app.test_request_context(
+        "/_api/auth/google/callback",
+        base_url="https://events-b.example",
+        environ_overrides={"SCRIPT_NAME": "/arctos"},
+    ):
+        response = _redirect_to_frontend("/auth/google/choose-account-type")
+        assert response.location == "/arctos/auth/google/choose-account-type"


### PR DESCRIPTION
this way it's all based on the path of the request, which should allow us to host simultaneously on both `events.californiajugger.org` (for backwards compatability) and `arctos.usnja.org`.

also updated the footer

closes #152 