### PR TITLE
Show quick-register status in search results

### DIFF
--- a/app/routes/sidecomps.py
+++ b/app/routes/sidecomps.py
@@ -247,7 +247,7 @@ def deregister_player_as_to(comp_id: int):
 @bp.route("/sidecomps/<int:comp_id>/eligible-players", methods=["GET"])
 @login_required
 def eligible_players(comp_id: int):
-    """TO-only: list players registered for the event but not yet in this side comp."""
+    """TO-only: list event-registered players with side competition status."""
     from app.domain.enums import RegistrationStatus
     from app.services.registration_resolver import (
         player_registrations_for_tournament,
@@ -270,13 +270,12 @@ def eligible_players(comp_id: int):
 
     tournament = Tournament.query.get(sc.event)
 
-    already_in = {r.player for r in SideCompRegistration.query.filter_by(comp=comp_id).all()}
+    sidecomp_regs = {r.player: r for r in SideCompRegistration.query.filter_by(comp=comp_id).all()}
 
     event_regs = player_registrations_for_tournament(tournament, statuses=[RegistrationStatus.CONFIRMED])
 
-    eligible = [er for er in event_regs if er.player not in already_in]
-    player_ids = [er.player for er in eligible]
-    team_ids = {er.team for er in eligible if er.team}
+    player_ids = [er.player for er in event_regs]
+    team_ids = {er.team for er in event_regs if er.team}
 
     players_by_id = {p.id: p for p in Player.query.filter(Player.id.in_(player_ids)).all()} if player_ids else {}
     team_pseudonyms = (
@@ -292,7 +291,9 @@ def eligible_players(comp_id: int):
             "team_id": er.team,
             "team_pseudonym": team_pseudonyms.get(er.team) if er.team else None,
             "jersey_name": er.jersey_name,
+            "sidecomp_registered": er.player in sidecomp_regs,
+            "entry_number": sidecomp_regs[er.player].entry_number if er.player in sidecomp_regs else None,
         }
-        for er in eligible
+        for er in event_regs
     ]
     return jsonify(out)

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -3615,7 +3615,10 @@ pub async fn sidecomp_deregister(comp_id: i32) -> Result<Value, String> {
     response_json(r).await
 }
 
-pub async fn sidecomp_to_register_player_as_to(comp_id: i32, player_id: &str) -> Result<Value, String> {
+pub async fn sidecomp_to_register_player_as_to(
+    comp_id: i32,
+    player_id: &str,
+) -> Result<SideCompRegisterPlayerResponse, String> {
     let c = client();
     let body = serde_json::json!({"player_id": player_id});
     let r = with_credentials(

--- a/frontend/src/pages/sidecomp_register_as_to.rs
+++ b/frontend/src/pages/sidecomp_register_as_to.rs
@@ -1,19 +1,12 @@
 use crate::api;
-use crate::types::EligiblePlayer;
+use crate::types::{EligiblePlayer, SideCompRegisterPlayerResponse};
 use crate::Route;
 use dioxus::prelude::*;
-
-#[derive(Clone, Debug, PartialEq)]
-struct LogEntry {
-    player_id: String,
-    player_name: String,
-}
 
 #[component]
 pub fn SideCompRegisterAsTo(url: String, comp_id: i32) -> Element {
     let mut eligible = use_signal(Vec::<EligiblePlayer>::new);
     let mut filter = use_signal(String::new);
-    let mut session_log = use_signal(Vec::<LogEntry>::new);
     let mut error = use_signal(|| None::<String>);
 
     use_effect(move || {
@@ -54,7 +47,7 @@ pub fn SideCompRegisterAsTo(url: String, comp_id: i32) -> Element {
                         .collect();
                     rsx! {
                         if rows.is_empty() {
-                            p { class: "text-muted", "No eligible players found." }
+                            p { class: "text-muted", "No players found." }
                         } else {
                             ul { class: "list-group mb-4",
                                 for p in rows.iter().cloned() {
@@ -62,25 +55,17 @@ pub fn SideCompRegisterAsTo(url: String, comp_id: i32) -> Element {
                                         key: "{p.player_id}",
                                         p: p.clone(),
                                         comp_id,
-                                        on_registered: move |entry: LogEntry| {
-                                            let pid = entry.player_id.clone();
-                                            session_log.write().insert(0, entry);
-                                            eligible.write().retain(|x| x.player_id != pid);
+                                        on_registered: move |registered: SideCompRegisterPlayerResponse| {
+                                            let player_id = registered.player_id.clone();
+                                            if let Some(row) = eligible.write().iter_mut().find(|x| x.player_id == player_id) {
+                                                row.sidecomp_registered = true;
+                                                row.entry_number = Some(registered.entry_number);
+                                            }
                                         },
                                         on_error: move |e| error.set(Some(e)),
                                     }
                                 }
                             }
-                        }
-                    }
-                }
-                h2 { "Session log ({session_log().len()})" }
-                if session_log().is_empty() {
-                    p { class: "text-muted", "No one registered yet." }
-                } else {
-                    ul { class: "list-group",
-                        for entry in session_log().iter() {
-                            li { class: "list-group-item", "{entry.player_name} (registered)" }
                         }
                     }
                 }
@@ -93,7 +78,7 @@ pub fn SideCompRegisterAsTo(url: String, comp_id: i32) -> Element {
 fn EligibleRow(
     p: EligiblePlayer,
     comp_id: i32,
-    on_registered: EventHandler<LogEntry>,
+    on_registered: EventHandler<SideCompRegisterPlayerResponse>,
     on_error: EventHandler<String>,
 ) -> Element {
     let mut busy = use_signal(|| false);
@@ -108,22 +93,32 @@ fn EligibleRow(
                     span { class: "text-muted ms-2", "({team})" }
                 }
             }
-            button {
-                class: "btn btn-sm btn-primary",
-                disabled: busy(),
-                onclick: move |_| {
-                    let pid = p_click.player_id.clone();
-                    let pname = p_click.player_name.clone();
-                    busy.set(true);
-                    spawn(async move {
-                        match api::sidecomp_to_register_player_as_to(comp_id, &pid).await {
-                            Ok(_) => on_registered.call(LogEntry { player_id: pid, player_name: pname }),
-                            Err(e) => on_error.call(e),
-                        }
-                        busy.set(false);
-                    });
-                },
-                if busy() { "Registering..." } else { "Quick Register" }
+            if p_render.sidecomp_registered {
+                span {
+                    class: "badge bg-success",
+                    if let Some(entry_number) = p_render.entry_number {
+                        "Registered #{entry_number}"
+                    } else {
+                        "Registered"
+                    }
+                }
+            } else {
+                button {
+                    class: "btn btn-sm btn-primary",
+                    disabled: busy(),
+                    onclick: move |_| {
+                        let pid = p_click.player_id.clone();
+                        busy.set(true);
+                        spawn(async move {
+                            match api::sidecomp_to_register_player_as_to(comp_id, &pid).await {
+                                Ok(registered) => on_registered.call(registered),
+                                Err(e) => on_error.call(e),
+                            }
+                            busy.set(false);
+                        });
+                    },
+                    if busy() { "Registering..." } else { "Quick Register" }
+                }
             }
         }
     }

--- a/frontend/src/types.rs
+++ b/frontend/src/types.rs
@@ -1396,4 +1396,15 @@ pub struct EligiblePlayer {
     pub team_id: Option<String>,
     pub team_pseudonym: Option<String>,
     pub jersey_name: Option<String>,
+    #[serde(default)]
+    pub sidecomp_registered: bool,
+    pub entry_number: Option<i32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SideCompRegisterPlayerResponse {
+    pub player_id: String,
+    pub player_name: String,
+    pub entry_number: i32,
+    pub registered_at: Option<String>,
 }

--- a/tests/test_sidecomps.py
+++ b/tests/test_sidecomps.py
@@ -1089,7 +1089,7 @@ def test_delete_tournament_cascades_sidecomp_registrations(app, client, tourname
         assert SideCompRegistration.query.filter_by(comp=comp_id).count() == 0
 
 
-def test_route_eligible_players_excludes_already_registered(app, client, tournament):
+def test_route_eligible_players_marks_sidecomp_registered_players(app, client, tournament):
     with app.app_context():
         to_user = _make_player("to_user", "TO User")
         _make_to(tournament.url, to_user.id)
@@ -1107,9 +1107,12 @@ def test_route_eligible_players_excludes_already_registered(app, client, tournam
 
     resp = client.get(f"/_api/sidecomps/{comp_id}/eligible-players")
     assert resp.status_code == 200
-    ids = {row["player_id"] for row in resp.get_json()}
-    assert "p2" in ids
-    assert "p1" not in ids
+    rows_by_id = {row["player_id"]: row for row in resp.get_json()}
+    assert set(rows_by_id) == {"p1", "p2"}
+    assert rows_by_id["p1"]["sidecomp_registered"] is True
+    assert rows_by_id["p1"]["entry_number"] == 1
+    assert rows_by_id["p2"]["sidecomp_registered"] is False
+    assert rows_by_id["p2"]["entry_number"] is None
 
 
 def test_route_eligible_players_returns_league_scoped_registrations(app, client, test_db):


### PR DESCRIPTION
Follow-up to #179.

This changes the TO quick-register flow so search results still show players who are already in the side comp. Those rows now show a registered badge and entry number, including immediately after a successful register action, so the page no longer needs a separate session log.

System impact: the eligible-players response now includes sidecomp_registered and entry_number. Existing consumers can ignore those fields. No migration needed.

Tested:
tests/test_sidecomps.py::test_route_eligible_players_marks_sidecomp_registered_players tests/test_sidecomps.py::test_route_eligible_players_returns_league_scoped_registrations
