### PR TITLE
[Feature] Coverage config, quieter test logs, package-init docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ __pycache__/
 .pytest_cache/
 *.py[cod]
 
+# coverage output
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
 # secrets
 .env
 run

--- a/README.md
+++ b/README.md
@@ -192,12 +192,18 @@ output files to somewhere that your reverse proxy can serve.
 | Goal | Command |
 |------|---------|
 | Run all tests | `make test` |
+| Run with coverage | `uv run pytest tests/ --cov=app --cov-report=term-missing` |
 | Lint | `make lint` |
 | Format | `make format` |
 | Apply migrations | `make db-backup && make db-migrate` |
 | Generate a migration | `make db-revision MSG="snake_case_message"` |
 | Start dev backend | `make dev` (HTTP, :5006) or `make run` (TLS, :8081) |
 | Start dev frontend | `make frontend` |
+
+Coverage is configured under `[tool.coverage.*]` in `pyproject.toml`
+with a soft `fail_under = 30` floor; current actual is around 33% with
+branch coverage on. See [`TESTING.md`](TESTING.md#coverage) for the
+HTML report path and how the threshold is meant to move.
 
 ## Conventions
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -28,9 +28,32 @@ Useful flags:
 
 ```bash
 uv run pytest tests/ -k "registration"   # filter by name
-uv run pytest tests/ --cov=app           # coverage report
 uv run pytest tests/ --tb=long           # full tracebacks
 ```
+
+## Coverage
+
+Run the suite with coverage:
+
+```bash
+uv run pytest tests/ --cov=app --cov-report=term-missing
+```
+
+Generate an HTML report (lands in `htmlcov/`, gitignored):
+
+```bash
+uv run pytest tests/ --cov=app --cov-report=html
+open htmlcov/index.html                  # or xdg-open on Linux
+```
+
+Coverage settings live under `[tool.coverage.*]` in `pyproject.toml`:
+
+- **Source** is `app/` (tests, scripts, and migrations are not measured).
+- **Branch coverage** is on, so untested `else` branches count as misses.
+- **`fail_under = 30`** is a soft floor that catches significant
+  regressions without blocking small fluctuations. Current actual
+  coverage is around 33% (with branch coverage on); raise the floor
+  when overall coverage grows.
 
 ## Structure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,12 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "--verbose --tb=short --strict-markers --numprocesses=auto --color=yes --capture=no"
+# Console logging stays at WARNING so a normal test run isn't flooded with
+# app INFO messages. Bump to INFO/DEBUG on the CLI with
+# `--log-cli-level=DEBUG` when investigating a failure. The on-disk
+# pytest.log keeps INFO so post-hoc inspection is still possible.
 log_cli = true
-log_cli_level = "INFO"
+log_cli_level = "WARNING"
 log_format = "[%(name)s][%(asctime)s] %(levelname)s: %(message)s (%(filename)s:%(lineno)d)"
 log_date_format = "%Y-%m-%d %H:%M:%S"
 log_file_level = "INFO"
@@ -66,6 +70,33 @@ markers = [
     "integration: Integration tests",
     "slow: Slow running tests",
 ]
+
+[tool.coverage.run]
+source = ["app"]
+branch = true
+omit = [
+    "*/__pycache__/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+precision = 1
+# Soft floor. Current actual is ~33% with branch coverage on; this gate
+# catches significant regressions without blocking small fluctuations.
+# Bump it when coverage rises.
+fail_under = 30
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+    "@(abc\\.)?abstractmethod",
+    "\\.\\.\\.",
+]
+
+[tool.coverage.html]
+directory = "htmlcov"
 
 [tool.mypy]
 python_version = "3.12"

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,9 +11,13 @@ make test          # everything
 make unit          # unit tests only (-m unit)
 make integration   # integration tests only (-m integration)
 
-uv run pytest tests/ -k "registration"   # by name
-uv run pytest tests/ --cov=app           # coverage
+uv run pytest tests/ -k "registration"                          # by name
+uv run pytest tests/ --cov=app --cov-report=term-missing        # coverage
+uv run pytest tests/ --cov=app --cov-report=html                # HTML report → htmlcov/
 ```
+
+See [`TESTING.md`](../TESTING.md#coverage) for the coverage threshold
+and what's configured under `[tool.coverage.*]` in `pyproject.toml`.
 
 ## Layout
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,3 +1,6 @@
-"""
-Integration tests (exercise routes/services through the app/test client).
+"""Integration tests (exercise routes/services through the app/test client).
+
+This file is intentionally minimal: its job is to make ``tests/integration/``
+a Python package so test modules elsewhere can ``from tests.utils import …``
+without sys.path gymnastics. Do not delete.
 """

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,3 +1,6 @@
-"""
-Unit tests (fast, narrow scope).
+"""Unit tests (fast, narrow scope).
+
+This file is intentionally minimal: its job is to make ``tests/unit/`` a
+Python package so test modules elsewhere can ``from tests.utils import …``
+without sys.path gymnastics. Do not delete.
 """


### PR DESCRIPTION
## Summary

Wires up `pytest-cov` properly. Adds coverage configuration to `pyproject.toml`, sets a soft regression floor, quiets the test-runner's INFO firehose, and documents what's now possible.

## What changed

- **`pyproject.toml`** gains `[tool.coverage.run]` and `[tool.coverage.report]`.
  - `source = ["app"]`. Tests, scripts, and migrations stay unmeasured.
  - `branch = true` so untested `else` paths show up as misses.
  - `exclude_lines` covers the usual `TYPE_CHECKING` / `abstractmethod` / `pragma: no cover` / `...` patterns.
  - `fail_under = 30`. Current actual is 33.3% on 343 passing tests, so this catches significant regressions without blocking small fluctuations.
  - HTML output goes to `htmlcov/`.
- **`log_cli_level`** drops from `INFO` to `WARNING`. INFO/DEBUG is still available with `--log-cli-level=DEBUG` on the CLI; the on-disk `pytest.log` keeps INFO for post-hoc inspection.
- **`tests/unit/__init__.py` and `tests/integration/__init__.py`** get a docstring explaining that they're package markers needed for `from tests.utils import …`. A future cleanup pass shouldn't delete them.
- **`.gitignore`** ignores `.coverage`, `.coverage.*`, `htmlcov/`, and `coverage.xml`.
- **`TESTING.md`** gains a Coverage section with the commands and the threshold story.
- **`tests/README.md`** picks up the `--cov-report=html` invocation and a link to the new section.
- **`README.md`** gets a "Run with coverage" row in the daily-commands table and a short paragraph explaining the floor.

## Migration impact

None for the database. For contributors: `make test` (or `uv run pytest tests/`) behaves the same as before. Coverage runs are opt-in via `--cov=app`. The console log level dropping to WARNING is the only behaviour change a normal test run will notice; bumping it back up is a one-flag override.

## Test plan

Ran locally:

```
$ uv run pytest tests/ --cov=app --cov-report=term -n 0
...
TOTAL                                            12313   7646   5094    474  33.3%
Required test coverage of 30.0% reached. Total coverage: 33.30%
343 passed, 295 warnings in 51.74s
```

- 343 tests pass.
- Coverage threshold passes at 33.3% against the 30% floor.
- Branch coverage is reflected in the report (the 4th column).
- Ran with `-n 0` to keep output readable; the `--numprocesses=auto` default still works for full parallel runs.

- [x] `make test` passes locally
- [x] Manual verification:
  - Coverage run hits the 30% floor and reports the expected term output.
  - HTML report generates into `htmlcov/`.
  - `--log-cli-level=DEBUG` override still works.

## Linked issues

None.

## Screenshots / repro

```
$ uv run pytest tests/ --cov=app --cov-report=html -n 0
$ ls htmlcov/ | head
class_index.html
coverage_html_cb_6fb7b396.js
favicon_32_cb_58284776.png
function_index.html
index.html
keybd_closed_cb_ce680311.png
status.json
style_cb_8e611ae1.css
```

---

### Pre-review checklist

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [x] Targeting `dev`, not `main` (unless this is a release PR).
- [x] `make lint` and `make format` are clean.
- [x] ~~Tests added or updated for the new behavior.~~ (config and docs only; no application logic touched)
- [x] ~~If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated (per `CLAUDE.md`).~~ (no new modules)
- [x] If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.
- [x] No merge conflicts with the base branch.
