### PR TITLE
Fix league side-comp registration

### DIFF
--- a/app/routes/sidecomps.py
+++ b/app/routes/sidecomps.py
@@ -50,18 +50,11 @@ def _detail_payload(sc, registrants):
     viewer_can_register = False
     viewer_is_registered_in_comp = False
     if current_user.is_authenticated:
-        from app.domain.enums import RegistrationStatus
-        from models import PlayerRegistration
-
         viewer_is_to = PermissionService.is_tournament_organizer(sc.event, current_user)
         if is_player(current_user):
             viewer_is_registered_in_comp = any(reg.player == current_user.id for reg, _ in registrants)
             if not viewer_is_registered_in_comp and sc.registration_open:
-                event_reg = PlayerRegistration.query.filter_by(
-                    event=sc.event,
-                    player=current_user.id,
-                    status=RegistrationStatus.CONFIRMED,
-                ).first()
+                event_reg = SideCompService._confirmed_player_registration_for_tournament(sc.event, current_user.id)
                 viewer_can_register = event_reg is not None
 
     return {

--- a/app/services/sidecomp_service.py
+++ b/app/services/sidecomp_service.py
@@ -113,6 +113,22 @@ class SideCompService:
         return Ok(None)
 
     @staticmethod
+    def _confirmed_player_registration_for_tournament(tournament_url: str, player_id: str):
+        from app.domain.enums import RegistrationStatus
+        from app.services.registration_resolver import player_registrations_for_tournament
+        from models import Tournament
+
+        tournament = Tournament.query.get(tournament_url)
+        if tournament is None:
+            return None
+
+        registrations = player_registrations_for_tournament(tournament, statuses=[RegistrationStatus.CONFIRMED])
+        for registration in registrations:
+            if registration.player == player_id:
+                return registration
+        return None
+
+    @staticmethod
     @allow_Q
     def create(
         tournament_url: str,
@@ -327,9 +343,7 @@ class SideCompService:
             found, player not registered for the parent event, or duplicate
             registration).
         """
-        from app.domain.enums import RegistrationStatus
         from models import (
-            PlayerRegistration,
             SideComp,
             SideCompRegistration,
         )
@@ -341,11 +355,7 @@ class SideCompService:
         if not sc.registration_open:
             return Err(RegistrationClosedError("This side competition is not open for registration"))
 
-        event_reg = PlayerRegistration.query.filter_by(
-            event=sc.event,
-            player=player_id,
-            status=RegistrationStatus.CONFIRMED,
-        ).first()
+        event_reg = SideCompService._confirmed_player_registration_for_tournament(sc.event, player_id)
         if not event_reg:
             return Err(ValidationError("You must be registered for the event before joining a side competition"))
 
@@ -389,10 +399,8 @@ class SideCompService:
             found, actor not a TO, target player not found, target not
             registered for the parent event, or duplicate registration).
         """
-        from app.domain.enums import RegistrationStatus
         from models import (
             Player,
-            PlayerRegistration,
             SideComp,
             SideCompRegistration,
         )
@@ -407,11 +415,7 @@ class SideCompService:
         if target is None:
             return Err(ValidationError("Player not found"))
 
-        event_reg = PlayerRegistration.query.filter_by(
-            event=sc.event,
-            player=player_id,
-            status=RegistrationStatus.CONFIRMED,
-        ).first()
+        event_reg = SideCompService._confirmed_player_registration_for_tournament(sc.event, player_id)
         if not event_reg:
             return Err(ValidationError("Player is not registered for this event"))
 

--- a/tests/test_sidecomps.py
+++ b/tests/test_sidecomps.py
@@ -40,6 +40,70 @@ def _confirm_event_registration(tournament_url, player_id, team_id=None):
     return reg
 
 
+def _make_league_sidecomp_context(registration_open=False):
+    from datetime import datetime, timedelta, timezone
+
+    from app.domain.enums import TeamRegistrationStatus
+    from models import League, Team, TeamRegistration, Tournament
+    from tests.utils import make_registrable_config
+
+    cfg = make_registrable_config(team_registration_open=True, player_registration_open=True)
+    league = League(url="lg", name="LG", registrable_config_id=cfg.id)
+    db.session.add(league)
+    db.session.flush()
+
+    tournament = Tournament(
+        url="lg-evt",
+        name="League Event",
+        start_date=datetime.now(timezone.utc),
+        end_date=datetime.now(timezone.utc) + timedelta(days=1),
+        league_id=league.url,
+    )
+    db.session.add(tournament)
+    db.session.flush()
+
+    to_user = _make_player("lg_to", "LG TO")
+    db.session.add(TO(user_id=to_user.id, user_type="player", event=None, league_id=league.url))
+
+    team = Team(id="lg_team", name="LG Team", pw_hash="dummy_hash")
+    db.session.add(team)
+    db.session.flush()
+    db.session.add(
+        TeamRegistration(
+            event=None,
+            league_id=league.url,
+            team=team.id,
+            pseudonym="LG Pseudonym",
+            status=TeamRegistrationStatus.CONFIRMED,
+        )
+    )
+
+    player = _make_player("lg_p1", "LG P1")
+    db.session.add(
+        PlayerRegistration(
+            event=None,
+            league_id=league.url,
+            player=player.id,
+            team=team.id,
+            jersey_number="7",
+            jersey_name="P1",
+            status=RegistrationStatus.CONFIRMED,
+            paid=True,
+        )
+    )
+
+    sidecomp = SideComp(event=tournament.url, name="LG SC", type="DUELING", registration_open=registration_open)
+    db.session.add(sidecomp)
+    db.session.commit()
+
+    return {
+        "tournament": tournament,
+        "to_user": to_user,
+        "player": player,
+        "sidecomp": sidecomp,
+    }
+
+
 def test_sidecomp_has_created_at(test_db, tournament):
     sc = SideComp(event=tournament.url, name="Dueling 1v1", type="DUELING")
     db.session.add(sc)
@@ -275,6 +339,20 @@ def test_register_player_succeeds_when_event_registered(test_db, tournament):
     assert reg.registered_by_to is False
 
 
+def test_register_player_succeeds_with_league_scoped_registration(test_db):
+    ctx = _make_league_sidecomp_context(registration_open=True)
+
+    from app.services.sidecomp_service import SideCompService
+
+    res = SideCompService.register_player(ctx["sidecomp"].id, player_id=ctx["player"].id)
+
+    assert isinstance(res, Ok)
+    reg = res.unwrap()
+    assert reg.comp == ctx["sidecomp"].id
+    assert reg.player == ctx["player"].id
+    assert reg.registered_by_to is False
+
+
 def test_register_player_no_event_registration(test_db, tournament):
     p = _make_player()
     sc = SideComp(event=tournament.url, name="A", type="DUELING", registration_open=True)
@@ -380,6 +458,25 @@ def test_register_player_as_to_succeeds(test_db, tournament):
     )
     assert isinstance(res, Ok)
     reg = res.unwrap()
+    assert reg.registered_by_to is True
+
+
+def test_register_player_as_to_succeeds_with_league_scoped_registration(test_db):
+    ctx = _make_league_sidecomp_context()
+
+    from app.services.sidecomp_service import SideCompService
+
+    res = SideCompService.register_player_as_to(
+        ctx["sidecomp"].id,
+        actor_user_id=ctx["to_user"].id,
+        actor_user_type="player",
+        player_id=ctx["player"].id,
+    )
+
+    assert isinstance(res, Ok)
+    reg = res.unwrap()
+    assert reg.comp == ctx["sidecomp"].id
+    assert reg.player == ctx["player"].id
     assert reg.registered_by_to is True
 
 
@@ -830,6 +927,20 @@ def test_route_detail_viewer_flags_already_registered(app, client, tournament):
     payload = resp.get_json()
     assert payload["viewer_can_register"] is False
     assert payload["viewer_is_registered_in_comp"] is True
+
+
+def test_route_detail_viewer_can_register_with_league_scoped_registration(app, client, test_db):
+    with app.app_context():
+        ctx = _make_league_sidecomp_context(registration_open=True)
+        comp_id = ctx["sidecomp"].id
+        login_as(client, ctx["player"])
+
+    resp = client.get(f"/_api/sidecomps/{comp_id}")
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["viewer_can_register"] is True
+    assert payload["viewer_is_registered_in_comp"] is False
 
 
 def test_route_detail_viewer_flags_to(app, client, tournament):


### PR DESCRIPTION
Follow-up to #179.

This fixes side-comp registration for league-backed tournaments. The previous lookup only treated a player as registered when their PlayerRegistration event matched the side-comp event directly, which breaks league-scoped registrations. The side-comp service now resolves eligibility through the tournament event and league scope, so player self-registration, TO registration, and the detail-page viewer_can_register flag all use the same rule.

System impact: limited to side-comp eligibility and registration checks. No migration needed.

Tested:
tests/test_sidecomps.py::test_register_player_succeeds_with_league_scoped_registration tests/test_sidecomps.py::test_register_player_as_to_succeeds_with_league_scoped_registration tests/test_sidecomps.py::test_route_detail_viewer_can_register_with_league_scoped_registration tests/test_sidecomps.py::test_route_eligible_players_returns_league_scoped_registrations

