### PR TITLE
[Feature] improved ass entry box UI

### DIFF
--- a/app/routes/tournaments.py
+++ b/app/routes/tournaments.py
@@ -2867,11 +2867,11 @@ def validate_dsl(tournament_url):
         # Serialize the full value for JSON response
         serialized_value = serialize_value(result)
 
-        # Create string representation
-        simplified_str = value_to_string(result)
-
-        # Only include simplified if it's different from the input
-        simplified = simplified_str if simplified_str != expression else None
+        # Create string representation. We always send it back so the frontend can render
+        # the simplified form (with chips). Suppressing on equality hid useful previews
+        # for expressions whose literal text already happens to be in canonical form
+        # (e.g. anything containing an unset [tag::Foo] that stays symbolic).
+        simplified = value_to_string(result)
 
         # Treat unresolvable team/match references as errors so the user notices typos.
         if warnings:

--- a/app/routes/tournaments.py
+++ b/app/routes/tournaments.py
@@ -2861,6 +2861,7 @@ def validate_dsl(tournament_url):
 
     try:
         parser = get_parser(tournament_url)
+        warnings = parser.static_check(expression)
         result = parser.parse(expression)
 
         # Serialize the full value for JSON response
@@ -2872,12 +2873,25 @@ def validate_dsl(tournament_url):
         # Only include simplified if it's different from the input
         simplified = simplified_str if simplified_str != expression else None
 
+        # Treat unresolvable team/match references as errors so the user notices typos.
+        if warnings:
+            return jsonify(
+                {
+                    "valid": False,
+                    "value": None,
+                    "simplified": None,
+                    "error": "; ".join(warnings),
+                    "warnings": warnings,
+                }
+            )
+
         return jsonify(
             {
                 "valid": True,
                 "value": serialized_value,
                 "simplified": simplified,
                 "error": None,
+                "warnings": [],
             }
         )
     except DSLValidationError as e:

--- a/app/utils/parser.py
+++ b/app/utils/parser.py
@@ -232,13 +232,18 @@ def parse_team_literal(literal: str, event: str):
             return Match(match_obj, event).loser()
         elif match_name == "tag":
             tag = Tag.query.filter_by(name=qualifier, event=event).first()
-            if not tag or not tag.team:
-                # Return symbolic team if tag doesn't exist or isn't set
+            if not tag:
+                known = [t.name for t in Tag.query.filter_by(event=event).all()]
+                suggestion = _suggest_function(qualifier, known)
+                hint = f" Did you mean 'tag::{suggestion}'?" if suggestion else ""
+                raise DSLValidationError(f"Tag '{qualifier}' does not exist.{hint}")
+            if not tag.team:
+                # Tag exists but its team isn't assigned yet — stay symbolic.
                 return SymbolicTeam(literal, event)
             team_obj = TeamDB.query.filter_by(id=tag.team).first()
             if team_obj:
                 return Team(team_obj, event)
-            # Team not found, return symbolic
+            # Tag's team id refers to a deleted team — stay symbolic.
             return SymbolicTeam(literal, event)
         else:
             raise DSLValidationError(f"Invalid team literal: {literal}")
@@ -1229,23 +1234,52 @@ def _collect_literals(text: str):
 
 
 def _check_references(text: str, event: str) -> list[str]:
-    """Return a list of warnings about unresolvable team/match references.
+    """Return a list of warnings about unresolvable team/match/tag references.
 
-    Skips MatchName::winner / MatchName::loser / tag::Foo (those legitimately
-    resolve symbolically). Plain team ids and match names should map to existing
-    rows; if not, we tell the user.
+    A `[name]` literal must resolve to:
+      - a team id, or
+      - a `tag::TagName` for a Tag that exists in this event, or
+      - `MatchName::winner` / `MatchName::loser` for a match that exists.
+    A `{name}` literal must name a match in this event.
+    Anything that doesn't match these rules gets a warning; symbolic references
+    that legitimately can't be resolved yet (e.g. an unset tag's team) are not
+    warned about here, only typoed names are.
     """
     warnings: list[str] = []
     teams, matches = _collect_literals(text)
+    known_match_names: list[str] | None = None
+    known_tag_names: list[str] | None = None
     for inner, pos in teams:
-        if not inner or "::" in inner:
+        if not inner:
+            continue
+        if "::" in inner:
+            head, _, tail = inner.partition("::")
+            if head == "tag":
+                if not Tag.query.filter_by(name=tail, event=event).first():
+                    if known_tag_names is None:
+                        known_tag_names = [t.name for t in Tag.query.filter_by(event=event).all()]
+                    suggestion = _suggest_function(tail, known_tag_names)
+                    hint = f" Did you mean 'tag::{suggestion}'?" if suggestion else ""
+                    warnings.append(f"Unknown tag '[tag::{tail}]' at {_format_position(text, pos)}.{hint}")
+                continue
+            if tail in ("winner", "loser"):
+                if not MatchDB.query.filter_by(name=head, event=event).first():
+                    if known_match_names is None:
+                        known_match_names = [m.name for m in MatchDB.query.filter_by(event=event).all()]
+                    suggestion = _suggest_function(head, known_match_names)
+                    hint = f" Did you mean '{suggestion}::{tail}'?" if suggestion else ""
+                    warnings.append(f"Unknown match '[{head}::{tail}]' at {_format_position(text, pos)}.{hint}")
+                continue
+            warnings.append(
+                f"Invalid team literal '[{inner}]' at {_format_position(text, pos)} — "
+                "expected a team id, tag::TagName, or MatchName::winner/loser."
+            )
             continue
         if not TeamDB.query.filter_by(id=inner).first():
             all_names = [t.id for t in TeamDB.query.all()]
             suggestion = _suggest_function(inner, all_names)
             hint = f" Did you mean '{suggestion}'?" if suggestion else ""
             warnings.append(f"Unknown team '[{inner}]' at {_format_position(text, pos)}.{hint}")
-    known_match_names = None
     for inner, pos in matches:
         if not inner:
             continue

--- a/app/utils/parser.py
+++ b/app/utils/parser.py
@@ -58,7 +58,10 @@ data types:
 
 """
 
+import difflib
+
 from lark import Lark, Tree
+from lark.exceptions import LarkError, UnexpectedInput
 from sqlalchemy import or_, and_
 from app.models import Match as MatchDB, Point as PointDB, Team as TeamDB, Tag
 from app.domain.enums import WinnerSide
@@ -68,6 +71,85 @@ class DSLValidationError(Exception):
     """Raised when DSL expression validation fails."""
 
     pass
+
+
+# Bracket pairings that ASS supports.
+_BRACKET_PAIRS = {"(": ")", "[": "]", "{": "}"}
+_CLOSE_TO_OPEN = {v: k for k, v in _BRACKET_PAIRS.items()}
+
+
+def _format_position(text: str, pos: int) -> str:
+    """Render `(line N, col M)` for a 0-based byte offset into `text`."""
+    if pos < 0 or pos > len(text):
+        return ""
+    line = text.count("\n", 0, pos) + 1
+    last_nl = text.rfind("\n", 0, pos)
+    col = pos - last_nl  # 1-based when last_nl == -1 because pos - (-1) = pos + 1
+    return f"line {line}, col {col}"
+
+
+def _check_balanced_brackets(text: str) -> None:
+    """Lightweight bracket-balance check that points at the offending character.
+
+    ASS uses three nesting kinds — `()`, `[]`, `{}`. Square and curly
+    literals don't nest (they enclose names, not sub-expressions), but they
+    still need to be paired. We scan once and raise a `DSLValidationError`
+    with a position the caller can show in the UI.
+    """
+    stack: list[tuple[str, int]] = []
+    in_team_literal = False
+    in_match_literal = False
+    for i, c in enumerate(text):
+        if in_team_literal:
+            if c == "]":
+                in_team_literal = False
+                stack.pop()
+            continue
+        if in_match_literal:
+            if c == "}":
+                in_match_literal = False
+                stack.pop()
+            continue
+        if c == "[":
+            if stack and stack[-1][0] == "[":
+                raise DSLValidationError(
+                    f"Nested '[' at {_format_position(text, i)} — team literals can't contain '['."
+                )
+            stack.append(("[", i))
+            in_team_literal = True
+        elif c == "{":
+            if stack and stack[-1][0] == "{":
+                raise DSLValidationError(
+                    f"Nested '{{' at {_format_position(text, i)} — match literals can't contain '{{'."
+                )
+            stack.append(("{", i))
+            in_match_literal = True
+        elif c == "(":
+            stack.append(("(", i))
+        elif c in (")", "]", "}"):
+            expected_open = _CLOSE_TO_OPEN[c]
+            if not stack:
+                raise DSLValidationError(
+                    f"Unexpected '{c}' at {_format_position(text, i)} — no matching '{expected_open}' to close."
+                )
+            open_c, _open_pos = stack[-1]
+            if open_c != expected_open:
+                raise DSLValidationError(
+                    f"Mismatched bracket: '{c}' at {_format_position(text, i)} closes a '{open_c}' opened at {_format_position(text, _open_pos)}."
+                )
+            stack.pop()
+    if stack:
+        open_c, open_pos = stack[-1]
+        close_c = _BRACKET_PAIRS[open_c]
+        raise DSLValidationError(
+            f"Unclosed '{open_c}' at {_format_position(text, open_pos)} — expected matching '{close_c}'."
+        )
+
+
+def _suggest_function(name: str, candidates) -> str | None:
+    """Return the best fuzzy match for `name` in `candidates`, or None."""
+    matches = difflib.get_close_matches(name, list(candidates), n=1, cutoff=0.6)
+    return matches[0] if matches else None
 
 
 class Lambda:
@@ -561,8 +643,12 @@ class Simplifier:
             elif head == "is-skipped":
                 return self._evaluate_is_skipped(head, args)
             else:
-                # Unknown function name
-                raise DSLValidationError(f"No symbol named '{head}'")
+                # Unknown function name — try did-you-mean from the builtin set + bound env names.
+                known = set(self.BUILTINS) | set(self.env.keys())
+                suggestion = _suggest_function(head, known)
+                if suggestion:
+                    raise DSLValidationError(f"Unknown function '{head}'. Did you mean '{suggestion}'?")
+                raise DSLValidationError(f"Unknown function '{head}'.")
 
         # If head is not a string or lambda, it's an error
         raise DSLValidationError(f"Cannot call {type(head).__name__} as a function")
@@ -1110,6 +1196,68 @@ class Simplifier:
         return min_elem
 
 
+def _collect_literals(text: str):
+    """Pull out raw team and match literals for a quick reference-existence check.
+
+    Returns (team_literals, match_literals) — lists of (raw_inside, position) tuples,
+    skipping things that aren't directly resolvable (MatchName::winner, tag::Foo).
+    """
+    teams: list[tuple[str, int]] = []
+    matches: list[tuple[str, int]] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == "[":
+            j = text.find("]", i + 1)
+            if j == -1:
+                break
+            inner = text[i + 1 : j].strip()
+            teams.append((inner, i))
+            i = j + 1
+            continue
+        if c == "{":
+            j = text.find("}", i + 1)
+            if j == -1:
+                break
+            inner = text[i + 1 : j].strip()
+            matches.append((inner, i))
+            i = j + 1
+            continue
+        i += 1
+    return teams, matches
+
+
+def _check_references(text: str, event: str) -> list[str]:
+    """Return a list of warnings about unresolvable team/match references.
+
+    Skips MatchName::winner / MatchName::loser / tag::Foo (those legitimately
+    resolve symbolically). Plain team ids and match names should map to existing
+    rows; if not, we tell the user.
+    """
+    warnings: list[str] = []
+    teams, matches = _collect_literals(text)
+    for inner, pos in teams:
+        if not inner or "::" in inner:
+            continue
+        if not TeamDB.query.filter_by(id=inner).first():
+            all_names = [t.id for t in TeamDB.query.all()]
+            suggestion = _suggest_function(inner, all_names)
+            hint = f" Did you mean '{suggestion}'?" if suggestion else ""
+            warnings.append(f"Unknown team '[{inner}]' at {_format_position(text, pos)}.{hint}")
+    known_match_names = None
+    for inner, pos in matches:
+        if not inner:
+            continue
+        if not MatchDB.query.filter_by(name=inner, event=event).first():
+            if known_match_names is None:
+                known_match_names = [m.name for m in MatchDB.query.filter_by(event=event).all()]
+            suggestion = _suggest_function(inner, known_match_names)
+            hint = f" Did you mean '{{{suggestion}}}'?" if suggestion else ""
+            warnings.append(f"Unknown match '{{{inner}}}' at {_format_position(text, pos)}.{hint}")
+    return warnings
+
+
 def get_parser(event: str, match_resolver=None):
     """
     Create a parser for the given event (tournament URL).
@@ -1127,15 +1275,46 @@ def get_parser(event: str, match_resolver=None):
         parse_match = match_resolver if match_resolver is not None else (lambda x: parse_match_literal(x, event))
 
         def parse(text):
-            tree = parser.parse(text)
+            # Cheap structural check first — gives clean position-aware errors before Lark tries.
+            _check_balanced_brackets(text)
+            try:
+                tree = parser.parse(text)
+            except UnexpectedInput as e:
+                # Convert Lark's verbose dump to a one-line message with position.
+                pos = getattr(e, "pos_in_stream", None)
+                line = getattr(e, "line", None)
+                col = getattr(e, "column", None)
+                if line is not None and col is not None:
+                    where = f"line {line}, col {col}"
+                elif pos is not None:
+                    where = _format_position(text, pos)
+                else:
+                    where = "an unknown position"
+                got = ""
+                tok = getattr(e, "token", None)
+                if tok is not None and getattr(tok, "value", None):
+                    got = f" near `{tok.value}`"
+                raise DSLValidationError(f"Parse error at {where}{got}.") from e
+            except LarkError as e:
+                raise DSLValidationError(f"Parse error: {e}") from e
             interpreter = Simplifier(
                 lambda x: parse_team_literal(x, event),
                 parse_match,
             )
             return interpreter.visit(tree)
 
-        class Parser:
-            def __init__(self, parse_func):
-                self.parse = parse_func
+        def static_check(text):
+            """Quick lint pass: balanced brackets and reference existence.
 
-        return Parser(parse)
+            Raises DSLValidationError on unbalanced brackets. Returns a list of
+            soft warnings (typo-likely team/match names) without raising.
+            """
+            _check_balanced_brackets(text)
+            return _check_references(text, event)
+
+        class Parser:
+            def __init__(self, parse_func, static_check_func):
+                self.parse = parse_func
+                self.static_check = static_check_func
+
+        return Parser(parse, static_check)

--- a/frontend/src/components.rs
+++ b/frontend/src/components.rs
@@ -1,5 +1,6 @@
 //! Reusable UI components.
 
+mod ass_entry;
 mod change_password_card;
 mod edit_registration_modal;
 mod event_about;
@@ -11,6 +12,7 @@ mod league_registration_buttons;
 mod penalty_display;
 mod team_token_input;
 
+pub use ass_entry::AssEntry;
 pub use change_password_card::ChangePasswordCard;
 pub use edit_registration_modal::{EditRegistrationContext, EditRegistrationModal};
 pub use event_about::EventAbout;

--- a/frontend/src/components/ass_entry.rs
+++ b/frontend/src/components/ass_entry.rs
@@ -143,13 +143,61 @@ pub fn innermost_around_cursor(s: &str, cursor_char: usize) -> Option<InnermostB
 
 /// Tokenize the expression for the preview row. Each token is a chunk of text the user wrote,
 /// classified as a literal kind so we can render chips for [..] and {..}.
+///
+/// As a special case, the patterns `(winner {NAME})` and `(loser {NAME})` collapse into a
+/// single `WinnerCall`/`LoserCall` token — they're conceptually a single team-reference,
+/// just spelled differently from `[NAME::winner]` / `[NAME::loser]`.
 #[derive(Clone, Debug)]
 enum PreviewToken {
     Text(String),
-    Team(String),    // raw inside [..]
-    Match(String),   // raw inside {..}
+    Team(String),
+    Match(String),
+    WinnerCall(String),
+    LoserCall(String),
     OpenBracket(char),
     CloseBracket(char),
+}
+
+/// If `s[i..]` starts with `( <ws>* (winner|loser) <ws>+ {NAME} <ws>* )`, return
+/// `(winner_or_loser, name, end_byte)` so we can collapse it into a single chip.
+fn match_winner_loser_call(s: &str, i: usize) -> Option<(bool, String, usize)> {
+    let bytes = s.as_bytes();
+    if bytes.get(i).copied() != Some(b'(') {
+        return None;
+    }
+    let mut j = i + 1;
+    while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+        j += 1;
+    }
+    let is_winner = if s[j..].starts_with("winner") {
+        j += "winner".len();
+        true
+    } else if s[j..].starts_with("loser") {
+        j += "loser".len();
+        false
+    } else {
+        return None;
+    };
+    if !bytes.get(j).map_or(false, |c| c.is_ascii_whitespace()) {
+        return None;
+    }
+    while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+        j += 1;
+    }
+    if bytes.get(j).copied() != Some(b'{') {
+        return None;
+    }
+    let after_open = j + 1;
+    let close_rel = s[after_open..].find('}')?;
+    let name = s[after_open..after_open + close_rel].trim().to_string();
+    let mut k = after_open + close_rel + 1;
+    while k < bytes.len() && bytes[k].is_ascii_whitespace() {
+        k += 1;
+    }
+    if bytes.get(k).copied() != Some(b')') {
+        return None;
+    }
+    Some((is_winner, name, k + 1))
 }
 
 fn tokenize_preview(s: &str) -> Vec<PreviewToken> {
@@ -157,17 +205,32 @@ fn tokenize_preview(s: &str) -> Vec<PreviewToken> {
     let bytes = s.as_bytes();
     let mut i = 0;
     let mut text_buf = String::new();
+    let flush_text = |buf: &mut String, out: &mut Vec<PreviewToken>| {
+        if !buf.is_empty() {
+            out.push(PreviewToken::Text(std::mem::take(buf)));
+        }
+    };
     while i < bytes.len() {
         let c = bytes[i] as char;
+        if c == '(' {
+            if let Some((is_winner, name, end)) = match_winner_loser_call(s, i) {
+                flush_text(&mut text_buf, &mut out);
+                if is_winner {
+                    out.push(PreviewToken::WinnerCall(name));
+                } else {
+                    out.push(PreviewToken::LoserCall(name));
+                }
+                i = end;
+                continue;
+            }
+        }
         if c == '[' || c == '{' {
             let close_c = if c == '[' { ']' } else { '}' };
             // Find first close in same kind without trying to support nesting (literals don't nest).
             let after = i + 1;
             if let Some(rel) = s[after..].find(close_c) {
                 let inner = &s[after..after + rel];
-                if !text_buf.is_empty() {
-                    out.push(PreviewToken::Text(std::mem::take(&mut text_buf)));
-                }
+                flush_text(&mut text_buf, &mut out);
                 if c == '[' {
                     out.push(PreviewToken::Team(inner.to_string()));
                 } else {
@@ -177,18 +240,14 @@ fn tokenize_preview(s: &str) -> Vec<PreviewToken> {
                 continue;
             } else {
                 // Unclosed: render as open bracket then continue rendering remaining text
-                if !text_buf.is_empty() {
-                    out.push(PreviewToken::Text(std::mem::take(&mut text_buf)));
-                }
+                flush_text(&mut text_buf, &mut out);
                 out.push(PreviewToken::OpenBracket(c));
                 i += 1;
                 continue;
             }
         }
         if c == ']' || c == '}' {
-            if !text_buf.is_empty() {
-                out.push(PreviewToken::Text(std::mem::take(&mut text_buf)));
-            }
+            flush_text(&mut text_buf, &mut out);
             out.push(PreviewToken::CloseBracket(c));
             i += 1;
             continue;
@@ -280,6 +339,289 @@ enum TeamRefKind {
     Loser(String),
 }
 
+/// Compact display name for a team — prefer `shortname` when present, then `pseudonym`, then id.
+fn team_short_label(t: &TeamOption) -> String {
+    t.shortname
+        .clone()
+        .or_else(|| t.pseudonym.clone())
+        .unwrap_or_else(|| t.id.clone())
+}
+
+/// One ASS atom (the kind of thing that can stand in for a team in a match): a team id,
+/// `tag::TagName`, or `MatchName::winner` / `MatchName::loser`. Used to render compact
+/// inline references in the match autocomplete.
+#[derive(Clone, Debug)]
+enum AssAtom {
+    Team(String),       // team id
+    Tag(String),        // tag name (without the "tag::" prefix)
+    Winner(String),     // match name
+    Loser(String),      // match name
+}
+
+fn parse_ass_atom(raw: &str) -> AssAtom {
+    let s = raw.trim();
+    if let Some(rest) = s.strip_suffix("::winner") {
+        return AssAtom::Winner(rest.trim().to_string());
+    }
+    if let Some(rest) = s.strip_suffix("::loser") {
+        return AssAtom::Loser(rest.trim().to_string());
+    }
+    if s.len() >= 5 && s[..5].eq_ignore_ascii_case("tag::") {
+        return AssAtom::Tag(s[5..].trim().to_string());
+    }
+    AssAtom::Team(s.to_string())
+}
+
+/// Render an ASS atom as a compact inline pill: avatar + shortname for teams, an
+/// icon + label for tags / winner / loser. Used in the match autocomplete to show
+/// who's playing and reffing without taking much space.
+fn render_atom_compact(
+    raw: &str,
+    base_url: &str,
+    team_options: &[TeamOption],
+    tags: &[TagSetupData],
+) -> Element {
+    let atom = parse_ass_atom(raw);
+    match atom {
+        AssAtom::Team(id) => {
+            if let Some(t) = team_options.iter().find(|t| t.id.eq_ignore_ascii_case(&id)) {
+                let label = team_short_label(t);
+                if let Some(p) = t.profile_photo.clone() {
+                    rsx! {
+                        span { class: "ass-atom",
+                            img {
+                                src: "{base_url}/static/{p}",
+                                alt: "",
+                                class: "ass-atom-avatar rounded-circle",
+                            }
+                            span { class: "ass-atom-label", "{label}" }
+                        }
+                    }
+                } else {
+                    let initial = label.chars().next().unwrap_or('?').to_string();
+                    rsx! {
+                        span { class: "ass-atom",
+                            span { class: "ass-atom-avatar ass-atom-avatar-text", "{initial}" }
+                            span { class: "ass-atom-label", "{label}" }
+                        }
+                    }
+                }
+            } else {
+                rsx! {
+                    span { class: "ass-atom ass-atom-unknown",
+                        span { class: "ass-atom-avatar ass-atom-avatar-text", "?" }
+                        span { class: "ass-atom-label", "{id}" }
+                    }
+                }
+            }
+        }
+        AssAtom::Tag(name) => {
+            let known = tags.iter().any(|t| t.name.eq_ignore_ascii_case(&name));
+            let cls = if known { "ass-atom" } else { "ass-atom ass-atom-unknown" };
+            rsx! {
+                span { class: "{cls}",
+                    img { class: "ass-atom-icon icon-primary-svg", src: "{base_url}/static/tag.svg", alt: "" }
+                    span { class: "ass-atom-label", "{name}" }
+                }
+            }
+        }
+        AssAtom::Winner(name) => rsx! {
+            span { class: "ass-atom",
+                img { class: "ass-atom-icon icon-primary-svg", src: "{base_url}/static/reference.svg", alt: "" }
+                span { class: "ass-atom-label", "{name}" }
+                span { class: "ass-atom-badge winner-badge", "W" }
+            }
+        },
+        AssAtom::Loser(name) => rsx! {
+            span { class: "ass-atom",
+                img { class: "ass-atom-icon icon-primary-svg", src: "{base_url}/static/reference.svg", alt: "" }
+                span { class: "ass-atom-label", "{name}" }
+                span { class: "ass-atom-badge loser-badge", "L" }
+            }
+        },
+    }
+}
+
+/// Split a comma-separated list of ASS atoms ("team1, tag::Foo, Match1::winner") into trimmed pieces.
+fn split_atoms(raw: &str) -> Vec<String> {
+    raw.split(',').map(str::trim).filter(|s| !s.is_empty()).map(str::to_string).collect()
+}
+
+/// Render an ASS expression string as a row of chips: literals (`[..]`/`{..}`) and the
+/// `(winner ...)` / `(loser ...)` patterns become labeled chips with resolution arrows;
+/// everything else passes through as plain text.
+fn render_expression_chips(
+    s: &str,
+    team_options: &[TeamOption],
+    tags: &[TagSetupData],
+    matches: &[MatchSetupData],
+    base_url: &str,
+    key_prefix: &str,
+) -> Vec<Element> {
+    tokenize_preview(s)
+        .into_iter()
+        .enumerate()
+        .map(|(i, tok)| match tok {
+            PreviewToken::Text(s) => {
+                let key = format!("{key_prefix}-{i}");
+                rsx! { span { key: "{key}", class: "ass-entry-preview-text", "{s}" } }
+            }
+            PreviewToken::OpenBracket(c) | PreviewToken::CloseBracket(c) => {
+                let key = format!("{key_prefix}-{i}");
+                let txt = c.to_string();
+                rsx! { span { key: "{key}", class: "ass-entry-preview-bracket text-warning", "{txt}" } }
+            }
+            PreviewToken::Team(inner) => {
+                let key = format!("{key_prefix}-{i}");
+                let (kind, resolved) = resolve_team_literal(&inner, team_options, tags, matches);
+                let (chip_class, label, icon) = match &kind {
+                    TeamRefKind::Team(name) => ("team-token-chip team-token-chip-team", name.clone(), None),
+                    TeamRefKind::Tag(name) => (
+                        "team-token-chip team-token-chip-tag",
+                        name.clone(),
+                        Some(("tag.svg", "Tag")),
+                    ),
+                    TeamRefKind::Winner(name) => (
+                        "team-token-chip team-token-chip-winner",
+                        format!("{} winner", name),
+                        Some(("reference.svg", "Reference")),
+                    ),
+                    TeamRefKind::Loser(name) => (
+                        "team-token-chip team-token-chip-loser",
+                        format!("{} loser", name),
+                        Some(("reference.svg", "Reference")),
+                    ),
+                };
+                let avatar = match (&kind, &resolved) {
+                    (TeamRefKind::Team(_), Some(r)) => {
+                        if let Some(p) = r.profile_photo.clone() {
+                            rsx! { img {
+                                src: "{base_url}/static/{p}",
+                                alt: "",
+                                class: "team-token-avatar rounded-circle",
+                                style: "width: 1.4em; height: 1.4em; object-fit: cover;"
+                            } }
+                        } else {
+                            rsx! { span { class: "team-token-avatar", "{r.display.chars().next().unwrap_or('?')}" } }
+                        }
+                    }
+                    (TeamRefKind::Team(name), None) => {
+                        rsx! { span { class: "team-token-avatar", "{name.chars().next().unwrap_or('?')}" } }
+                    }
+                    _ => {
+                        if let Some((icon_name, alt)) = icon {
+                            rsx! { img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/{icon_name}", alt: "{alt}" } }
+                        } else {
+                            rsx! {}
+                        }
+                    }
+                };
+                let resolved_arrow = match (&kind, resolved.clone()) {
+                    (TeamRefKind::Team(_), _) => rsx! {},
+                    (_, Some(r)) => {
+                        let disp = r.display.clone();
+                        let photo = r.profile_photo.clone();
+                        rsx! {
+                            span { class: "team-token-resolved text-muted ms-1",
+                                " → "
+                                if let Some(p) = photo {
+                                    img {
+                                        src: "{base_url}/static/{p}",
+                                        alt: "",
+                                        class: "team-token-avatar small rounded-circle ms-1",
+                                        style: "width: 1em; height: 1em; object-fit: cover; vertical-align: middle;"
+                                    }
+                                } else {
+                                    span { class: "team-token-avatar small ms-1", style: "display: inline-flex; width: 1em; height: 1em; align-items: center; justify-content: center; font-size: 0.85em;", "{disp.chars().next().unwrap_or('?')}" }
+                                }
+                                span { "{disp}" }
+                            }
+                        }
+                    }
+                    _ => rsx! {},
+                };
+                rsx! {
+                    span { key: "{key}", class: "{chip_class}",
+                        {avatar}
+                        span { class: "team-token-label", "{label}" }
+                        {resolved_arrow}
+                    }
+                }
+            }
+            PreviewToken::Match(inner) => {
+                let key = format!("{key_prefix}-{i}");
+                let name = inner.trim().to_string();
+                let known = matches.iter().any(|m| m.name.eq_ignore_ascii_case(&name));
+                let extra_class = if known { "" } else { " ass-entry-preview-unknown" };
+                rsx! {
+                    span { key: "{key}", class: "team-token-chip team-token-chip-match{extra_class}",
+                        img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/reference.svg", alt: "Match" }
+                        span { class: "team-token-label", "{name}" }
+                    }
+                }
+            }
+            ref tok @ (PreviewToken::WinnerCall(_) | PreviewToken::LoserCall(_)) => {
+                let key = format!("{key_prefix}-{i}");
+                let (name, is_winner) = match tok {
+                    PreviewToken::WinnerCall(n) => (n.clone(), true),
+                    PreviewToken::LoserCall(n) => (n.clone(), false),
+                    _ => unreachable!(),
+                };
+                let chip_class = if is_winner {
+                    "team-token-chip team-token-chip-winner"
+                } else {
+                    "team-token-chip team-token-chip-loser"
+                };
+                let label = if is_winner {
+                    format!("{} winner", name)
+                } else {
+                    format!("{} loser", name)
+                };
+                let resolved = matches
+                    .iter()
+                    .find(|m| m.name.eq_ignore_ascii_case(&name) && m.status.eq_ignore_ascii_case("COMPLETED"))
+                    .and_then(|m| {
+                        let side = m.match_winner.as_deref()?;
+                        let id = if is_winner {
+                            if side.eq_ignore_ascii_case("TEAM1") { m.team1.clone() } else if side.eq_ignore_ascii_case("TEAM2") { m.team2.clone() } else { None }
+                        } else if side.eq_ignore_ascii_case("TEAM1") { m.team2.clone() } else if side.eq_ignore_ascii_case("TEAM2") { m.team1.clone() } else { None }?;
+                        Some(id)
+                    })
+                    .and_then(|tid| team_options.iter().find(|t| t.id == tid).cloned());
+                let resolved_arrow = if let Some(t) = resolved {
+                    let team_label = team_short_label(&t);
+                    let photo = t.profile_photo.clone();
+                    rsx! {
+                        span { class: "team-token-resolved text-muted ms-1",
+                            " → "
+                            if let Some(p) = photo {
+                                img {
+                                    src: "{base_url}/static/{p}",
+                                    alt: "",
+                                    class: "team-token-avatar small rounded-circle ms-1",
+                                    style: "width: 1em; height: 1em; object-fit: cover; vertical-align: middle;"
+                                }
+                            } else {
+                                span { class: "team-token-avatar small ms-1", style: "display: inline-flex; width: 1em; height: 1em; align-items: center; justify-content: center; font-size: 0.85em;", "{team_label.chars().next().unwrap_or('?')}" }
+                            }
+                            span { "{team_label}" }
+                        }
+                    }
+                } else {
+                    rsx! {}
+                };
+                rsx! {
+                    span { key: "{key}", class: "{chip_class}",
+                        img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/reference.svg", alt: "Reference" }
+                        span { class: "team-token-label", "{label}" }
+                        {resolved_arrow}
+                    }
+                }
+            }
+        })
+        .collect()
+}
+
 #[derive(Clone, Debug)]
 enum AcOption {
     Function {
@@ -295,6 +637,7 @@ enum AcOption {
     Tag {
         insert: String,
         display: String,
+        resolved_team: Option<String>,
     },
     MatchRef {
         insert: String,
@@ -304,6 +647,10 @@ enum AcOption {
     Match {
         insert: String,
         display: String,
+        field: Option<String>,
+        team1: Option<String>,
+        team2: Option<String>,
+        refs: Vec<String>,
     },
 }
 
@@ -328,55 +675,57 @@ fn collect_team_options(
     matches: &[MatchSetupData],
 ) -> Vec<AcOption> {
     let q = query.to_lowercase();
-    let mut out: Vec<AcOption> = Vec::new();
-    for t in team_options.iter() {
-        let id_lower = t.id.to_lowercase();
-        let pseudo_lower = t.pseudonym.as_deref().unwrap_or("").to_lowercase();
-        if q.is_empty() || id_lower.contains(&q) || pseudo_lower.contains(&q) {
-            let display = t
+    // Build each kind separately, then interleave with per-kind caps so tags/matches always
+    // get a fair slice when there's no query (otherwise a long team list can starve them).
+    let team_opts: Vec<AcOption> = team_options
+        .iter()
+        .filter(|t| {
+            q.is_empty()
+                || t.id.to_lowercase().contains(&q)
+                || t.pseudonym.as_deref().unwrap_or("").to_lowercase().contains(&q)
+        })
+        .map(|t| AcOption::Team {
+            insert: t.id.clone(),
+            display: t
                 .pseudonym
                 .clone()
                 .map(|p| format!("{p} ({})", t.id))
-                .unwrap_or_else(|| t.id.clone());
-            out.push(AcOption::Team {
-                insert: t.id.clone(),
-                display,
-                photo: t.profile_photo.clone(),
-            });
-        }
-        if out.len() >= 20 {
-            break;
-        }
-    }
+                .unwrap_or_else(|| t.id.clone()),
+            photo: t.profile_photo.clone(),
+        })
+        .collect();
+    let tag_opts: Vec<AcOption> = tags
+        .iter()
+        .filter(|tag| q.is_empty() || tag.name.to_lowercase().contains(&q))
+        .map(|tag| AcOption::Tag {
+            insert: format!("tag::{}", tag.name),
+            display: tag.name.clone(),
+            resolved_team: tag.team.clone(),
+        })
+        .collect();
+    let mut match_ref_opts: Vec<AcOption> = Vec::new();
     for m in matches.iter() {
         if q.is_empty() || m.name.to_lowercase().contains(&q) {
-            out.push(AcOption::MatchRef {
+            match_ref_opts.push(AcOption::MatchRef {
                 insert: format!("{}::winner", m.name),
                 display: format!("{} winner", m.name),
                 is_winner: true,
             });
-            out.push(AcOption::MatchRef {
+            match_ref_opts.push(AcOption::MatchRef {
                 insert: format!("{}::loser", m.name),
                 display: format!("{} loser", m.name),
                 is_winner: false,
             });
         }
-        if out.len() >= 30 {
-            break;
-        }
     }
-    for tag in tags.iter() {
-        if q.is_empty() || tag.name.to_lowercase().contains(&q) {
-            out.push(AcOption::Tag {
-                insert: format!("tag::{}", tag.name),
-                display: tag.name.clone(),
-            });
-        }
-        if out.len() >= 35 {
-            break;
-        }
-    }
-    out.into_iter().take(25).collect()
+    // Caps: when the query is empty, give each kind a fair slice. With a query, prefer the
+    // best matches but keep tag/match-ref space available.
+    let (team_cap, tag_cap, match_cap) = if q.is_empty() { (12, 8, 10) } else { (15, 8, 10) };
+    let mut out: Vec<AcOption> = Vec::new();
+    out.extend(team_opts.into_iter().take(team_cap));
+    out.extend(tag_opts.into_iter().take(tag_cap));
+    out.extend(match_ref_opts.into_iter().take(match_cap));
+    out.into_iter().take(30).collect()
 }
 
 fn collect_match_options(query: &str, matches: &[MatchSetupData]) -> Vec<AcOption> {
@@ -388,6 +737,15 @@ fn collect_match_options(query: &str, matches: &[MatchSetupData]) -> Vec<AcOptio
         .map(|m| AcOption::Match {
             insert: m.name.clone(),
             display: m.name.clone(),
+            field: m.field.clone(),
+            team1: m.team1_initial.clone().or_else(|| m.team1.clone()),
+            team2: m.team2_initial.clone().or_else(|| m.team2.clone()),
+            refs: m
+                .refs_initial
+                .as_deref()
+                .or(m.refs.as_deref())
+                .map(split_atoms)
+                .unwrap_or_default(),
         })
         .collect()
 }
@@ -417,7 +775,9 @@ pub fn AssEntry(
     let mut ac_index = use_signal(|| 0usize);
     let mut ac_open = use_signal(|| false);
     let mut error_msg = use_signal(|| None::<String>);
-    let mut simplified_msg = use_signal(|| None::<String>);
+    // Tagged with the input string the simplification was computed for, so we can hide it
+    // when the user has typed something that no longer matches.
+    let mut simplified_msg = use_signal(|| None::<(String, String)>);
 
     // After auto-close insertions, we need to reposition the cursor on the next tick.
     #[cfg(target_arch = "wasm32")]
@@ -441,6 +801,36 @@ pub fn AssEntry(
                     }
                 });
             }
+        });
+    }
+
+    // Debounced re-validation: when the value settles for ~500ms, ask the server for a
+    // fresh simplification. Without this, the simplified row only refreshes on blur,
+    // which is rare while the user is actively editing.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let v_for_effect = value_rc.as_ref().clone();
+        let url_for_effect = tournament_url.clone();
+        use_effect(move || {
+            let v = v_for_effect.clone();
+            let url = url_for_effect.clone();
+            if v.trim().is_empty() || url.is_empty() {
+                return;
+            }
+            spawn(async move {
+                gloo_timers::future::TimeoutFuture::new(500).await;
+                let validated_for = v.clone();
+                if let Ok(res) = api::validate_dsl(&url, &v).await {
+                    if res.valid {
+                        error_msg.set(None);
+                        if let Some(simp) = res.simplified {
+                            simplified_msg.set(Some((validated_for, simp)));
+                        }
+                    } else {
+                        error_msg.set(res.error);
+                    }
+                }
+            });
         });
     }
 
@@ -508,7 +898,9 @@ pub fn AssEntry(
         ac_open.set(true);
         ac_index.set(0);
         error_msg.set(None);
-        simplified_msg.set(None);
+        // Don't wipe simplified_msg here. It's tagged with the input it was computed for, so
+        // the rsx guard hides it automatically once the input no longer matches; that's
+        // gentler than the row blinking out on every keystroke.
         if let Some(byte_after_open) = after_open {
             // ASCII brackets only — byte position equals char position.
             pending_cursor.set(Some(byte_after_open));
@@ -663,11 +1055,12 @@ pub fn AssEntry(
             return;
         }
         spawn(async move {
+            let validated_for = expr.clone();
             match api::validate_dsl(&url, &expr).await {
                 Ok(res) => {
                     if res.valid {
                         error_msg.set(None);
-                        simplified_msg.set(res.simplified);
+                        simplified_msg.set(res.simplified.map(|s| (validated_for, s)));
                     } else {
                         error_msg.set(res.error);
                         simplified_msg.set(None);
@@ -780,11 +1173,36 @@ pub fn AssEntry(
                         }
                     }
                 }
-                AcOption::Tag { display, .. } => {
+                AcOption::Tag { display, resolved_team, .. } => {
                     let d = display.clone();
+                    let resolved_node = resolved_team
+                        .as_ref()
+                        .and_then(|tid| team_options_for_render.iter().find(|t| &t.id == tid))
+                        .map(|t| {
+                            let label = team_short_label(t);
+                            let photo = t.profile_photo.clone();
+                            rsx! {
+                                span { class: "ass-entry-ac-resolved text-muted ms-2",
+                                    " → "
+                                    if let Some(p) = photo {
+                                        img {
+                                            src: "{base_url}/static/{p}",
+                                            alt: "",
+                                            class: "ass-atom-avatar rounded-circle",
+                                        }
+                                    } else {
+                                        span { class: "ass-atom-avatar ass-atom-avatar-text", "{label.chars().next().unwrap_or('?')}" }
+                                    }
+                                    span { "{label}" }
+                                }
+                            }
+                        });
                     rsx! {
-                        img { class: "icon-primary-svg me-1", src: "{base_url}/static/tag.svg", alt: "Tag", style: "width: 1.25em; height: 1.25em;" }
-                        span { "{d}" }
+                        span { class: "ass-entry-ac-row",
+                            img { class: "icon-primary-svg me-1", src: "{base_url}/static/tag.svg", alt: "Tag", style: "width: 1.25em; height: 1.25em;" }
+                            span { "{d}" }
+                            if let Some(r) = resolved_node { {r} }
+                        }
                     }
                 }
                 AcOption::MatchRef { display, is_winner, .. } => {
@@ -796,11 +1214,43 @@ pub fn AssEntry(
                         span { class: "team-token-badge ms-1 {badge}-badge small", "{badge}" }
                     }
                 }
-                AcOption::Match { display, .. } => {
+                AcOption::Match { display, field, team1, team2, refs, .. } => {
                     let d = display.clone();
+                    let field_str = field.clone().unwrap_or_default();
+                    let teams_for_atom = team_options_for_render.clone();
+                    let tags_for_atom = tags_for_render.clone();
+                    let team1_node = team1.as_deref().map(|raw| render_atom_compact(raw, &base_url, teams_for_atom.as_ref(), tags_for_atom.as_ref()));
+                    let teams_for_atom2 = team_options_for_render.clone();
+                    let tags_for_atom2 = tags_for_render.clone();
+                    let team2_node = team2.as_deref().map(|raw| render_atom_compact(raw, &base_url, teams_for_atom2.as_ref(), tags_for_atom2.as_ref()));
+                    let teams_for_refs = team_options_for_render.clone();
+                    let tags_for_refs = tags_for_render.clone();
+                    let refs_clone = refs.clone();
+                    let ref_nodes: Vec<_> = refs_clone
+                        .iter()
+                        .map(|raw| render_atom_compact(raw, &base_url, teams_for_refs.as_ref(), tags_for_refs.as_ref()))
+                        .collect();
                     rsx! {
-                        img { class: "icon-primary-svg me-1", src: "{base_url}/static/reference.svg", alt: "Match", style: "width: 1.25em; height: 1.25em;" }
-                        span { "{d}" }
+                        div { class: "ass-entry-ac-match-head",
+                            img { class: "icon-primary-svg me-1", src: "{base_url}/static/reference.svg", alt: "Match", style: "width: 1.25em; height: 1.25em;" }
+                            span { class: "ass-entry-ac-match-name", "{d}" }
+                            if !field_str.is_empty() {
+                                span { class: "ass-entry-ac-match-field text-muted ms-2", "on {field_str}" }
+                            }
+                        }
+                        div { class: "ass-entry-ac-match-meta small text-muted",
+                            if let Some(t) = team1_node { {t} }
+                            span { class: "ass-entry-ac-vs mx-1", "vs" }
+                            if let Some(t) = team2_node { {t} }
+                            if !ref_nodes.is_empty() {
+                                span { class: "ass-entry-ac-refs ms-2",
+                                    span { class: "me-1", "refs:" }
+                                    for ref_n in ref_nodes.iter() {
+                                        {ref_n.clone()}
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             };
@@ -817,120 +1267,34 @@ pub fn AssEntry(
         })
         .collect();
 
-    let preview_chips: Vec<_> = preview_tokens
-        .iter()
-        .enumerate()
-        .map(|(i, tok)| {
-            match tok {
-                PreviewToken::Text(s) => {
-                    let s = s.clone();
-                    rsx! { span { key: "{i}", class: "ass-entry-preview-text", "{s}" } }
-                }
-                PreviewToken::OpenBracket(c) => {
-                    let s = c.to_string();
-                    rsx! { span { key: "{i}", class: "ass-entry-preview-bracket text-warning", "{s}" } }
-                }
-                PreviewToken::CloseBracket(c) => {
-                    let s = c.to_string();
-                    rsx! { span { key: "{i}", class: "ass-entry-preview-bracket text-warning", "{s}" } }
-                }
-                PreviewToken::Team(inner) => {
-                    let (kind, resolved) = resolve_team_literal(
-                        inner,
-                        team_options_for_render.as_ref(),
-                        tags_for_render.as_ref(),
-                        matches_for_render.as_ref(),
-                    );
-                    let (chip_class, label, icon) = match &kind {
-                        TeamRefKind::Team(name) => ("team-token-chip team-token-chip-team", name.clone(), None),
-                        TeamRefKind::Tag(name) => (
-                            "team-token-chip team-token-chip-tag",
-                            name.clone(),
-                            Some(("tag.svg", "Tag")),
-                        ),
-                        TeamRefKind::Winner(name) => (
-                            "team-token-chip team-token-chip-winner",
-                            format!("{} winner", name),
-                            Some(("reference.svg", "Reference")),
-                        ),
-                        TeamRefKind::Loser(name) => (
-                            "team-token-chip team-token-chip-loser",
-                            format!("{} loser", name),
-                            Some(("reference.svg", "Reference")),
-                        ),
-                    };
-                    let avatar = match (&kind, &resolved) {
-                        (TeamRefKind::Team(_), Some(r)) => {
-                            if let Some(p) = r.profile_photo.clone() {
-                                rsx! { img {
-                                    src: "{base_url}/static/{p}",
-                                    alt: "",
-                                    class: "team-token-avatar rounded-circle",
-                                    style: "width: 1.4em; height: 1.4em; object-fit: cover;"
-                                } }
-                            } else {
-                                rsx! { span { class: "team-token-avatar", "{r.display.chars().next().unwrap_or('?')}" } }
-                            }
-                        }
-                        (TeamRefKind::Team(name), None) => {
-                            rsx! { span { class: "team-token-avatar", "{name.chars().next().unwrap_or('?')}" } }
-                        }
-                        _ => {
-                            if let Some((icon_name, alt)) = icon {
-                                rsx! { img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/{icon_name}", alt: "{alt}" } }
-                            } else {
-                                rsx! { }
-                            }
-                        }
-                    };
-                    let resolved_arrow = if let Some(r) = resolved.clone() {
-                        if !matches!(kind, TeamRefKind::Team(_)) {
-                            let disp = r.display.clone();
-                            let photo = r.profile_photo.clone();
-                            rsx! {
-                                span { class: "team-token-resolved text-muted ms-1",
-                                    " → "
-                                    if let Some(p) = photo {
-                                        img {
-                                            src: "{base_url}/static/{p}",
-                                            alt: "",
-                                            class: "team-token-avatar small rounded-circle ms-1",
-                                            style: "width: 1em; height: 1em; object-fit: cover; vertical-align: middle;"
-                                        }
-                                    } else {
-                                        span { class: "team-token-avatar small ms-1", style: "display: inline-flex; width: 1em; height: 1em; align-items: center; justify-content: center; font-size: 0.85em;", "{disp.chars().next().unwrap_or('?')}" }
-                                    }
-                                    span { "{disp}" }
-                                }
-                            }
-                        } else {
-                            rsx! { }
-                        }
-                    } else {
-                        rsx! { }
-                    };
-                    rsx! {
-                        span { key: "{i}", class: "{chip_class}",
-                            {avatar}
-                            span { class: "team-token-label", "{label}" }
-                            {resolved_arrow}
-                        }
-                    }
-                }
-                PreviewToken::Match(inner) => {
-                    let name = inner.trim().to_string();
-                    let known = matches_for_render.iter().any(|m| m.name.eq_ignore_ascii_case(&name));
-                    let extra_class = if known { "" } else { " ass-entry-preview-unknown" };
-                    rsx! {
-                        span { key: "{i}", class: "team-token-chip team-token-chip-match{extra_class}",
-                            img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/reference.svg", alt: "Match" }
-                            span { class: "team-token-label", "{name}" }
-                        }
-                    }
-                }
-            }
-        })
-        .collect();
+    let preview_chips = render_expression_chips(
+        &v,
+        team_options_for_render.as_ref(),
+        tags_for_render.as_ref(),
+        matches_for_render.as_ref(),
+        &base_url,
+        "input",
+    );
+    // Show the simplified row only when the cached simplification was computed for the
+    // exact value currently in the input — keeps stale results from confusing the user.
+    let simplified_value: Option<String> = simplified_msg().and_then(|(input_at, simp)| {
+        if input_at.trim() == v.trim() {
+            Some(simp)
+        } else {
+            None
+        }
+    });
+    let simplified_chips = simplified_value.as_deref().map(|simp| {
+        render_expression_chips(
+            simp,
+            team_options_for_render.as_ref(),
+            tags_for_render.as_ref(),
+            matches_for_render.as_ref(),
+            &base_url,
+            "simp",
+        )
+    });
+    let _ = preview_tokens;
 
     rsx! {
         div { class: "ass-entry position-relative",
@@ -960,10 +1324,18 @@ pub fn AssEntry(
                     }
                 }
             }
+            if let Some(chips) = simplified_chips.as_ref() {
+                div { class: "ass-entry-simplified small",
+                    span { class: "ass-entry-simplified-label text-muted me-1", "simplified:" }
+                    for chip in chips.iter() {
+                        {chip.clone()}
+                    }
+                }
+            }
             if let Some(err) = error_msg() {
                 div { class: "form-text text-danger ass-entry-error", "✗ {err}" }
-            } else if let Some(simp) = simplified_msg() {
-                div { class: "form-text text-success", "✓ Valid (simplified: {simp})" }
+            } else if simplified_value.is_some() {
+                div { class: "form-text text-success", "✓ Valid" }
             } else if !value.trim().is_empty() {
                 div { class: "form-text text-success", "✓" }
             }

--- a/frontend/src/components/ass_entry.rs
+++ b/frontend/src/components/ass_entry.rs
@@ -1,0 +1,972 @@
+//! ASS (Arctos Schedule Script) expression editor.
+//!
+//! Single-input component for entering skip conditions:
+//! - Auto-closes `(`, `[`, `{`.
+//! - Pops up a function dropdown when the cursor is inside `( ... )`.
+//! - Pops up a team/tag/match-ref dropdown inside `[ ... ]`.
+//! - Pops up a match dropdown inside `{ ... }`.
+//! - Renders parsed `[...]` and `{...}` literals as chips in a live preview.
+//! - Calls `validate_dsl` on blur and shows error/simplified output.
+
+use crate::api;
+use crate::types::*;
+use dioxus::html::ModifiersInteraction;
+use dioxus::prelude::*;
+use std::cell::RefCell;
+use std::rc::Rc;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast as _;
+
+/// (name, signature, short description)
+const DSL_FUNCTIONS: &[(&str, &str, &str)] = &[
+    ("wins", "(wins TEAM) -> INT", "Wins for a team this event"),
+    ("losses", "(losses TEAM) -> INT", "Losses for a team this event"),
+    ("winner", "(winner MATCH) -> TEAM", "Winner of a match"),
+    ("loser", "(loser MATCH) -> TEAM", "Loser of a match"),
+    ("points-won", "(points-won TEAM MATCH?) -> INT", "Points won (optionally in MATCH)"),
+    ("points-lost", "(points-lost TEAM MATCH?) -> INT", "Points lost (optionally in MATCH)"),
+    ("is-skipped", "(is-skipped MATCH) -> BOOL", "True if match was skipped"),
+    ("if", "(if COND IF_TRUE IF_FALSE)", "Conditional"),
+    ("and", "(and BOOL BOOL) -> BOOL", "Logical and"),
+    ("or", "(or BOOL BOOL) -> BOOL", "Logical or"),
+    ("not", "(not BOOL) -> BOOL", "Logical not"),
+    ("==", "(== ANY ANY) -> BOOL", "Equality"),
+    (">", "(> INT INT) -> BOOL", "Greater than"),
+    ("<", "(< INT INT) -> BOOL", "Less than"),
+    (">=", "(>= INT INT) -> BOOL", "Greater or equal"),
+    ("<=", "(<= INT INT) -> BOOL", "Less or equal"),
+    ("+", "(+ INT INT) -> INT", "Addition"),
+    ("-", "(- INT INT) -> INT", "Subtraction"),
+    ("*", "(* INT INT) -> INT", "Multiplication"),
+    ("/", "(/ INT INT) -> INT", "Integer division"),
+    ("cons", "(cons *_) -> LIST", "Build a list from arguments"),
+    ("car", "(car LIST)", "First element"),
+    ("cdr", "(cdr LIST)", "All but the first element"),
+    ("get", "(get INDEX LIST)", "Element at INDEX, or NIL"),
+    ("len", "(len LIST) -> INT", "Length of a list"),
+    ("or-default", "(or-default VAL DEFAULT)", "VAL if not NIL else DEFAULT"),
+    ("map", "(map LIST FUNC) -> LIST", "Apply FUNC to each element"),
+    ("reduce", "(reduce LIST FUNC)", "Combine elements with FUNC"),
+    ("max", "(max LIST)", "Maximum of a list"),
+    ("min", "(min LIST)", "Minimum of a list"),
+    ("max-by", "(max-by LIST FUNC)", "Element with max FUNC value"),
+    ("min-by", "(min-by LIST FUNC)", "Element with min FUNC value"),
+    ("lambda", "(lambda (args) body)", "Define a function"),
+];
+
+/// Find matching close bracket from open_pos (byte index of open char). Returns byte index of close char.
+fn find_matching_close(s: &str, open_byte_pos: usize, open_c: char, close_c: char) -> Option<usize> {
+    let after_open = open_byte_pos + open_c.len_utf8();
+    let rest = s.get(after_open..)?;
+    let mut depth = 1u32;
+    for (i, c) in rest.char_indices() {
+        if c == open_c {
+            depth += 1;
+        } else if c == close_c {
+            depth -= 1;
+            if depth == 0 {
+                return Some(after_open + i);
+            }
+        }
+    }
+    None
+}
+
+/// Convert a cursor position in characters to byte offset.
+fn cursor_byte(s: &str, cursor_char: usize) -> usize {
+    s.char_indices().nth(cursor_char).map(|(i, _)| i).unwrap_or(s.len())
+}
+
+/// Index in `new` (byte offset) of the inserted character when `new.len() == old.len() + 1`.
+fn new_char_index(old: &str, new: &str) -> Option<usize> {
+    if new.len() != old.len() + 1 {
+        return None;
+    }
+    let mut new_chars = new.char_indices();
+    let mut old_chars = old.char_indices();
+    loop {
+        match (new_chars.next(), old_chars.next()) {
+            (Some((i, c_new)), Some((_, c_old))) => {
+                if c_new != c_old {
+                    return Some(i);
+                }
+            }
+            (Some((i, _)), None) => return Some(i),
+            (None, _) => return None,
+        }
+    }
+}
+
+/// Innermost bracket whose content contains the cursor, recorded as (content_start_byte, content_end_byte).
+/// content_end_byte is the byte position of the closing char, or s.len() if unclosed.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum InnermostBracket {
+    Paren(usize, usize),
+    Square(usize, usize),
+    Curly(usize, usize),
+}
+
+/// Pick the bracket whose open is closest to the cursor (largest content_start ≤ cursor) among
+/// brackets that either contain the cursor (close ≥ cursor) or are unclosed.
+pub fn innermost_around_cursor(s: &str, cursor_char: usize) -> Option<InnermostBracket> {
+    let cb = cursor_byte(s, cursor_char);
+    let mut best: Option<(usize, InnermostBracket)> = None;
+
+    let consider = |open_c: char, close_c: char, best: &mut Option<(usize, InnermostBracket)>, s: &str, cb: usize| {
+        let Some(open_pos) = s[..cb].rfind(open_c) else {
+            return;
+        };
+        let close = find_matching_close(s, open_pos, open_c, close_c);
+        let end = close.unwrap_or(s.len());
+        if close.is_some() && end < cb {
+            return;
+        }
+        let content_start = open_pos + open_c.len_utf8();
+        if content_start > cb {
+            return;
+        }
+        let bracket = match open_c {
+            '(' => InnermostBracket::Paren(content_start, end),
+            '[' => InnermostBracket::Square(content_start, end),
+            '{' => InnermostBracket::Curly(content_start, end),
+            _ => return,
+        };
+        if best.map_or(true, |(cs, _)| content_start > cs) {
+            *best = Some((content_start, bracket));
+        }
+    };
+    consider('(', ')', &mut best, s, cb);
+    consider('[', ']', &mut best, s, cb);
+    consider('{', '}', &mut best, s, cb);
+    best.map(|(_, b)| b)
+}
+
+/// Tokenize the expression for the preview row. Each token is a chunk of text the user wrote,
+/// classified as a literal kind so we can render chips for [..] and {..}.
+#[derive(Clone, Debug)]
+enum PreviewToken {
+    Text(String),
+    Team(String),    // raw inside [..]
+    Match(String),   // raw inside {..}
+    OpenBracket(char),
+    CloseBracket(char),
+}
+
+fn tokenize_preview(s: &str) -> Vec<PreviewToken> {
+    let mut out: Vec<PreviewToken> = Vec::new();
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    let mut text_buf = String::new();
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if c == '[' || c == '{' {
+            let close_c = if c == '[' { ']' } else { '}' };
+            // Find first close in same kind without trying to support nesting (literals don't nest).
+            let after = i + 1;
+            if let Some(rel) = s[after..].find(close_c) {
+                let inner = &s[after..after + rel];
+                if !text_buf.is_empty() {
+                    out.push(PreviewToken::Text(std::mem::take(&mut text_buf)));
+                }
+                if c == '[' {
+                    out.push(PreviewToken::Team(inner.to_string()));
+                } else {
+                    out.push(PreviewToken::Match(inner.to_string()));
+                }
+                i = after + rel + 1;
+                continue;
+            } else {
+                // Unclosed: render as open bracket then continue rendering remaining text
+                if !text_buf.is_empty() {
+                    out.push(PreviewToken::Text(std::mem::take(&mut text_buf)));
+                }
+                out.push(PreviewToken::OpenBracket(c));
+                i += 1;
+                continue;
+            }
+        }
+        if c == ']' || c == '}' {
+            if !text_buf.is_empty() {
+                out.push(PreviewToken::Text(std::mem::take(&mut text_buf)));
+            }
+            out.push(PreviewToken::CloseBracket(c));
+            i += 1;
+            continue;
+        }
+        text_buf.push(c);
+        i += 1;
+    }
+    if !text_buf.is_empty() {
+        out.push(PreviewToken::Text(text_buf));
+    }
+    out
+}
+
+#[derive(Clone, Debug)]
+struct TeamRefResolved {
+    profile_photo: Option<String>,
+    display: String,
+}
+
+/// Resolve a `[...]` literal to display info: pseudonym, tag→team, MatchName::winner/loser.
+/// Returns the kind label and resolved team if available.
+fn resolve_team_literal(
+    inner: &str,
+    team_options: &[TeamOption],
+    tags: &[TagSetupData],
+    matches: &[MatchSetupData],
+) -> (TeamRefKind, Option<TeamRefResolved>) {
+    let trimmed = inner.trim();
+    if let Some(rest) = trimmed.strip_suffix("::winner") {
+        let name = rest.trim();
+        let resolved = matches
+            .iter()
+            .find(|m| m.name.eq_ignore_ascii_case(name) && m.status.eq_ignore_ascii_case("COMPLETED"))
+            .and_then(|m| match m.match_winner.as_deref() {
+                Some(s) if s.eq_ignore_ascii_case("TEAM1") => m.team1.clone(),
+                Some(s) if s.eq_ignore_ascii_case("TEAM2") => m.team2.clone(),
+                _ => None,
+            })
+            .and_then(|tid| team_options.iter().find(|t| t.id == tid))
+            .map(|t| TeamRefResolved {
+                profile_photo: t.profile_photo.clone(),
+                display: t.pseudonym.clone().map(|p| format!("{p} ({})", t.id)).unwrap_or_else(|| t.id.clone()),
+            });
+        return (TeamRefKind::Winner(name.to_string()), resolved);
+    }
+    if let Some(rest) = trimmed.strip_suffix("::loser") {
+        let name = rest.trim();
+        let resolved = matches
+            .iter()
+            .find(|m| m.name.eq_ignore_ascii_case(name) && m.status.eq_ignore_ascii_case("COMPLETED"))
+            .and_then(|m| match m.match_winner.as_deref() {
+                Some(s) if s.eq_ignore_ascii_case("TEAM1") => m.team2.clone(),
+                Some(s) if s.eq_ignore_ascii_case("TEAM2") => m.team1.clone(),
+                _ => None,
+            })
+            .and_then(|tid| team_options.iter().find(|t| t.id == tid))
+            .map(|t| TeamRefResolved {
+                profile_photo: t.profile_photo.clone(),
+                display: t.pseudonym.clone().map(|p| format!("{p} ({})", t.id)).unwrap_or_else(|| t.id.clone()),
+            });
+        return (TeamRefKind::Loser(name.to_string()), resolved);
+    }
+    if trimmed.len() >= 5 && trimmed[..5].eq_ignore_ascii_case("tag::") {
+        let name = trimmed[5..].trim();
+        let resolved = tags
+            .iter()
+            .find(|t| t.name.eq_ignore_ascii_case(name))
+            .and_then(|t| t.team.clone())
+            .and_then(|tid| team_options.iter().find(|t| t.id == tid).cloned())
+            .map(|t| TeamRefResolved {
+                profile_photo: t.profile_photo.clone(),
+                display: t.pseudonym.clone().map(|p| format!("{p} ({})", t.id)).unwrap_or_else(|| t.id.clone()),
+            });
+        return (TeamRefKind::Tag(name.to_string()), resolved);
+    }
+    let team = team_options.iter().find(|t| t.id.eq_ignore_ascii_case(trimmed));
+    let resolved = team.map(|t| TeamRefResolved {
+        profile_photo: t.profile_photo.clone(),
+        display: t.pseudonym.clone().map(|p| format!("{p} ({})", t.id)).unwrap_or_else(|| t.id.clone()),
+    });
+    (TeamRefKind::Team(trimmed.to_string()), resolved)
+}
+
+#[derive(Clone, Debug)]
+enum TeamRefKind {
+    Team(String),
+    Tag(String),
+    Winner(String),
+    Loser(String),
+}
+
+#[derive(Clone, Debug)]
+enum AcOption {
+    Function {
+        name: String,
+        signature: String,
+        description: String,
+    },
+    Team {
+        insert: String,
+        display: String,
+        photo: Option<String>,
+    },
+    Tag {
+        insert: String,
+        display: String,
+    },
+    MatchRef {
+        insert: String,
+        display: String,
+        is_winner: bool,
+    },
+    Match {
+        insert: String,
+        display: String,
+    },
+}
+
+fn collect_function_options(prefix: &str) -> Vec<AcOption> {
+    let q = prefix.to_lowercase();
+    DSL_FUNCTIONS
+        .iter()
+        .filter(|(n, _, _)| q.is_empty() || n.to_lowercase().starts_with(&q))
+        .take(20)
+        .map(|(n, s, d)| AcOption::Function {
+            name: (*n).to_string(),
+            signature: (*s).to_string(),
+            description: (*d).to_string(),
+        })
+        .collect()
+}
+
+fn collect_team_options(
+    query: &str,
+    team_options: &[TeamOption],
+    tags: &[TagSetupData],
+    matches: &[MatchSetupData],
+) -> Vec<AcOption> {
+    let q = query.to_lowercase();
+    let mut out: Vec<AcOption> = Vec::new();
+    for t in team_options.iter() {
+        let id_lower = t.id.to_lowercase();
+        let pseudo_lower = t.pseudonym.as_deref().unwrap_or("").to_lowercase();
+        if q.is_empty() || id_lower.contains(&q) || pseudo_lower.contains(&q) {
+            let display = t
+                .pseudonym
+                .clone()
+                .map(|p| format!("{p} ({})", t.id))
+                .unwrap_or_else(|| t.id.clone());
+            out.push(AcOption::Team {
+                insert: t.id.clone(),
+                display,
+                photo: t.profile_photo.clone(),
+            });
+        }
+        if out.len() >= 20 {
+            break;
+        }
+    }
+    for m in matches.iter() {
+        if q.is_empty() || m.name.to_lowercase().contains(&q) {
+            out.push(AcOption::MatchRef {
+                insert: format!("{}::winner", m.name),
+                display: format!("{} winner", m.name),
+                is_winner: true,
+            });
+            out.push(AcOption::MatchRef {
+                insert: format!("{}::loser", m.name),
+                display: format!("{} loser", m.name),
+                is_winner: false,
+            });
+        }
+        if out.len() >= 30 {
+            break;
+        }
+    }
+    for tag in tags.iter() {
+        if q.is_empty() || tag.name.to_lowercase().contains(&q) {
+            out.push(AcOption::Tag {
+                insert: format!("tag::{}", tag.name),
+                display: tag.name.clone(),
+            });
+        }
+        if out.len() >= 35 {
+            break;
+        }
+    }
+    out.into_iter().take(25).collect()
+}
+
+fn collect_match_options(query: &str, matches: &[MatchSetupData]) -> Vec<AcOption> {
+    let q = query.to_lowercase();
+    matches
+        .iter()
+        .filter(|m| q.is_empty() || m.name.to_lowercase().contains(&q))
+        .take(25)
+        .map(|m| AcOption::Match {
+            insert: m.name.clone(),
+            display: m.name.clone(),
+        })
+        .collect()
+}
+
+#[component]
+pub fn AssEntry(
+    /// Unique suffix for input ID (e.g. "create", "edit", "modal"). Multiple instances need distinct IDs.
+    id_suffix: String,
+    value: String,
+    on_change: EventHandler<String>,
+    team_options: Vec<TeamOption>,
+    tags: Vec<TagSetupData>,
+    matches: Vec<MatchSetupData>,
+    /// For server-side validate-dsl on blur. Pass empty to skip server validation.
+    tournament_url: String,
+    #[props(default = String::from("e.g. (== 0 (losses [Team]))"))] placeholder: String,
+) -> Element {
+    let input_id = format!("ass-entry-{}", id_suffix);
+
+    let value_rc = Rc::new(value.clone());
+    let team_options_rc = Rc::new(team_options);
+    let tags_rc = Rc::new(tags);
+    let matches_rc = Rc::new(matches);
+
+    let mut cursor_pos = use_signal(|| None::<usize>);
+    let mut pending_cursor = use_signal(|| None::<usize>);
+    let mut ac_index = use_signal(|| 0usize);
+    let mut ac_open = use_signal(|| false);
+    let mut error_msg = use_signal(|| None::<String>);
+    let mut simplified_msg = use_signal(|| None::<String>);
+
+    // After auto-close insertions, we need to reposition the cursor on the next tick.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let id_eff = input_id.clone();
+        use_effect(move || {
+            if let Some(p) = pending_cursor() {
+                pending_cursor.set(None);
+                let id = id_eff.clone();
+                spawn(async move {
+                    gloo_timers::future::TimeoutFuture::new(0).await;
+                    if let Some(window) = web_sys::window() {
+                        if let Some(doc) = window.document() {
+                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
+                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
+                                    let _ = input.set_selection_range(p as u32, p as u32);
+                                    let _ = input.focus();
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    // Compute autocomplete state from the current value and cursor.
+    let v = value_rc.as_ref().clone();
+    let cur = cursor_pos();
+    let inn = cur.and_then(|c| innermost_around_cursor(&v, c));
+    let cursor_b = cur.map(|c| cursor_byte(&v, c)).unwrap_or(0);
+
+    let ac_options: Vec<AcOption> = if ac_open() {
+        match &inn {
+            Some(InnermostBracket::Paren(cs, ce)) => {
+                let end = (*ce).min(cursor_b).max(*cs);
+                let prefix = v[*cs..end].split_whitespace().next().unwrap_or("");
+                collect_function_options(prefix)
+            }
+            Some(InnermostBracket::Square(cs, ce)) => {
+                let end = (*ce).min(cursor_b).max(*cs);
+                let q = v[*cs..end].trim();
+                collect_team_options(q, team_options_rc.as_ref(), tags_rc.as_ref(), matches_rc.as_ref())
+            }
+            Some(InnermostBracket::Curly(cs, ce)) => {
+                let end = (*ce).min(cursor_b).max(*cs);
+                let q = v[*cs..end].trim();
+                collect_match_options(q, matches_rc.as_ref())
+            }
+            None => vec![],
+        }
+    } else {
+        vec![]
+    };
+
+    let ac_idx = ac_index().min(ac_options.len().saturating_sub(1));
+
+    let preview_tokens = tokenize_preview(&v);
+    let base_url = api::base_url();
+
+    let v_for_oninput = v.clone();
+    let value_rc_input = value_rc.clone();
+    let on_change_input = on_change.clone();
+    let oninput_handler = move |e: Event<FormData>| {
+        let new_val = e.value();
+        let old = value_rc_input.as_ref().clone();
+        let _ = v_for_oninput;
+        // Auto-close brackets on single-char insert.
+        let (out, after_open) = if let Some(byte_i) = new_char_index(&old, &new_val) {
+            let open_c = new_val[byte_i..].chars().next().unwrap_or('\0');
+            let closing = match open_c {
+                '(' => Some(')'),
+                '[' => Some(']'),
+                '{' => Some('}'),
+                _ => None,
+            };
+            if let Some(close_c) = closing {
+                let char_end = byte_i + open_c.len_utf8();
+                let out_str = format!("{}{}{}", &new_val[..char_end], close_c, &new_val[char_end..]);
+                (out_str, Some(char_end))
+            } else {
+                (new_val, None)
+            }
+        } else {
+            (new_val, None)
+        };
+        on_change_input.call(out);
+        ac_open.set(true);
+        ac_index.set(0);
+        error_msg.set(None);
+        simplified_msg.set(None);
+        if let Some(byte_after_open) = after_open {
+            // ASCII brackets only — byte position equals char position.
+            pending_cursor.set(Some(byte_after_open));
+        }
+    };
+
+    let id_for_keydown = input_id.clone();
+    let value_rc_kd = value_rc.clone();
+    let on_change_kd = on_change.clone();
+    let ac_options_kd = ac_options.clone();
+    let onkeydown_handler = move |ev: Event<KeyboardData>| {
+        let key = ev.key().to_string();
+        let n = ac_options_kd.len();
+        if ac_open() && n > 0 {
+            if key == "ArrowDown" {
+                ev.prevent_default();
+                ac_index.set((ac_idx + 1) % n);
+                return;
+            }
+            if key == "ArrowUp" {
+                ev.prevent_default();
+                ac_index.set((ac_idx + n - 1) % n);
+                return;
+            }
+            if key == "Tab" || (key == "Enter" && !ev.modifiers().contains(Modifiers::SHIFT)) {
+                if let Some(opt) = ac_options_kd.get(ac_idx) {
+                    ev.prevent_default();
+                    let v_now = value_rc_kd.as_ref().clone();
+                    let cur_char = cursor_pos().unwrap_or(0);
+                    let cur_b = cursor_byte(&v_now, cur_char);
+                    let inn_now = innermost_around_cursor(&v_now, cur_char);
+                    match (opt, inn_now) {
+                        (AcOption::Function { name, .. }, Some(InnermostBracket::Paren(cs, ce))) => {
+                            // Replace the prefix word inside the parens with the function name.
+                            let end = ce.min(cur_b).max(cs);
+                            let prefix_end = v_now[cs..end]
+                                .find(|c: char| c.is_whitespace())
+                                .map(|i| cs + i)
+                                .unwrap_or(end);
+                            let new_v = format!("{}{}{}", &v_now[..cs], name, &v_now[prefix_end..]);
+                            let cs_chars = v_now[..cs].chars().count();
+                            let new_cursor = cs_chars + name.chars().count();
+                            on_change_kd.call(new_v);
+                            pending_cursor.set(Some(new_cursor));
+                            ac_open.set(false);
+                            return;
+                        }
+                        (
+                            AcOption::Team { insert, .. }
+                            | AcOption::Tag { insert, .. }
+                            | AcOption::MatchRef { insert, .. },
+                            Some(InnermostBracket::Square(cs, ce)),
+                        ) => {
+                            let end = ce.min(cur_b).max(cs);
+                            // Replace from cs to end with insert
+                            let new_v = format!("{}{}{}", &v_now[..cs], insert, &v_now[end..]);
+                            let cs_chars = v_now[..cs].chars().count();
+                            let new_cursor = cs_chars + insert.chars().count();
+                            on_change_kd.call(new_v);
+                            pending_cursor.set(Some(new_cursor));
+                            ac_open.set(false);
+                            return;
+                        }
+                        (AcOption::Match { insert, .. }, Some(InnermostBracket::Curly(cs, ce))) => {
+                            let end = ce.min(cur_b).max(cs);
+                            let new_v = format!("{}{}{}", &v_now[..cs], insert, &v_now[end..]);
+                            let cs_chars = v_now[..cs].chars().count();
+                            let new_cursor = cs_chars + insert.chars().count();
+                            on_change_kd.call(new_v);
+                            pending_cursor.set(Some(new_cursor));
+                            ac_open.set(false);
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            if key == "Escape" {
+                ev.prevent_default();
+                ac_open.set(false);
+                return;
+            }
+        }
+        // Block raw Enter so it doesn't submit the form (Shift+Enter still bubbles up).
+        if key == "Enter" && !ev.modifiers().contains(Modifiers::SHIFT) {
+            ev.prevent_default();
+        }
+        let _ = id_for_keydown.clone();
+    };
+
+    let id_for_keyup = input_id.clone();
+    let onkeyup_handler = move |_| {
+        let id = id_for_keyup.clone();
+        spawn(async move {
+            #[cfg(target_arch = "wasm32")]
+            {
+                gloo_timers::future::TimeoutFuture::new(0).await;
+                if let Some(window) = web_sys::window() {
+                    if let Some(doc) = window.document() {
+                        if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
+                            if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
+                                if let Ok(Some(sel)) = input.selection_start() {
+                                    cursor_pos.set(Some(sel as usize));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            let _ = id;
+        });
+    };
+
+    let id_for_focus = input_id.clone();
+    let onfocus_handler = move |_| {
+        ac_open.set(true);
+        let id = id_for_focus.clone();
+        spawn(async move {
+            #[cfg(target_arch = "wasm32")]
+            {
+                gloo_timers::future::TimeoutFuture::new(0).await;
+                if let Some(window) = web_sys::window() {
+                    if let Some(doc) = window.document() {
+                        if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
+                            if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
+                                if let Ok(Some(sel)) = input.selection_start() {
+                                    cursor_pos.set(Some(sel as usize));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            let _ = id;
+        });
+    };
+
+    let url_for_blur = tournament_url.clone();
+    let value_rc_blur = value_rc.clone();
+    let onblur_handler = move |_| {
+        ac_open.set(false);
+        let expr = value_rc_blur.as_ref().clone();
+        let url = url_for_blur.clone();
+        if expr.trim().is_empty() {
+            error_msg.set(None);
+            simplified_msg.set(None);
+            return;
+        }
+        if url.is_empty() {
+            return;
+        }
+        spawn(async move {
+            match api::validate_dsl(&url, &expr).await {
+                Ok(res) => {
+                    if res.valid {
+                        error_msg.set(None);
+                        simplified_msg.set(res.simplified);
+                    } else {
+                        error_msg.set(res.error);
+                        simplified_msg.set(None);
+                    }
+                }
+                Err(e) => {
+                    error_msg.set(Some(e));
+                    simplified_msg.set(None);
+                }
+            }
+        });
+    };
+
+    // Build dropdown items.
+    let team_options_for_render = team_options_rc.clone();
+    let tags_for_render = tags_rc.clone();
+    let matches_for_render = matches_rc.clone();
+    let value_rc_click = value_rc.clone();
+    let on_change_click = on_change.clone();
+    let click_rc: Rc<RefCell<Box<dyn FnMut(usize)>>> = {
+        let opts = ac_options.clone();
+        Rc::new(RefCell::new(Box::new(move |idx: usize| {
+            let Some(opt) = opts.get(idx).cloned() else {
+                return;
+            };
+            let v_now = value_rc_click.as_ref().clone();
+            let cur_char = cursor_pos().unwrap_or(v_now.chars().count());
+            let cur_b = cursor_byte(&v_now, cur_char);
+            let inn_now = innermost_around_cursor(&v_now, cur_char);
+            match (opt, inn_now) {
+                (AcOption::Function { name, .. }, Some(InnermostBracket::Paren(cs, ce))) => {
+                    let end = ce.min(cur_b).max(cs);
+                    let prefix_end = v_now[cs..end]
+                        .find(|c: char| c.is_whitespace())
+                        .map(|i| cs + i)
+                        .unwrap_or(end);
+                    let new_v = format!("{}{}{}", &v_now[..cs], name, &v_now[prefix_end..]);
+                    let cs_chars = v_now[..cs].chars().count();
+                    let new_cursor = cs_chars + name.chars().count();
+                    on_change_click.call(new_v);
+                    pending_cursor.set(Some(new_cursor));
+                    ac_open.set(false);
+                }
+                (
+                    AcOption::Team { insert, .. }
+                    | AcOption::Tag { insert, .. }
+                    | AcOption::MatchRef { insert, .. },
+                    Some(InnermostBracket::Square(cs, ce)),
+                ) => {
+                    let end = ce.min(cur_b).max(cs);
+                    let new_v = format!("{}{}{}", &v_now[..cs], insert, &v_now[end..]);
+                    let cs_chars = v_now[..cs].chars().count();
+                    let new_cursor = cs_chars + insert.chars().count();
+                    on_change_click.call(new_v);
+                    pending_cursor.set(Some(new_cursor));
+                    ac_open.set(false);
+                }
+                (AcOption::Match { insert, .. }, Some(InnermostBracket::Curly(cs, ce))) => {
+                    let end = ce.min(cur_b).max(cs);
+                    let new_v = format!("{}{}{}", &v_now[..cs], insert, &v_now[end..]);
+                    let cs_chars = v_now[..cs].chars().count();
+                    let new_cursor = cs_chars + insert.chars().count();
+                    on_change_click.call(new_v);
+                    pending_cursor.set(Some(new_cursor));
+                    ac_open.set(false);
+                }
+                _ => {}
+            }
+        })))
+    };
+
+    let dropdown_items: Vec<_> = ac_options
+        .iter()
+        .enumerate()
+        .map(|(idx, opt)| {
+            let click = click_rc.clone();
+            let is_active = idx == ac_idx;
+            let li_class = if is_active {
+                "ass-entry-ac-item ass-entry-ac-item-active"
+            } else {
+                "ass-entry-ac-item"
+            };
+            let inner = match opt {
+                AcOption::Function { name, signature, description } => {
+                    let n = name.clone();
+                    let s = signature.clone();
+                    let d = description.clone();
+                    rsx! {
+                        span { class: "ass-entry-ac-fn-name", "{n}" }
+                        span { class: "ass-entry-ac-fn-sig text-muted", " {s}" }
+                        div { class: "ass-entry-ac-fn-desc text-muted small", "{d}" }
+                    }
+                }
+                AcOption::Team { display, photo, .. } => {
+                    let d = display.clone();
+                    if let Some(p) = photo.clone() {
+                        rsx! {
+                            img {
+                                class: "team-token-avatar small me-1 rounded-circle",
+                                style: "width: 1.4em; height: 1.4em; object-fit: cover;",
+                                src: "{base_url}/static/{p}",
+                                alt: "{d}",
+                            }
+                            span { "{d}" }
+                        }
+                    } else {
+                        rsx! {
+                            span { class: "team-token-avatar small me-1", "{d.chars().next().unwrap_or('?')}" }
+                            span { "{d}" }
+                        }
+                    }
+                }
+                AcOption::Tag { display, .. } => {
+                    let d = display.clone();
+                    rsx! {
+                        img { class: "icon-primary-svg me-1", src: "{base_url}/static/tag.svg", alt: "Tag", style: "width: 1.25em; height: 1.25em;" }
+                        span { "{d}" }
+                    }
+                }
+                AcOption::MatchRef { display, is_winner, .. } => {
+                    let d = display.clone();
+                    let badge = if *is_winner { "winner" } else { "loser" };
+                    rsx! {
+                        img { class: "icon-primary-svg me-1", src: "{base_url}/static/reference.svg", alt: "Reference", style: "width: 1.25em; height: 1.25em;" }
+                        span { "{d}" }
+                        span { class: "team-token-badge ms-1 {badge}-badge small", "{badge}" }
+                    }
+                }
+                AcOption::Match { display, .. } => {
+                    let d = display.clone();
+                    rsx! {
+                        img { class: "icon-primary-svg me-1", src: "{base_url}/static/reference.svg", alt: "Match", style: "width: 1.25em; height: 1.25em;" }
+                        span { "{d}" }
+                    }
+                }
+            };
+            rsx! {
+                li {
+                    key: "{idx}",
+                    class: "{li_class}",
+                    onmousedown: move |ev: Event<MouseData>| { ev.prevent_default(); },
+                    onclick: move |_| { click.borrow_mut()(idx); },
+                    onmouseenter: move |_| { ac_index.set(idx); },
+                    {inner}
+                }
+            }
+        })
+        .collect();
+
+    let preview_chips: Vec<_> = preview_tokens
+        .iter()
+        .enumerate()
+        .map(|(i, tok)| {
+            match tok {
+                PreviewToken::Text(s) => {
+                    let s = s.clone();
+                    rsx! { span { key: "{i}", class: "ass-entry-preview-text", "{s}" } }
+                }
+                PreviewToken::OpenBracket(c) => {
+                    let s = c.to_string();
+                    rsx! { span { key: "{i}", class: "ass-entry-preview-bracket text-warning", "{s}" } }
+                }
+                PreviewToken::CloseBracket(c) => {
+                    let s = c.to_string();
+                    rsx! { span { key: "{i}", class: "ass-entry-preview-bracket text-warning", "{s}" } }
+                }
+                PreviewToken::Team(inner) => {
+                    let (kind, resolved) = resolve_team_literal(
+                        inner,
+                        team_options_for_render.as_ref(),
+                        tags_for_render.as_ref(),
+                        matches_for_render.as_ref(),
+                    );
+                    let (chip_class, label, icon) = match &kind {
+                        TeamRefKind::Team(name) => ("team-token-chip team-token-chip-team", name.clone(), None),
+                        TeamRefKind::Tag(name) => (
+                            "team-token-chip team-token-chip-tag",
+                            name.clone(),
+                            Some(("tag.svg", "Tag")),
+                        ),
+                        TeamRefKind::Winner(name) => (
+                            "team-token-chip team-token-chip-winner",
+                            format!("{} winner", name),
+                            Some(("reference.svg", "Reference")),
+                        ),
+                        TeamRefKind::Loser(name) => (
+                            "team-token-chip team-token-chip-loser",
+                            format!("{} loser", name),
+                            Some(("reference.svg", "Reference")),
+                        ),
+                    };
+                    let avatar = match (&kind, &resolved) {
+                        (TeamRefKind::Team(_), Some(r)) => {
+                            if let Some(p) = r.profile_photo.clone() {
+                                rsx! { img {
+                                    src: "{base_url}/static/{p}",
+                                    alt: "",
+                                    class: "team-token-avatar rounded-circle",
+                                    style: "width: 1.4em; height: 1.4em; object-fit: cover;"
+                                } }
+                            } else {
+                                rsx! { span { class: "team-token-avatar", "{r.display.chars().next().unwrap_or('?')}" } }
+                            }
+                        }
+                        (TeamRefKind::Team(name), None) => {
+                            rsx! { span { class: "team-token-avatar", "{name.chars().next().unwrap_or('?')}" } }
+                        }
+                        _ => {
+                            if let Some((icon_name, alt)) = icon {
+                                rsx! { img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/{icon_name}", alt: "{alt}" } }
+                            } else {
+                                rsx! { }
+                            }
+                        }
+                    };
+                    let resolved_arrow = if let Some(r) = resolved.clone() {
+                        if !matches!(kind, TeamRefKind::Team(_)) {
+                            let disp = r.display.clone();
+                            let photo = r.profile_photo.clone();
+                            rsx! {
+                                span { class: "team-token-resolved text-muted ms-1",
+                                    " → "
+                                    if let Some(p) = photo {
+                                        img {
+                                            src: "{base_url}/static/{p}",
+                                            alt: "",
+                                            class: "team-token-avatar small rounded-circle ms-1",
+                                            style: "width: 1em; height: 1em; object-fit: cover; vertical-align: middle;"
+                                        }
+                                    } else {
+                                        span { class: "team-token-avatar small ms-1", style: "display: inline-flex; width: 1em; height: 1em; align-items: center; justify-content: center; font-size: 0.85em;", "{disp.chars().next().unwrap_or('?')}" }
+                                    }
+                                    span { "{disp}" }
+                                }
+                            }
+                        } else {
+                            rsx! { }
+                        }
+                    } else {
+                        rsx! { }
+                    };
+                    rsx! {
+                        span { key: "{i}", class: "{chip_class}",
+                            {avatar}
+                            span { class: "team-token-label", "{label}" }
+                            {resolved_arrow}
+                        }
+                    }
+                }
+                PreviewToken::Match(inner) => {
+                    let name = inner.trim().to_string();
+                    let known = matches_for_render.iter().any(|m| m.name.eq_ignore_ascii_case(&name));
+                    let extra_class = if known { "" } else { " ass-entry-preview-unknown" };
+                    rsx! {
+                        span { key: "{i}", class: "team-token-chip team-token-chip-match{extra_class}",
+                            img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/reference.svg", alt: "Match" }
+                            span { class: "team-token-label", "{name}" }
+                        }
+                    }
+                }
+            }
+        })
+        .collect();
+
+    rsx! {
+        div { class: "ass-entry position-relative",
+            input {
+                id: "{input_id}",
+                class: "form-control font-monospace ass-entry-input",
+                "type": "text",
+                placeholder: "{placeholder}",
+                value: "{value}",
+                oninput: oninput_handler,
+                onkeydown: onkeydown_handler,
+                onkeyup: onkeyup_handler,
+                onfocus: onfocus_handler,
+                onblur: onblur_handler,
+            }
+            if ac_open() && !ac_options.is_empty() {
+                ul { class: "ass-entry-ac dropdown-menu show",
+                    for item in dropdown_items.iter() {
+                        {item.clone()}
+                    }
+                }
+            }
+            if !value.trim().is_empty() {
+                div { class: "ass-entry-preview small",
+                    for chip in preview_chips.iter() {
+                        {chip.clone()}
+                    }
+                }
+            }
+            if let Some(err) = error_msg() {
+                div { class: "form-text text-danger ass-entry-error", "✗ {err}" }
+            } else if let Some(simp) = simplified_msg() {
+                div { class: "form-text text-success", "✓ Valid (simplified: {simp})" }
+            } else if !value.trim().is_empty() {
+                div { class: "form-text text-success", "✓" }
+            }
+        }
+    }
+}

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -11,6 +11,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use super::TeamSelectionField;
+use crate::components::AssEntry;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsCast as _;
 
@@ -535,30 +536,6 @@ pub fn Schedule(url: String) -> Element {
 // ... EditMatchModal ...
 
 /// Matches on the given field, sorted by nominal_start_time descending (most recent first).
-/// DSL function names and signatures for skip-condition docs popup (from app/utils/parser.py).
-const DSL_FUNCTIONS: &[(&str, &str)] = &[
-    ("wins", "(wins TEAM) -> INT"),
-    ("losses", "(losses TEAM) -> INT"),
-    ("winner", "(winner MATCH) -> TEAM"),
-    ("loser", "(loser MATCH) -> TEAM"),
-    ("points-won", "(points-won TEAM MATCH) -> INT"),
-    ("points-lost", "(points-lost TEAM MATCH) -> INT"),
-    ("is-skipped", "(is-skipped MATCH) -> BOOL"),
-    ("+", "(+ INT INT) -> INT"),
-    ("-", "(- INT INT) -> INT"),
-    ("*", "(* INT INT) -> INT"),
-    ("/", "(/ INT INT) -> INT"),
-    (">", "(> INT INT) -> BOOL"),
-    ("<", "(< INT INT) -> BOOL"),
-    (">=", "(>= INT INT) -> BOOL"),
-    ("<=", "(<= INT INT) -> BOOL"),
-    ("==", "(== ANY ANY) -> BOOL"),
-    ("or", "(or BOOL BOOL) -> BOOL"),
-    ("and", "(and BOOL BOOL) -> BOOL"),
-    ("not", "(not BOOL) -> BOOL"),
-    ("if", "(if COND IF_TRUE IF_FALSE)"),
-];
-
 fn matches_on_field_sorted<'a>(
     matches: &'a [MatchSetupData],
     field_name: &str,
@@ -571,119 +548,6 @@ fn matches_on_field_sorted<'a>(
         .collect();
     v.sort_by(|a, b| b.nominal_start_time.as_deref().cmp(&a.nominal_start_time.as_deref()));
     v
-}
-
-/// Index in `new` (byte offset) where the single added character is, when new.len() == old.len() + 1.
-fn skip_condition_new_char_index(old: &str, new: &str) -> Option<usize> {
-    if new.len() != old.len() + 1 {
-        return None;
-    }
-    let mut new_chars = new.char_indices();
-    let mut old_chars = old.char_indices();
-    loop {
-        match (new_chars.next(), old_chars.next()) {
-            (Some((i, c_new)), Some((_, c_old))) => {
-                if c_new != c_old {
-                    return Some(i);
-                }
-            }
-            (Some((i, _)), None) => return Some(i),
-            (None, _) => return None,
-        }
-    }
-}
-
-/// Find matching close bracket from open_pos (byte index of open char). Returns byte index of close char.
-fn skip_condition_find_matching_close(s: &str, open_byte_pos: usize, open_c: char, close_c: char) -> Option<usize> {
-    let rest = s.get(open_byte_pos..)?;
-    let mut depth = 1u32;
-    for (i, c) in rest.char_indices() {
-        if c == open_c {
-            depth += 1;
-        } else if c == close_c {
-            depth = depth.saturating_sub(1);
-            if depth == 0 {
-                return Some(open_byte_pos + i);
-            }
-        }
-    }
-    None
-}
-
-/// Innermost unclosed bracket: (content_start_byte, content_end_byte). content_end_byte = position of close or s.len().
-#[allow(dead_code)]
-fn skip_condition_innermost_unclosed(s: &str, open_c: char, close_c: char) -> Option<(usize, usize)> {
-    let open_len = open_c.len_utf8();
-    let mut search_end = s.len();
-    loop {
-        let Some(open_pos) = s[..search_end].rfind(open_c) else {
-            break;
-        };
-        let close_pos = skip_condition_find_matching_close(s, open_pos, open_c, close_c);
-        match close_pos {
-            None => return Some((open_pos + open_len, s.len())),
-            Some(_end) => search_end = open_pos,
-        }
-    }
-    None
-}
-
-/// Cursor position in character index (e.g. from selection_start).
-fn skip_condition_cursor_byte(s: &str, cursor_char: usize) -> usize {
-    s.char_indices()
-        .nth(cursor_char)
-        .map(|(i, _)| i)
-        .unwrap_or(s.len())
-}
-
-/// Innermost bracket that contains the cursor. Uses largest content_start (most recent open before cursor).
-#[derive(Clone, Copy)]
-enum InnermostBracket {
-    Paren(usize, usize), // content_start_byte, content_end_byte
-    Square(usize, usize),
-    Curly(usize, usize),
-}
-
-fn skip_condition_innermost_around_cursor(s: &str, cursor_char: usize) -> Option<InnermostBracket> {
-    let cursor_byte = skip_condition_cursor_byte(s, cursor_char);
-    let mut best: Option<(usize, InnermostBracket)> = None; // (content_start, bracket)
-    if let Some(open_pos) = s[..cursor_byte].rfind('(') {
-        let close_pos = skip_condition_find_matching_close(s, open_pos, '(', ')');
-        let content_end = close_pos.unwrap_or(s.len());
-        if close_pos.is_none() || content_end >= cursor_byte {
-            let content_start = open_pos + 1;
-            if content_start <= cursor_byte {
-                if best.map_or(true, |(cs, _)| content_start > cs) {
-                    best = Some((content_start, InnermostBracket::Paren(content_start, content_end)));
-                }
-            }
-        }
-    }
-    if let Some(open_pos) = s[..cursor_byte].rfind('[') {
-        let close_pos = skip_condition_find_matching_close(s, open_pos, '[', ']');
-        let content_end = close_pos.unwrap_or(s.len());
-        if close_pos.is_none() || content_end >= cursor_byte {
-            let content_start = open_pos + 1;
-            if content_start <= cursor_byte {
-                if best.map_or(true, |(cs, _)| content_start > cs) {
-                    best = Some((content_start, InnermostBracket::Square(content_start, content_end)));
-                }
-            }
-        }
-    }
-    if let Some(open_pos) = s[..cursor_byte].rfind('{') {
-        let close_pos = skip_condition_find_matching_close(s, open_pos, '{', '}');
-        let content_end = close_pos.unwrap_or(s.len());
-        if close_pos.is_none() || content_end >= cursor_byte {
-            let content_start = open_pos + 1;
-            if content_start <= cursor_byte {
-                if best.map_or(true, |(cs, _)| content_start > cs) {
-                    best = Some((content_start, InnermostBracket::Curly(content_start, content_end)));
-                }
-            }
-        }
-    }
-    best.map(|(_, b)| b)
 }
 
 /// Skip condition help modal (same content as Flask #dslHelpModal).
@@ -797,14 +661,6 @@ fn CreateMatchModal(
     let mut stones_per_set = use_signal(|| 100u32);
     let ribbon = use_signal(|| false);
     let mut skip_condition = use_signal(|| "".to_string());
-    let mut skip_condition_error = use_signal(|| None::<String>);
-    let mut skip_condition_simplified = use_signal(|| None::<String>);
-    let mut skip_condition_cursor = use_signal(|| None::<usize>);
-    let mut skip_condition_cursor_pos = use_signal(|| None::<usize>);
-    let mut skip_docs_visible = use_signal(|| false);
-    let mut skip_bracket_ac_visible = use_signal(|| false);
-    let mut skip_bracket_ac_team = use_signal(|| true);
-    let mut skip_bracket_ac_index = use_signal(|| 0usize);
     let mut skip_condition_help_open = use_signal(|| false);
 
     let mut error = use_signal(|| None::<String>);
@@ -820,56 +676,6 @@ fn CreateMatchModal(
                         if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
                             let _ = input.focus();
                         }
-                    }
-                }
-            }
-        });
-    });
-
-    #[cfg(target_arch = "wasm32")]
-    use_effect(move || {
-        let pos = skip_condition_cursor();
-        if let Some(p) = pos {
-            skip_condition_cursor.set(None);
-            let id = "skip-condition-input-create".to_string();
-            spawn(async move {
-                gloo_timers::future::TimeoutFuture::new(0).await;
-                if let Some(window) = web_sys::window() {
-                    if let Some(doc) = window.document() {
-                        if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                            if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                let _ = input.set_selection_range(p as u32, p as u32);
-                                let _ = input.focus();
-                            }
-                        }
-                    }
-                }
-            });
-        }
-    });
-
-    let tournament_url_val = tournament_url.clone();
-    use_effect(move || {
-        let expr = skip_condition();
-        let _ = expr.clone();
-        if expr.trim().is_empty() {
-            return;
-        }
-        let expr_captured = expr.clone();
-        let url = tournament_url_val.clone();
-        #[cfg(target_arch = "wasm32")]
-        spawn(async move {
-            gloo_timers::future::TimeoutFuture::new(3000).await;
-            let current = skip_condition();
-            if current == expr_captured {
-                match api::validate_dsl(&url, &expr_captured).await {
-                    Ok(res) => {
-                        skip_condition_error.set(if res.valid { None } else { res.error.clone() });
-                        skip_condition_simplified.set(if res.valid { res.simplified } else { None });
-                    }
-                    Err(e) => {
-                        skip_condition_error.set(Some(e));
-                        skip_condition_simplified.set(None);
                     }
                 }
             }
@@ -954,16 +760,13 @@ fn CreateMatchModal(
                 match api::validate_dsl(&tournament_url, &skip_condition()).await {
                     Ok(res) => {
                         if !res.valid {
-                            skip_condition_error.set(res.error);
-                            skip_condition_simplified.set(None);
+                            error.set(Some(format!("Skip condition: {}", res.error.unwrap_or_else(|| "invalid".to_string()))));
                             saving.set(false);
                             return;
                         }
-                        skip_condition_simplified.set(res.simplified);
                     }
                     Err(e) => {
-                        skip_condition_error.set(Some(e));
-                        skip_condition_simplified.set(None);
+                        error.set(Some(format!("Skip condition: {}", e)));
                         saving.set(false);
                         return;
                     }
@@ -1028,12 +831,10 @@ fn CreateMatchModal(
             if (schedule_type() == "SAFE" || schedule_type() == "FAST") && !skip_condition().trim().is_empty() {
                 if let Ok(res) = api::validate_dsl(&tournament_url, &skip_condition()).await {
                     if !res.valid {
-                        skip_condition_error.set(res.error);
-                        skip_condition_simplified.set(None);
+                        error.set(Some(format!("Skip condition: {}", res.error.unwrap_or_else(|| "invalid".to_string()))));
                         saving.set(false);
                         return;
                     }
-                    skip_condition_simplified.set(res.simplified);
                 }
             }
             let refs_vec: Vec<String> = refs()
@@ -1105,192 +906,6 @@ fn CreateMatchModal(
             ev.stop_propagation();
             submit_create_rc2.borrow_mut()();
         }
-    };
-
-    let sc_val = skip_condition();
-    let cursor_char = skip_condition_cursor_pos();
-    let innermost = cursor_char.and_then(|c| skip_condition_innermost_around_cursor(&sc_val, c));
-    let cursor_byte = cursor_char.map(|c| skip_condition_cursor_byte(&sc_val, c)).unwrap_or(0);
-    let show_skip_docs = matches!(innermost, Some(InnermostBracket::Paren(_, _)));
-    let docs_prefix = match &innermost {
-        Some(InnermostBracket::Paren(cs, ce)) => {
-            sc_val[*cs..*ce].trim().split_whitespace().next().unwrap_or("").to_lowercase()
-        }
-        _ => String::new(),
-    };
-    let docs_filtered: Vec<_> = if show_skip_docs {
-        DSL_FUNCTIONS
-            .iter()
-            .filter(|(n, _)| n.to_lowercase().starts_with(docs_prefix.as_str()))
-            .take(12)
-            .collect()
-    } else {
-        vec![]
-    };
-    let (bracket_is_team, bracket_query) = match &innermost {
-        Some(InnermostBracket::Square(cs, ce)) => {
-            let end = (*ce).min(cursor_byte).max(*cs);
-            (true, sc_val[*cs..end].trim().to_lowercase())
-        }
-        Some(InnermostBracket::Curly(cs, ce)) => {
-            let end = (*ce).min(cursor_byte).max(*cs);
-            (false, sc_val[*cs..end].trim().to_lowercase())
-        }
-        _ => (true, String::new()),
-    };
-    let show_bracket_ac = matches!(innermost, Some(InnermostBracket::Square(_, _)) | Some(InnermostBracket::Curly(_, _)));
-    let bracket_ac_idx_raw = skip_bracket_ac_index();
-    // (insert_value, display_value, profile_photo for teams). Teams: insert id; matches: insert name.
-    // Team bracket also includes MatchName::winner and MatchName::loser.
-    let bracket_options: Vec<(String, String, Option<String>)> = if show_bracket_ac && bracket_is_team {
-        let team_opts: Vec<_> = data
-            .team_options
-            .iter()
-            .filter(|t| {
-                let disp = t.pseudonym.as_deref().unwrap_or(t.id.as_str());
-                disp.to_lowercase().contains(bracket_query.as_str())
-                    || t.id.to_lowercase().contains(bracket_query.as_str())
-            })
-            .map(|t| {
-                (
-                    t.id.clone(),
-                    t.pseudonym.clone().unwrap_or_else(|| t.id.clone()),
-                    t.profile_photo.clone(),
-                )
-            })
-            .take(15)
-            .collect();
-        let match_qual_opts: Vec<_> = data
-            .matches
-            .iter()
-            .flat_map(|m| {
-                let w = (format!("{}::winner", m.name), format!("{}::winner", m.name), None);
-                let l = (format!("{}::loser", m.name), format!("{}::loser", m.name), None);
-                [w, l]
-            })
-            .filter(|(s, _, _)| s.to_lowercase().contains(bracket_query.as_str()))
-            .take(15)
-            .collect();
-        let tag_opts: Vec<_> = data
-            .tags
-            .iter()
-            .filter(|t| t.name.to_lowercase().contains(bracket_query.as_str()))
-            .map(|t| (format!("tag::{}", t.name), t.name.clone(), None))
-            .take(15)
-            .collect();
-        team_opts
-            .into_iter()
-            .chain(match_qual_opts)
-            .chain(tag_opts)
-            .take(20)
-            .collect()
-    } else if show_bracket_ac {
-        data.matches
-            .iter()
-            .filter(|m| m.name.to_lowercase().contains(bracket_query.as_str()))
-            .map(|m| (m.name.clone(), m.name.clone(), None))
-            .take(15)
-            .collect()
-    } else {
-        vec![]
-    };
-    let bracket_ac_idx = bracket_ac_idx_raw.min(bracket_options.len().saturating_sub(1));
-    let docs_items: Vec<_> = if show_skip_docs && !docs_filtered.is_empty() {
-        docs_filtered
-            .iter()
-            .map(|(dn, ds)| {
-                let fname = dn.to_string();
-                rsx! {
-                    li {
-                        class: "py-1 px-2 rounded",
-                        onclick: move |_| {
-                            let v = skip_condition();
-                            if let Some(i) = v.rfind('(') {
-                                skip_condition.set(format!("{}{}", &v[..=i], fname));
-                            }
-                            skip_docs_visible.set(false);
-                        },
-                        span { class: "fw-medium text-primary", "{dn}" }
-                        span { class: "text-muted ms-1", " {ds}" }
-                    }
-                }
-            })
-            .collect()
-    } else {
-        vec![]
-    };
-    let base_url_create = api::base_url();
-    let bracket_option_items: Vec<_> = if show_bracket_ac && !bracket_options.is_empty() {
-        bracket_options
-            .iter()
-            .enumerate()
-            .map(|(idx, (insert_val, display_val, photo))| {
-                let opt_insert = insert_val.clone();
-                let opt_display = display_val.clone();
-                let opt_photo = photo.clone();
-                let is_team = bracket_is_team;
-                let is_cur = bracket_ac_idx == idx;
-                let li_class = if is_cur {
-                    "py-1 px-2 rounded bg-primary text-white"
-                } else {
-                    "py-1 px-2 rounded"
-                };
-                let avatar_node = if is_team {
-                    if opt_insert.ends_with("::winner") || opt_insert.ends_with("::loser") {
-                        rsx! {
-                            img { class: "icon-primary-svg me-1", src: "{base_url_create}/static/reference.svg", alt: "Reference", style: "width: 1.25em; height: 1.25em;" }
-                        }
-                    } else if opt_insert.starts_with("tag::") {
-                        rsx! {
-                            img { class: "icon-primary-svg me-1", src: "{base_url_create}/static/tag.svg", alt: "Tag", style: "width: 1.25em; height: 1.25em;" }
-                        }
-                    } else if let Some(photo) = &opt_photo {
-                        rsx! {
-                            img {
-                                src: "{base_url_create}/static/{photo}",
-                                alt: "{opt_display}",
-                                class: "team-token-avatar small me-1 rounded-circle",
-                                style: "width: 1.5em; height: 1.5em; object-fit: cover;"
-                            }
-                        }
-                    } else {
-                        rsx! {
-                            span { class: "team-token-avatar small me-1", "{opt_display.chars().next().unwrap_or('?')}" }
-                        }
-                    }
-                } else {
-                    rsx! { }
-                };
-                rsx! {
-                    li {
-                        class: "{li_class}",
-                        onclick: move |_| {
-                            let v = skip_condition();
-                            let cursor_char = skip_condition_cursor_pos().unwrap_or(0);
-                            let cursor_byte = skip_condition_cursor_byte(&v, cursor_char);
-                            let inn = skip_condition_innermost_around_cursor(&v, cursor_char);
-                            let Some(cs) = inn.and_then(|b| match b {
-                                InnermostBracket::Square(cs, _) | InnermostBracket::Curly(cs, _) => Some(cs),
-                                _ => None,
-                            }) else {
-                                skip_bracket_ac_visible.set(false);
-                                return;
-                            };
-                            let new_v = format!("{}{}{}", &v[..cs], opt_insert, &v[cursor_byte..]);
-                            skip_condition.set(new_v.clone());
-                            let cs_chars = v[..cs].chars().count();
-                            let new_cursor_char = cs_chars + opt_insert.chars().count();
-                            skip_condition_cursor.set(Some(new_cursor_char));
-                            skip_bracket_ac_visible.set(false);
-                        },
-                        {avatar_node}
-                        span { "{display_val}" }
-                    }
-                }
-            })
-            .collect()
-    } else {
-        vec![]
     };
 
     rsx! {
@@ -1455,7 +1070,7 @@ fn CreateMatchModal(
                                     }
                                 }
                                 if schedule_type() == "SAFE" || schedule_type() == "FAST" {
-                                    div { class: "mb-3 position-relative",
+                                    div { class: "mb-3",
                                         label { class: "form-label", "Skip condition" }
                                         div { class: "form-text mb-1",
                                             "Optional expression that evaluates to a boolean. If true, this match will be skipped. "
@@ -1469,209 +1084,15 @@ fn CreateMatchModal(
                                                 "(skip condition help)"
                                             }
                                         }
-                                        input {
-                                            id: "skip-condition-input-create",
-                                            class: "form-control font-monospace",
-                                            "type": "text",
-                                            placeholder: "e.g. (== 0 (losses [Team]))",
-                                            value: "{skip_condition}",
-                                            oninput: move |e| {
-                                                let new_val = e.value();
-                                                let old = skip_condition();
-                                                let (out, cursor_after_open) = if let Some(byte_i) = skip_condition_new_char_index(&old, &new_val) {
-                                                    let open_c = new_val[byte_i..].chars().next().unwrap_or('\0');
-                                                    let closing = match open_c {
-                                                        '(' => ")",
-                                                        '[' => {
-                                                            skip_bracket_ac_visible.set(true);
-                                                            skip_bracket_ac_team.set(true);
-                                                            skip_bracket_ac_index.set(0);
-                                                            "]"
-                                                        }
-                                                        '{' => {
-                                                            skip_bracket_ac_visible.set(true);
-                                                            skip_bracket_ac_team.set(false);
-                                                            skip_bracket_ac_index.set(0);
-                                                            "}"
-                                                        }
-                                                        _ => "",
-                                                    };
-                                                    if closing.is_empty() {
-                                                        (new_val, None)
-                                                    } else {
-                                                        let char_end = byte_i + new_val[byte_i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
-                                                        let out_str = format!("{}{}{}", &new_val[..char_end], closing, &new_val[char_end..]);
-                                                        (out_str, Some(char_end))
-                                                    }
-                                                } else {
-                                                    (new_val, None)
-                                                };
-                                                skip_condition.set(out.clone());
-                                                if let Some(pos) = cursor_after_open {
-                                                    skip_condition_cursor.set(Some(pos));
-                                                }
-                                                skip_condition_error.set(None);
-                                                if out.contains('(') {
-                                                    skip_docs_visible.set(true);
-                                                }
-                                                let id = "skip-condition-input-create".to_string();
-                                                spawn(async move {
-                                                    gloo_timers::future::TimeoutFuture::new(0).await;
-                                                    #[cfg(target_arch = "wasm32")]
-                                                    if let Some(window) = web_sys::window() {
-                                                        if let Some(doc) = window.document() {
-                                                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                                                    if let Ok(Some(sel)) = input.selection_start() {
-                                                                        skip_condition_cursor_pos.set(Some(sel as usize));
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            onfocus: move |_| {
-                                                let id = "skip-condition-input-create".to_string();
-                                                spawn(async move {
-                                                    gloo_timers::future::TimeoutFuture::new(0).await;
-                                                    #[cfg(target_arch = "wasm32")]
-                                                    if let Some(window) = web_sys::window() {
-                                                        if let Some(doc) = window.document() {
-                                                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                                                    if let Ok(Some(sel)) = input.selection_start() {
-                                                                        skip_condition_cursor_pos.set(Some(sel as usize));
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            onkeydown: move |ev: Event<KeyboardData>| {
-                                                let key = ev.key().to_string();
-                                                let n = bracket_options.len();
-                                                if show_bracket_ac && n > 0 {
-                                                    if key == "ArrowDown" {
-                                                        ev.prevent_default();
-                                                        skip_bracket_ac_index.set((bracket_ac_idx + 1) % n);
-                                                        return;
-                                                    }
-                                                    if key == "ArrowUp" {
-                                                        ev.prevent_default();
-                                                        skip_bracket_ac_index.set((bracket_ac_idx + n - 1) % n);
-                                                        return;
-                                                    }
-                                                    if key == "Enter" {
-                                                        ev.prevent_default();
-                                                        if let Some((opt_insert, _, _)) = bracket_options.get(bracket_ac_idx) {
-                                                            let v = skip_condition();
-                                                            let cursor_char = skip_condition_cursor_pos().unwrap_or(0);
-                                                            let cursor_byte = skip_condition_cursor_byte(&v, cursor_char);
-                                                            let inn = skip_condition_innermost_around_cursor(&v, cursor_char);
-                                                            if let Some(cs) = inn.and_then(|b| match b {
-                                                                InnermostBracket::Square(cs, _) | InnermostBracket::Curly(cs, _) => Some(cs),
-                                                                _ => None,
-                                                            }) {
-                                                                let new_v = format!("{}{}{}", &v[..cs], opt_insert, &v[cursor_byte..]);
-                                                                skip_condition.set(new_v);
-                                                                let cs_chars = v[..cs].chars().count();
-                                                                let new_cursor_char = cs_chars + opt_insert.chars().count();
-                                                                skip_condition_cursor.set(Some(new_cursor_char));
-                                                                skip_bracket_ac_visible.set(false);
-                                                            }
-                                                        }
-                                                        return;
-                                                    }
-                                                }
-                                                if key == "Enter" && !ev.modifiers().contains(Modifiers::SHIFT) {
-                                                    ev.prevent_default();
-                                                }
-                                            },
-                                            onkeyup: move |_| {
-                                                let id = "skip-condition-input-create".to_string();
-                                                spawn(async move {
-                                                    gloo_timers::future::TimeoutFuture::new(0).await;
-                                                    #[cfg(target_arch = "wasm32")]
-                                                    if let Some(window) = web_sys::window() {
-                                                        if let Some(doc) = window.document() {
-                                                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                                                    if let Ok(Some(sel)) = input.selection_start() {
-                                                                        let sel_i = sel as usize;
-                                                                        skip_condition_cursor_pos.set(Some(sel_i));
-                                                                        let val = input.value();
-                                                                        let inside = skip_condition_innermost_around_cursor(&val, sel_i)
-                                                                            .map(|b| matches!(b, InnermostBracket::Square(_, _) | InnermostBracket::Curly(_, _)))
-                                                                            .unwrap_or(false);
-                                                                        if !inside {
-                                                                            skip_bracket_ac_visible.set(false);
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            onblur: move |_| {
-                                                skip_docs_visible.set(false);
-                                                skip_bracket_ac_visible.set(false);
-                                                let expr = skip_condition();
-                                                if expr.trim().is_empty() {
-                                                    skip_condition_error.set(None);
-                                                    return;
-                                                }
-                                                let url = tournament_url.clone();
-                                                spawn(async move {
-                                                    match api::validate_dsl(&url, &expr).await {
-                                                        Ok(res) => {
-                                                            skip_condition_error.set(if res.valid {
-                                                                None
-                                                            } else {
-                                                                res.error.clone()
-                                                            });
-                                                            skip_condition_simplified.set(if res.valid {
-                                                                res.simplified
-                                                            } else {
-                                                                None
-                                                            });
-                                                        }
-                                                        Err(e) => {
-                                                            skip_condition_error.set(Some(e));
-                                                            skip_condition_simplified.set(None);
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                        }
-                                        if show_skip_docs && !docs_filtered.is_empty() {
-                                            div { class: "position-absolute start-0 mt-1 p-2 bg-light border rounded shadow-sm z-3",
-                                                style: "min-width: 280px; max-height: 240px; overflow-y: auto;",
-                                                ul { class: "list-unstyled mb-0 small",
-                                                    for item in docs_items.iter() {
-                                                        {item.clone()}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        if show_bracket_ac && !bracket_option_items.is_empty() {
-                                            div { class: "position-absolute start-0 mt-1 p-2 bg-light border rounded shadow-sm z-3",
-                                                style: "min-width: 200px; max-height: 200px; overflow-y: auto;",
-                                                ul { class: "list-unstyled mb-0 small",
-                                                    for bracket_item in bracket_option_items.iter() {
-                                                        {bracket_item.clone()}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        if let Some(err) = skip_condition_error() {
-                                            div { class: "form-text text-danger", "✗ {err}" }
-                                        } else if let Some(simp) = skip_condition_simplified() {
-                                            div { class: "form-text text-success", "✓ Valid (simplified: {simp})" }
-                                        } else if !skip_condition().trim().is_empty() {
-                                            div { class: "form-text text-success", "✓ Valid" }
+                                        AssEntry {
+                                            id_suffix: "create".to_string(),
+                                            value: skip_condition(),
+                                            on_change: move |v| skip_condition.set(v),
+                                            team_options: data.team_options.clone(),
+                                            tags: data.tags.clone(),
+                                            matches: data.matches.clone(),
+                                            tournament_url: tournament_url.clone(),
+                                            placeholder: "e.g. (== 0 (losses [Team]))".to_string(),
                                         }
                                     }
                                 }
@@ -3551,37 +2972,7 @@ fn EditMatchModal(
     let mut stones_per_set = use_signal(|| m.stones_per_set.unwrap_or(100));
     let ribbon = use_signal(|| m.ribbon);
     let mut skip_condition = use_signal(|| m.skip_condition.clone().unwrap_or_default());
-    let mut skip_condition_error = use_signal(|| None::<String>);
-    let mut skip_condition_simplified = use_signal(|| None::<String>);
-    let mut skip_condition_cursor = use_signal(|| None::<usize>);
-    let mut skip_condition_cursor_pos = use_signal(|| None::<usize>);
-    let mut skip_docs_visible = use_signal(|| false);
-    let mut skip_bracket_ac_visible = use_signal(|| false);
-    let mut skip_bracket_ac_team = use_signal(|| true);
-    let mut skip_bracket_ac_index = use_signal(|| 0usize);
     let mut skip_condition_help_open = use_signal(|| false);
-
-    #[cfg(target_arch = "wasm32")]
-    use_effect(move || {
-        let pos = skip_condition_cursor();
-        if let Some(p) = pos {
-            skip_condition_cursor.set(None);
-            let id = "skip-condition-input-edit".to_string();
-            spawn(async move {
-                gloo_timers::future::TimeoutFuture::new(0).await;
-                if let Some(window) = web_sys::window() {
-                    if let Some(doc) = window.document() {
-                        if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                            if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                let _ = input.set_selection_range(p as u32, p as u32);
-                                let _ = input.focus();
-                            }
-                        }
-                    }
-                }
-            });
-        }
-    });
 
     let mut error = use_signal(|| None::<String>);
     let mut saving = use_signal(|| false);
@@ -3646,16 +3037,13 @@ fn EditMatchModal(
                 match api::validate_dsl(&tournament_url, &skip_condition()).await {
                     Ok(res) => {
                         if !res.valid {
-                            skip_condition_error.set(res.error);
-                            skip_condition_simplified.set(None);
+                            error.set(Some(format!("Skip condition: {}", res.error.unwrap_or_else(|| "invalid".to_string()))));
                             saving.set(false);
                             return;
                         }
-                        skip_condition_simplified.set(res.simplified);
                     }
                     Err(e) => {
-                        skip_condition_error.set(Some(e));
-                        skip_condition_simplified.set(None);
+                        error.set(Some(format!("Skip condition: {}", e)));
                         saving.set(false);
                         return;
                     }
@@ -3726,220 +3114,6 @@ fn EditMatchModal(
             do_save_rc3.borrow_mut()();
         }
     };
-
-    let sc_val_edit = skip_condition();
-    let cursor_char_edit = skip_condition_cursor_pos();
-    let innermost_edit = cursor_char_edit.and_then(|c| skip_condition_innermost_around_cursor(&sc_val_edit, c));
-    let cursor_byte_edit = cursor_char_edit.map(|c| skip_condition_cursor_byte(&sc_val_edit, c)).unwrap_or(0);
-    let show_skip_docs_edit = matches!(innermost_edit, Some(InnermostBracket::Paren(_, _)));
-    let docs_prefix_edit = match &innermost_edit {
-        Some(InnermostBracket::Paren(cs, ce)) => {
-            sc_val_edit[*cs..*ce].trim().split_whitespace().next().unwrap_or("").to_lowercase()
-        }
-        _ => String::new(),
-    };
-    let docs_filtered_edit: Vec<_> = if show_skip_docs_edit {
-        DSL_FUNCTIONS
-            .iter()
-            .filter(|(n, _)| n.to_lowercase().starts_with(docs_prefix_edit.as_str()))
-            .take(12)
-            .collect()
-    } else {
-        vec![]
-    };
-    let (bracket_is_team_edit, bracket_query_edit) = match &innermost_edit {
-        Some(InnermostBracket::Square(cs, ce)) => {
-            let end = (*ce).min(cursor_byte_edit).max(*cs);
-            (true, sc_val_edit[*cs..end].trim().to_lowercase())
-        }
-        Some(InnermostBracket::Curly(cs, ce)) => {
-            let end = (*ce).min(cursor_byte_edit).max(*cs);
-            (false, sc_val_edit[*cs..end].trim().to_lowercase())
-        }
-        _ => (true, String::new()),
-    };
-    let show_bracket_ac_edit = matches!(innermost_edit, Some(InnermostBracket::Square(_, _)) | Some(InnermostBracket::Curly(_, _)));
-    let bracket_ac_idx_edit_raw = skip_bracket_ac_index();
-    let bracket_options_edit: Vec<(String, String, Option<String>)> = if show_bracket_ac_edit && bracket_is_team_edit {
-        let team_opts_edit: Vec<_> = data
-            .team_options
-            .iter()
-            .filter(|t| {
-                let disp = t.pseudonym.as_deref().unwrap_or(t.id.as_str());
-                disp.to_lowercase().contains(bracket_query_edit.as_str())
-                    || t.id.to_lowercase().contains(bracket_query_edit.as_str())
-            })
-            .map(|t| {
-                (
-                    t.id.clone(),
-                    t.pseudonym.clone().unwrap_or_else(|| t.id.clone()),
-                    t.profile_photo.clone(),
-                )
-            })
-            .take(15)
-            .collect();
-        let match_qual_opts_edit: Vec<_> = data
-            .matches
-            .iter()
-            .flat_map(|m| {
-                let w = (format!("{}::winner", m.name), format!("{}::winner", m.name), None);
-                let l = (format!("{}::loser", m.name), format!("{}::loser", m.name), None);
-                [w, l]
-            })
-            .filter(|(s, _, _)| s.to_lowercase().contains(bracket_query_edit.as_str()))
-            .take(15)
-            .collect();
-        let tag_opts_edit: Vec<_> = data
-            .tags
-            .iter()
-            .filter(|t| t.name.to_lowercase().contains(bracket_query_edit.as_str()))
-            .map(|t| (format!("tag::{}", t.name), t.name.clone(), None))
-            .take(15)
-            .collect();
-        team_opts_edit
-            .into_iter()
-            .chain(match_qual_opts_edit)
-            .chain(tag_opts_edit)
-            .take(20)
-            .collect()
-    } else if show_bracket_ac_edit {
-        data.matches
-            .iter()
-            .filter(|m| m.name.to_lowercase().contains(bracket_query_edit.as_str()))
-            .map(|m| (m.name.clone(), m.name.clone(), None))
-            .take(15)
-            .collect()
-    } else {
-        vec![]
-    };
-    let bracket_ac_idx_edit = bracket_ac_idx_edit_raw.min(bracket_options_edit.len().saturating_sub(1));
-    let docs_items_edit: Vec<_> = if show_skip_docs_edit && !docs_filtered_edit.is_empty() {
-        docs_filtered_edit
-            .iter()
-            .map(|(dn, ds)| {
-                let fname = dn.to_string();
-                rsx! {
-                    li {
-                        class: "py-1 px-2 rounded",
-                        onclick: move |_| {
-                            let v = skip_condition();
-                            if let Some(i) = v.rfind('(') {
-                                skip_condition.set(format!("{}{}", &v[..=i], fname));
-                            }
-                            skip_docs_visible.set(false);
-                        },
-                        span { class: "fw-medium text-primary", "{dn}" }
-                        span { class: "text-muted ms-1", " {ds}" }
-                    }
-                }
-            })
-            .collect()
-    } else {
-        vec![]
-    };
-    let base_url_edit = api::base_url();
-    let bracket_option_items_edit: Vec<_> = if show_bracket_ac_edit && !bracket_options_edit.is_empty() {
-        bracket_options_edit
-            .iter()
-            .enumerate()
-            .map(|(idx, (insert_val, display_val, photo))| {
-                let opt_insert = insert_val.clone();
-                let opt_display = display_val.clone();
-                let opt_photo = photo.clone();
-                let is_team = bracket_is_team_edit;
-                let is_cur = bracket_ac_idx_edit == idx;
-                let li_class = if is_cur {
-                    "py-1 px-2 rounded bg-primary text-white"
-                } else {
-                    "py-1 px-2 rounded"
-                };
-                let avatar_node_edit = if is_team {
-                    if opt_insert.ends_with("::winner") || opt_insert.ends_with("::loser") {
-                        rsx! {
-                            img { class: "icon-primary-svg me-1", src: "{base_url_edit}/static/reference.svg", alt: "Reference", style: "width: 1.25em; height: 1.25em;" }
-                        }
-                    } else if opt_insert.starts_with("tag::") {
-                        rsx! {
-                            img { class: "icon-primary-svg me-1", src: "{base_url_edit}/static/tag.svg", alt: "Tag", style: "width: 1.25em; height: 1.25em;" }
-                        }
-                    } else if let Some(photo) = &opt_photo {
-                        rsx! {
-                            img {
-                                src: "{base_url_edit}/static/{photo}",
-                                alt: "{opt_display}",
-                                class: "team-token-avatar small me-1 rounded-circle",
-                                style: "width: 1.5em; height: 1.5em; object-fit: cover;"
-                            }
-                        }
-                    } else {
-                        rsx! {
-                            span { class: "team-token-avatar small me-1", "{opt_display.chars().next().unwrap_or('?')}" }
-                        }
-                    }
-                } else {
-                    rsx! { }
-                };
-                rsx! {
-                    li {
-                        class: "{li_class}",
-                        onclick: move |_| {
-                            let v = skip_condition();
-                            let cursor_char = skip_condition_cursor_pos().unwrap_or(0);
-                            let cursor_byte = skip_condition_cursor_byte(&v, cursor_char);
-                            let inn = skip_condition_innermost_around_cursor(&v, cursor_char);
-                            let Some(cs) = inn.and_then(|b| match b {
-                                InnermostBracket::Square(cs, _) | InnermostBracket::Curly(cs, _) => Some(cs),
-                                _ => None,
-                            }) else {
-                                skip_bracket_ac_visible.set(false);
-                                return;
-                            };
-                            let new_v = format!("{}{}{}", &v[..cs], opt_insert, &v[cursor_byte..]);
-                            skip_condition.set(new_v.clone());
-                            let cs_chars = v[..cs].chars().count();
-                            let new_cursor_char = cs_chars + opt_insert.chars().count();
-                            skip_condition_cursor.set(Some(new_cursor_char));
-                            skip_bracket_ac_visible.set(false);
-                        },
-                        {avatar_node_edit}
-                        span { "{display_val}" }
-                    }
-                }
-            })
-            .collect()
-    } else {
-        vec![]
-    };
-
-    let tournament_url_val_edit = tournament_url.clone();
-    use_effect(move || {
-        let expr = skip_condition();
-        let _ = expr.clone();
-        if expr.trim().is_empty() {
-            return;
-        }
-        let expr_captured = expr.clone();
-        let url = tournament_url_val_edit.clone();
-        #[cfg(target_arch = "wasm32")]
-        spawn(async move {
-            gloo_timers::future::TimeoutFuture::new(3000).await;
-            let current = skip_condition();
-            if current == expr_captured {
-                match api::validate_dsl(&url, &expr_captured).await {
-                    Ok(res) => {
-                        skip_condition_error.set(if res.valid { None } else { res.error.clone() });
-                        skip_condition_simplified.set(if res.valid { res.simplified } else { None });
-                    }
-                    Err(e) => {
-                        skip_condition_error.set(Some(e));
-                        skip_condition_simplified.set(None);
-                    }
-                }
-            }
-        });
-        #[cfg(not(target_arch = "wasm32"))]
-        let _ = (expr_captured, url);
-    });
 
     rsx! {
         div {
@@ -4105,7 +3279,7 @@ fn EditMatchModal(
                                     }
                                 }
                                 if schedule_type() == "SAFE" || schedule_type() == "FAST" {
-                                    div { class: "mb-3 position-relative",
+                                    div { class: "mb-3",
                                         label { class: "form-label", "Skip condition" }
                                         div { class: "form-text mb-1",
                                             "Optional expression that evaluates to a boolean. If true, this match will be skipped. "
@@ -4119,209 +3293,15 @@ fn EditMatchModal(
                                                 "(skip condition help)"
                                             }
                                         }
-                                        input {
-                                            id: "skip-condition-input-edit",
-                                            class: "form-control font-monospace",
-                                            "type": "text",
-                                            placeholder: "e.g. (== 0 (losses [Team]))",
-                                            value: "{skip_condition}",
-                                            oninput: move |e| {
-                                                let new_val = e.value();
-                                                let old = skip_condition();
-                                                let (out, cursor_after_open) = if let Some(byte_i) = skip_condition_new_char_index(&old, &new_val) {
-                                                    let open_c = new_val[byte_i..].chars().next().unwrap_or('\0');
-                                                    let closing = match open_c {
-                                                        '(' => ")",
-                                                        '[' => {
-                                                            skip_bracket_ac_visible.set(true);
-                                                            skip_bracket_ac_team.set(true);
-                                                            skip_bracket_ac_index.set(0);
-                                                            "]"
-                                                        }
-                                                        '{' => {
-                                                            skip_bracket_ac_visible.set(true);
-                                                            skip_bracket_ac_team.set(false);
-                                                            skip_bracket_ac_index.set(0);
-                                                            "}"
-                                                        }
-                                                        _ => "",
-                                                    };
-                                                    if closing.is_empty() {
-                                                        (new_val, None)
-                                                    } else {
-                                                        let char_end = byte_i + new_val[byte_i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
-                                                        let out_str = format!("{}{}{}", &new_val[..char_end], closing, &new_val[char_end..]);
-                                                        (out_str, Some(char_end))
-                                                    }
-                                                } else {
-                                                    (new_val, None)
-                                                };
-                                                skip_condition.set(out.clone());
-                                                if let Some(pos) = cursor_after_open {
-                                                    skip_condition_cursor.set(Some(pos));
-                                                }
-                                                skip_condition_error.set(None);
-                                                if out.contains('(') {
-                                                    skip_docs_visible.set(true);
-                                                }
-                                                let id = "skip-condition-input-edit".to_string();
-                                                spawn(async move {
-                                                    gloo_timers::future::TimeoutFuture::new(0).await;
-                                                    #[cfg(target_arch = "wasm32")]
-                                                    if let Some(window) = web_sys::window() {
-                                                        if let Some(doc) = window.document() {
-                                                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                                                    if let Ok(Some(sel)) = input.selection_start() {
-                                                                        skip_condition_cursor_pos.set(Some(sel as usize));
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            onfocus: move |_| {
-                                                let id = "skip-condition-input-edit".to_string();
-                                                spawn(async move {
-                                                    gloo_timers::future::TimeoutFuture::new(0).await;
-                                                    #[cfg(target_arch = "wasm32")]
-                                                    if let Some(window) = web_sys::window() {
-                                                        if let Some(doc) = window.document() {
-                                                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                                                    if let Ok(Some(sel)) = input.selection_start() {
-                                                                        skip_condition_cursor_pos.set(Some(sel as usize));
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            onkeydown: move |ev: Event<KeyboardData>| {
-                                                let key = ev.key().to_string();
-                                                let n_edit = bracket_options_edit.len();
-                                                if show_bracket_ac_edit && n_edit > 0 {
-                                                    if key == "ArrowDown" {
-                                                        ev.prevent_default();
-                                                        skip_bracket_ac_index.set((bracket_ac_idx_edit + 1) % n_edit);
-                                                        return;
-                                                    }
-                                                    if key == "ArrowUp" {
-                                                        ev.prevent_default();
-                                                        skip_bracket_ac_index.set((bracket_ac_idx_edit + n_edit - 1) % n_edit);
-                                                        return;
-                                                    }
-                                                    if key == "Enter" {
-                                                        ev.prevent_default();
-                                                        if let Some((opt_insert, _, _)) = bracket_options_edit.get(bracket_ac_idx_edit) {
-                                                            let v = skip_condition();
-                                                            let cursor_char = skip_condition_cursor_pos().unwrap_or(0);
-                                                            let cursor_byte = skip_condition_cursor_byte(&v, cursor_char);
-                                                            let inn = skip_condition_innermost_around_cursor(&v, cursor_char);
-                                                            if let Some(cs) = inn.and_then(|b| match b {
-                                                                InnermostBracket::Square(cs, _) | InnermostBracket::Curly(cs, _) => Some(cs),
-                                                                _ => None,
-                                                            }) {
-                                                                let new_v = format!("{}{}{}", &v[..cs], opt_insert, &v[cursor_byte..]);
-                                                                skip_condition.set(new_v);
-                                                                let cs_chars = v[..cs].chars().count();
-                                                                let new_cursor_char = cs_chars + opt_insert.chars().count();
-                                                                skip_condition_cursor.set(Some(new_cursor_char));
-                                                                skip_bracket_ac_visible.set(false);
-                                                            }
-                                                        }
-                                                        return;
-                                                    }
-                                                }
-                                                if key == "Enter" && !ev.modifiers().contains(Modifiers::SHIFT) {
-                                                    ev.prevent_default();
-                                                }
-                                            },
-                                            onkeyup: move |_| {
-                                                let id = "skip-condition-input-edit".to_string();
-                                                spawn(async move {
-                                                    gloo_timers::future::TimeoutFuture::new(0).await;
-                                                    #[cfg(target_arch = "wasm32")]
-                                                    if let Some(window) = web_sys::window() {
-                                                        if let Some(doc) = window.document() {
-                                                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                                                    if let Ok(Some(sel)) = input.selection_start() {
-                                                                        let sel_i = sel as usize;
-                                                                        skip_condition_cursor_pos.set(Some(sel_i));
-                                                                        let val = input.value();
-                                                                        let inside = skip_condition_innermost_around_cursor(&val, sel_i)
-                                                                            .map(|b| matches!(b, InnermostBracket::Square(_, _) | InnermostBracket::Curly(_, _)))
-                                                                            .unwrap_or(false);
-                                                                        if !inside {
-                                                                            skip_bracket_ac_visible.set(false);
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            onblur: move |_| {
-                                                skip_docs_visible.set(false);
-                                                skip_bracket_ac_visible.set(false);
-                                                let expr = skip_condition();
-                                                if expr.trim().is_empty() {
-                                                    skip_condition_error.set(None);
-                                                    return;
-                                                }
-                                                let url = tournament_url.clone();
-                                                spawn(async move {
-                                                    match api::validate_dsl(&url, &expr).await {
-                                                        Ok(res) => {
-                                                            skip_condition_error.set(if res.valid {
-                                                                None
-                                                            } else {
-                                                                res.error
-                                                            });
-                                                            skip_condition_simplified.set(if res.valid {
-                                                                res.simplified
-                                                            } else {
-                                                                None
-                                                            });
-                                                        }
-                                                        Err(e) => {
-                                                            skip_condition_error.set(Some(e));
-                                                            skip_condition_simplified.set(None);
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                        }
-                                        if show_skip_docs_edit && !docs_filtered_edit.is_empty() {
-                                            div { class: "position-absolute start-0 mt-1 p-2 bg-light border rounded shadow-sm z-3",
-                                                style: "min-width: 280px; max-height: 240px; overflow-y: auto;",
-                                                ul { class: "list-unstyled mb-0 small",
-                                                    for item in docs_items_edit.iter() {
-                                                        {item.clone()}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        if show_bracket_ac_edit && !bracket_options_edit.is_empty() {
-                                            div { class: "position-absolute start-0 mt-1 p-2 bg-light border rounded shadow-sm z-3",
-                                                style: "min-width: 200px; max-height: 240px; overflow-y: auto;",
-                                                ul { class: "list-unstyled mb-0 small",
-                                                    for item in bracket_option_items_edit.iter() {
-                                                        {item.clone()}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        if let Some(err) = skip_condition_error() {
-                                            div { class: "form-text text-danger", "✗ {err}" }
-                                        } else if let Some(simp) = skip_condition_simplified() {
-                                            div { class: "form-text text-success", "✓ Valid (simplified: {simp})" }
-                                        } else if !skip_condition().trim().is_empty() {
-                                            div { class: "form-text text-success", "✓ Valid" }
+                                        AssEntry {
+                                            id_suffix: "edit".to_string(),
+                                            value: skip_condition(),
+                                            on_change: move |v| skip_condition.set(v),
+                                            team_options: data.team_options.clone(),
+                                            tags: data.tags.clone(),
+                                            matches: data.matches.clone(),
+                                            tournament_url: tournament_url.clone(),
+                                            placeholder: "e.g. (== 0 (losses [Team]))".to_string(),
                                         }
                                     }
                                 }

--- a/frontend/src/pages/schedule_timeline.css
+++ b/frontend/src/pages/schedule_timeline.css
@@ -487,6 +487,104 @@
     padding: 0.05rem 0.25rem;
 }
 
+/* ASS (Arctos Schedule Script) entry component */
+.ass-entry {
+    /* container holds input + dropdown + preview + status */
+}
+
+.ass-entry-input {
+    /* monospaced input from form-control font-monospace */
+}
+
+.ass-entry-ac {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1050;
+    min-width: 280px;
+    max-width: 480px;
+    max-height: 280px;
+    overflow-y: auto;
+    margin-top: 2px;
+    padding: 0.25rem 0;
+    background: white;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+    list-style: none;
+}
+
+.ass-entry-ac-item {
+    padding: 0.3rem 0.6rem;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.ass-entry-ac-item-active {
+    background: #0d6efd;
+    color: white;
+}
+
+.ass-entry-ac-item-active .text-muted,
+.ass-entry-ac-item-active .ass-entry-ac-fn-desc {
+    color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.ass-entry-ac-fn-name {
+    font-weight: 600;
+    font-family: var(--bs-font-monospace, monospace);
+}
+
+.ass-entry-ac-fn-sig {
+    font-family: var(--bs-font-monospace, monospace);
+    font-size: 0.85em;
+}
+
+.ass-entry-ac-fn-desc {
+    font-size: 0.8em;
+    line-height: 1.3;
+}
+
+.ass-entry-preview {
+    margin-top: 0.3rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    align-items: center;
+    padding: 0.25rem 0.4rem;
+    background: #f8f9fa;
+    border-radius: 4px;
+    border: 1px dashed #ced4da;
+}
+
+.ass-entry-preview-text {
+    font-family: var(--bs-font-monospace, monospace);
+    color: #495057;
+    white-space: pre;
+}
+
+.ass-entry-preview-bracket {
+    font-family: var(--bs-font-monospace, monospace);
+    font-weight: 600;
+}
+
+.team-token-chip-match {
+    background: #fff3cd;
+    border-color: #ffe69c;
+}
+
+.ass-entry-preview-unknown {
+    background: #f8d7da;
+    border-color: #f5c2c7;
+}
+
+.ass-entry-error {
+    white-space: pre-wrap;
+    font-family: var(--bs-font-monospace, monospace);
+}
+
 /* Schedule table view: keep cells as table-cell so Team 1 / Team 2 / Refs columns layout correctly */
 .schedule-table-view table {
     table-layout: auto;

--- a/frontend/src/pages/schedule_timeline.css
+++ b/frontend/src/pages/schedule_timeline.css
@@ -585,6 +585,130 @@
     font-family: var(--bs-font-monospace, monospace);
 }
 
+.ass-entry-simplified {
+    margin-top: 0.25rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    align-items: center;
+    padding: 0.25rem 0.4rem;
+    background: rgba(25, 135, 84, 0.06);
+    border-radius: 4px;
+    border: 1px dashed rgba(25, 135, 84, 0.35);
+}
+
+.ass-entry-simplified-label {
+    font-style: italic;
+}
+
+/* Compact atom rendering used inside the match autocomplete and ASS preview */
+.ass-atom {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    background: rgba(13, 110, 253, 0.07);
+    border: 1px solid rgba(13, 110, 253, 0.18);
+    font-size: 0.85em;
+    line-height: 1.2;
+    margin-right: 0.15rem;
+}
+
+.ass-atom-unknown {
+    background: rgba(220, 53, 69, 0.07);
+    border-color: rgba(220, 53, 69, 0.25);
+    color: #842029;
+}
+
+.ass-atom-avatar {
+    display: inline-flex;
+    width: 1.1em;
+    height: 1.1em;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: #6c757d;
+    color: white;
+    font-size: 0.7em;
+    font-weight: 600;
+    object-fit: cover;
+}
+
+.ass-atom-avatar-text {
+    line-height: 1;
+}
+
+.ass-atom-icon {
+    width: 1em;
+    height: 1em;
+}
+
+.ass-atom-label {
+    font-size: 0.95em;
+}
+
+.ass-atom-badge {
+    font-size: 0.65em;
+    font-weight: 700;
+    padding: 0 0.25rem;
+    border-radius: 2px;
+    color: white;
+}
+
+.ass-entry-ac-item .ass-atom {
+    background: rgba(0, 0, 0, 0.04);
+    border-color: rgba(0, 0, 0, 0.1);
+}
+
+.ass-entry-ac-item-active .ass-atom {
+    background: rgba(255, 255, 255, 0.18);
+    border-color: rgba(255, 255, 255, 0.3);
+    color: white;
+}
+
+.ass-entry-ac-item-active .ass-atom-unknown {
+    background: rgba(255, 255, 255, 0.18);
+    border-color: rgba(255, 200, 200, 0.4);
+    color: #ffd9d9;
+}
+
+.ass-entry-ac-match-head {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.ass-entry-ac-match-name {
+    font-weight: 600;
+}
+
+.ass-entry-ac-match-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.15rem;
+    margin-top: 0.15rem;
+}
+
+.ass-entry-ac-vs {
+    font-style: italic;
+}
+
+.ass-entry-ac-refs {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.15rem;
+}
+
+.ass-entry-ac-resolved {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    font-size: 0.85em;
+}
+
 /* Schedule table view: keep cells as table-cell so Team 1 / Team 2 / Refs columns layout correctly */
 .schedule-table-view table {
     table-layout: auto;

--- a/tests/test_dsl_parser.py
+++ b/tests/test_dsl_parser.py
@@ -577,7 +577,7 @@ class TestErrorHandling:
         with app.app_context():
             parser = get_parser(tournament.url)
 
-            with pytest.raises(DSLValidationError, match="No symbol named"):
+            with pytest.raises(DSLValidationError, match="Unknown function"):
                 parser.parse("(undefined_function 1 2)")
 
     @pytest.mark.unit

--- a/tests/test_dsl_parser.py
+++ b/tests/test_dsl_parser.py
@@ -538,13 +538,22 @@ class TestSymbolicExpressions:
     @pytest.mark.unit
     def test_preserved_expression_with_unresolved_team(self, app, tournament_with_data):
         with app.app_context():
-            parser = get_parser(tournament_with_data["tournament_url"])
+            tournament_url = tournament_with_data["tournament_url"]
+            # Create a tag without a team — its team is unknown, so the expression should preserve.
+            db.session.add(Tag(event=tournament_url, name="UnsetTagPreserve", team=None))
+            db.session.commit()
 
-            # Tag that doesn't exist or isn't set should preserve expression
-            result = parser.parse("(== 0 (losses [tag::NonExistent]))")
-            # Should be a preserved expression (list)
+            parser = get_parser(tournament_url)
+            result = parser.parse("(== 0 (losses [tag::UnsetTagPreserve]))")
             assert isinstance(result, list)
             assert result[0] == "=="
+
+    @pytest.mark.unit
+    def test_unknown_tag_errors(self, app, tournament_with_data):
+        with app.app_context():
+            parser = get_parser(tournament_with_data["tournament_url"])
+            with pytest.raises(DSLValidationError, match="Tag .* does not exist"):
+                parser.parse("[tag::NonExistent]")
 
     @pytest.mark.unit
     def test_preserved_expression_with_unresolved_match(self, app, tournament_with_data):
@@ -560,13 +569,16 @@ class TestSymbolicExpressions:
     @pytest.mark.unit
     def test_preserved_expression_nested(self, app, tournament_with_data):
         with app.app_context():
-            parser = get_parser(tournament_with_data["tournament_url"])
+            tournament_url = tournament_with_data["tournament_url"]
+            # The tag exists but has no team — preserve, don't error.
+            db.session.add(Tag(event=tournament_url, name="UnsetTagNested", team=None))
+            db.session.commit()
 
-            # Complex expression with unresolved values should preserve
-            result = parser.parse("(== 0 (losses [tag::UnsetTag]))")
+            parser = get_parser(tournament_url)
+            result = parser.parse("(== 0 (losses [tag::UnsetTagNested]))")
             assert isinstance(result, list)
-            # The inner expression should also be preserved
-            assert isinstance(result[2], list)  # (losses [tag::UnsetTag])
+            # The inner expression should also be preserved.
+            assert isinstance(result[2], list)
 
 
 class TestErrorHandling:


### PR DESCRIPTION
## Summary

adds a component for ASS entry with suggestions, completion, and validation that actually make sense.  
also helps split up the massive Thing that is `schedule.rs`

## What changed

- returns errors/warnings that actually make sense (ie, `unexpected '(', line 1, col 32`)
- checks that braces are balanced
- difflib fuzzy search for suggestions
- distinguish between nonexistant tags and unset tags 🫪
- check for invalid references
- display more match info (teams, field) in the autocomplete when in curly brackets
- updated DSL_FUNCTIONS const
- make the ass-related frontend stuff into a component and move it into a separate file in the components directory

still todo: 
- [ ] ensure it can work with different box sizes
- [ ] make it a bit more compact for use in team and ref entries
- [ ] make it actually check the expression when i stop typing for long enough (rn its just when i focus away from the box)

## Migration impact

none! the migration will come when we actually start using this for team1/team2/refs.

## Test plan


- [x] `make test` passes locally
- [x] Manual verification - tested expressions with:
  - tags (that exist, don't exist, or exist but are not set)
  - team literals which do or dont exist
  - team literals in the `matchname::winner` format
  - match literals which do or do not exist
  - conditionals
  - lambdas, cons, cat, cdr, and map (over numbers)

## Linked issues

Closes #200 

## Screenshots / repro

<!-- For UI changes, include before/after. For API changes, a curl invocation
     or response sample is just as useful (see #181 for the format). -->
(todo when i get onto a different computer)

---

### Pre-review checklist

<!-- Strike through (~~item~~) anything that doesn't apply, rather than
     deleting, so reviewers can see you thought about it. -->

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [ ] Targeting `dev`, not `main` (unless this is a release PR).
- [x] `make lint` and `make format` are clean.
- [x] Tests added or updated for the new behavior.
- [ ] ~~If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated (per `CLAUDE.md`).~~
- [x] If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.
- [x] No merge conflicts with the base branch.
