### PR TITLE
[Feature] ASS entry box component

### DIFF
--- a/app/routes/tournaments/scheduling.py
+++ b/app/routes/tournaments/scheduling.py
@@ -831,15 +831,18 @@ def validate_dsl(tournament_url):
         SymbolicTeam,
         SymbolicMatch,
         Lambda,
+        Nil,
+        _format_dsl_value,
         _infer_types,
     )
 
     def serialize_value(value):
         """Convert the interpreted value to a JSON-serializable format."""
-        if isinstance(value, (int, bool, type(None))):
+        if isinstance(value, Nil):
+            return None
+        if isinstance(value, (int, bool)):
             return value
         elif isinstance(value, list):
-            # Recursively serialize list elements
             return [serialize_value(item) for item in value]
         elif isinstance(value, Team):
             # Return team ID
@@ -860,33 +863,6 @@ def validate_dsl(tournament_url):
             # Fallback to string representation
             return str(value)
 
-    def value_to_string(value):
-        """Convert the interpreted value to a readable string representation."""
-        if isinstance(value, (int, bool, type(None))):
-            return str(value)
-        elif isinstance(value, list):
-            # Format as Lisp-like expression
-            if len(value) > 0 and isinstance(value[0], str):
-                # Preserved expression - format as s-expression
-                return "(" + " ".join(value_to_string(item) for item in value) + ")"
-            else:
-                # Data list
-                return "[" + ", ".join(value_to_string(item) for item in value) + "]"
-        elif isinstance(value, Team):
-            return f"[{value.obj.id}]"
-        elif isinstance(value, Match):
-            return f"{{{value.obj.name}}}"
-        elif isinstance(value, SymbolicTeam):
-            return f"[{value.literal}]"
-        elif isinstance(value, SymbolicMatch):
-            return f"{{{value.literal}}}"
-        elif isinstance(value, Lambda):
-            # Lambda objects shouldn't appear in final results, but handle gracefully
-            params_str = " ".join(value.params) if value.params else ""
-            return f"(lambda ({params_str}) ...)"
-        else:
-            return str(value)
-
     data = request.get_json()
     expression = data.get("expression", "").strip()
 
@@ -905,7 +881,7 @@ def validate_dsl(tournament_url):
         # the simplified form (with chips). Suppressing on equality hid useful previews
         # for expressions whose literal text already happens to be in canonical form
         # (e.g. anything containing an unset [tag::Foo] that stays symbolic).
-        simplified = value_to_string(result)
+        simplified = _format_dsl_value(result)
 
         # Treat unresolvable team/match references as errors so the user notices typos.
         if warnings:

--- a/app/routes/tournaments/scheduling.py
+++ b/app/routes/tournaments/scheduling.py
@@ -822,8 +822,7 @@ def validate_dsl(tournament_url):
     """Validate and simplify a DSL expression.
     Returns JSON with: valid (bool), value (the full interpreted value), simplified (str representation), error (str or None)
     """
-    # Kept inline: app.utils.parser exports `Team` and `Match` names that
-    # would shadow `models.Team`/`models.Match` if hoisted to module top.
+    from flask import jsonify
     from app.utils.parser import (
         get_parser,
         DSLValidationError,
@@ -895,6 +894,7 @@ def validate_dsl(tournament_url):
 
     try:
         parser = get_parser(tournament_url)
+        warnings = parser.static_check(expression)
         result = parser.parse(expression)
 
         # Serialize the full value for JSON response
@@ -906,12 +906,25 @@ def validate_dsl(tournament_url):
         # Only include simplified if it's different from the input
         simplified = simplified_str if simplified_str != expression else None
 
+        # Treat unresolvable team/match references as errors so the user notices typos.
+        if warnings:
+            return jsonify(
+                {
+                    "valid": False,
+                    "value": None,
+                    "simplified": None,
+                    "error": "; ".join(warnings),
+                    "warnings": warnings,
+                }
+            )
+
         return jsonify(
             {
                 "valid": True,
                 "value": serialized_value,
                 "simplified": simplified,
                 "error": None,
+                "warnings": [],
             }
         )
     except DSLValidationError as e:
@@ -925,6 +938,7 @@ def validate_dsl(tournament_url):
                 "error": f"Parse error: {str(e)}",
             }
         )
+
 
 
 @bp.route("/tournaments/<tournament_url>/start-match", methods=["GET"])

--- a/app/routes/tournaments/scheduling.py
+++ b/app/routes/tournaments/scheduling.py
@@ -831,6 +831,7 @@ def validate_dsl(tournament_url):
         SymbolicTeam,
         SymbolicMatch,
         Lambda,
+        _infer_types,
     )
 
     def serialize_value(value):
@@ -925,6 +926,7 @@ def validate_dsl(tournament_url):
                 "simplified": simplified,
                 "error": None,
                 "warnings": [],
+                "result_type": sorted(_infer_types(result))
             }
         )
     except DSLValidationError as e:

--- a/app/routes/tournaments/scheduling.py
+++ b/app/routes/tournaments/scheduling.py
@@ -900,11 +900,11 @@ def validate_dsl(tournament_url):
         # Serialize the full value for JSON response
         serialized_value = serialize_value(result)
 
-        # Create string representation
-        simplified_str = value_to_string(result)
-
-        # Only include simplified if it's different from the input
-        simplified = simplified_str if simplified_str != expression else None
+        # Create string representation. We always send it back so the frontend can render
+        # the simplified form (with chips). Suppressing on equality hid useful previews
+        # for expressions whose literal text already happens to be in canonical form
+        # (e.g. anything containing an unset [tag::Foo] that stays symbolic).
+        simplified = value_to_string(result)
 
         # Treat unresolvable team/match references as errors so the user notices typos.
         if warnings:

--- a/app/utils/grammar.lark
+++ b/app/utils/grammar.lark
@@ -1,8 +1,8 @@
 ?start: expression
 
-// same as lisp! everything is atom or list.
 ?expression: atom
            | list
+           | quoted
 
 // atoms are all the non-list types.
 // identifiers are like. variable names for lambdas.
@@ -16,6 +16,9 @@
 
 // Lists (S-expressions) - everything is a list!
 list: "(" (expression (expression)*)? ")"
+
+// 'EXPR is shorthand for (quote EXPR), as in standard Lisp.
+quoted: "'" expression
 
 // Data type literals
 INT: /-?\d+/

--- a/app/utils/parser.py
+++ b/app/utils/parser.py
@@ -232,13 +232,18 @@ def parse_team_literal(literal: str, event: str):
             return Match(match_obj, event).loser()
         elif match_name == "tag":
             tag = Tag.query.filter_by(name=qualifier, event=event).first()
-            if not tag or not tag.team:
-                # Return symbolic team if tag doesn't exist or isn't set
+            if not tag:
+                known = [t.name for t in Tag.query.filter_by(event=event).all()]
+                suggestion = _suggest_function(qualifier, known)
+                hint = f" Did you mean 'tag::{suggestion}'?" if suggestion else ""
+                raise DSLValidationError(f"Tag '{qualifier}' does not exist.{hint}")
+            if not tag.team:
+                # Tag exists but its team isn't assigned yet — stay symbolic.
                 return SymbolicTeam(literal, event)
             team_obj = TeamDB.query.filter_by(id=tag.team).first()
             if team_obj:
                 return Team(team_obj, event)
-            # Team not found, return symbolic
+            # Tag's team id refers to a deleted team — stay symbolic.
             return SymbolicTeam(literal, event)
         else:
             raise DSLValidationError(f"Invalid team literal: {literal}")
@@ -1229,23 +1234,52 @@ def _collect_literals(text: str):
 
 
 def _check_references(text: str, event: str) -> list[str]:
-    """Return a list of warnings about unresolvable team/match references.
+    """Return a list of warnings about unresolvable team/match/tag references.
 
-    Skips MatchName::winner / MatchName::loser / tag::Foo (those legitimately
-    resolve symbolically). Plain team ids and match names should map to existing
-    rows; if not, we tell the user.
+    A `[name]` literal must resolve to:
+      - a team id, or
+      - a `tag::TagName` for a Tag that exists in this event, or
+      - `MatchName::winner` / `MatchName::loser` for a match that exists.
+    A `{name}` literal must name a match in this event.
+    Anything that doesn't match these rules gets a warning; symbolic references
+    that legitimately can't be resolved yet (e.g. an unset tag's team) are not
+    warned about here, only typoed names are.
     """
     warnings: list[str] = []
     teams, matches = _collect_literals(text)
+    known_match_names: list[str] | None = None
+    known_tag_names: list[str] | None = None
     for inner, pos in teams:
-        if not inner or "::" in inner:
+        if not inner:
+            continue
+        if "::" in inner:
+            head, _, tail = inner.partition("::")
+            if head == "tag":
+                if not Tag.query.filter_by(name=tail, event=event).first():
+                    if known_tag_names is None:
+                        known_tag_names = [t.name for t in Tag.query.filter_by(event=event).all()]
+                    suggestion = _suggest_function(tail, known_tag_names)
+                    hint = f" Did you mean 'tag::{suggestion}'?" if suggestion else ""
+                    warnings.append(f"Unknown tag '[tag::{tail}]' at {_format_position(text, pos)}.{hint}")
+                continue
+            if tail in ("winner", "loser"):
+                if not MatchDB.query.filter_by(name=head, event=event).first():
+                    if known_match_names is None:
+                        known_match_names = [m.name for m in MatchDB.query.filter_by(event=event).all()]
+                    suggestion = _suggest_function(head, known_match_names)
+                    hint = f" Did you mean '{suggestion}::{tail}'?" if suggestion else ""
+                    warnings.append(f"Unknown match '[{head}::{tail}]' at {_format_position(text, pos)}.{hint}")
+                continue
+            warnings.append(
+                f"Invalid team literal '[{inner}]' at {_format_position(text, pos)} — "
+                "expected a team id, tag::TagName, or MatchName::winner/loser."
+            )
             continue
         if not TeamDB.query.filter_by(id=inner).first():
             all_names = [t.id for t in TeamDB.query.all()]
             suggestion = _suggest_function(inner, all_names)
             hint = f" Did you mean '{suggestion}'?" if suggestion else ""
             warnings.append(f"Unknown team '[{inner}]' at {_format_position(text, pos)}.{hint}")
-    known_match_names = None
     for inner, pos in matches:
         if not inner:
             continue

--- a/app/utils/parser.py
+++ b/app/utils/parser.py
@@ -58,7 +58,10 @@ data types:
 
 """
 
+import difflib
+
 from lark import Lark, Tree
+from lark.exceptions import LarkError, UnexpectedInput
 from sqlalchemy import or_, and_
 from app.models import Match as MatchDB, Point as PointDB, Team as TeamDB, Tag
 from app.domain.enums import WinnerSide
@@ -68,6 +71,85 @@ class DSLValidationError(Exception):
     """Raised when DSL expression validation fails."""
 
     pass
+
+
+# Bracket pairings that ASS supports.
+_BRACKET_PAIRS = {"(": ")", "[": "]", "{": "}"}
+_CLOSE_TO_OPEN = {v: k for k, v in _BRACKET_PAIRS.items()}
+
+
+def _format_position(text: str, pos: int) -> str:
+    """Render `(line N, col M)` for a 0-based byte offset into `text`."""
+    if pos < 0 or pos > len(text):
+        return ""
+    line = text.count("\n", 0, pos) + 1
+    last_nl = text.rfind("\n", 0, pos)
+    col = pos - last_nl  # 1-based when last_nl == -1 because pos - (-1) = pos + 1
+    return f"line {line}, col {col}"
+
+
+def _check_balanced_brackets(text: str) -> None:
+    """Lightweight bracket-balance check that points at the offending character.
+
+    ASS uses three nesting kinds — `()`, `[]`, `{}`. Square and curly
+    literals don't nest (they enclose names, not sub-expressions), but they
+    still need to be paired. We scan once and raise a `DSLValidationError`
+    with a position the caller can show in the UI.
+    """
+    stack: list[tuple[str, int]] = []
+    in_team_literal = False
+    in_match_literal = False
+    for i, c in enumerate(text):
+        if in_team_literal:
+            if c == "]":
+                in_team_literal = False
+                stack.pop()
+            continue
+        if in_match_literal:
+            if c == "}":
+                in_match_literal = False
+                stack.pop()
+            continue
+        if c == "[":
+            if stack and stack[-1][0] == "[":
+                raise DSLValidationError(
+                    f"Nested '[' at {_format_position(text, i)} — team literals can't contain '['."
+                )
+            stack.append(("[", i))
+            in_team_literal = True
+        elif c == "{":
+            if stack and stack[-1][0] == "{":
+                raise DSLValidationError(
+                    f"Nested '{{' at {_format_position(text, i)} — match literals can't contain '{{'."
+                )
+            stack.append(("{", i))
+            in_match_literal = True
+        elif c == "(":
+            stack.append(("(", i))
+        elif c in (")", "]", "}"):
+            expected_open = _CLOSE_TO_OPEN[c]
+            if not stack:
+                raise DSLValidationError(
+                    f"Unexpected '{c}' at {_format_position(text, i)} — no matching '{expected_open}' to close."
+                )
+            open_c, _open_pos = stack[-1]
+            if open_c != expected_open:
+                raise DSLValidationError(
+                    f"Mismatched bracket: '{c}' at {_format_position(text, i)} closes a '{open_c}' opened at {_format_position(text, _open_pos)}."
+                )
+            stack.pop()
+    if stack:
+        open_c, open_pos = stack[-1]
+        close_c = _BRACKET_PAIRS[open_c]
+        raise DSLValidationError(
+            f"Unclosed '{open_c}' at {_format_position(text, open_pos)} — expected matching '{close_c}'."
+        )
+
+
+def _suggest_function(name: str, candidates) -> str | None:
+    """Return the best fuzzy match for `name` in `candidates`, or None."""
+    matches = difflib.get_close_matches(name, list(candidates), n=1, cutoff=0.6)
+    return matches[0] if matches else None
 
 
 class Lambda:
@@ -561,8 +643,12 @@ class Simplifier:
             elif head == "is-skipped":
                 return self._evaluate_is_skipped(head, args)
             else:
-                # Unknown function name
-                raise DSLValidationError(f"No symbol named '{head}'")
+                # Unknown function name — try did-you-mean from the builtin set + bound env names.
+                known = set(self.BUILTINS) | set(self.env.keys())
+                suggestion = _suggest_function(head, known)
+                if suggestion:
+                    raise DSLValidationError(f"Unknown function '{head}'. Did you mean '{suggestion}'?")
+                raise DSLValidationError(f"Unknown function '{head}'.")
 
         # If head is not a string or lambda, it's an error
         raise DSLValidationError(f"Cannot call {type(head).__name__} as a function")
@@ -1110,6 +1196,68 @@ class Simplifier:
         return min_elem
 
 
+def _collect_literals(text: str):
+    """Pull out raw team and match literals for a quick reference-existence check.
+
+    Returns (team_literals, match_literals) — lists of (raw_inside, position) tuples,
+    skipping things that aren't directly resolvable (MatchName::winner, tag::Foo).
+    """
+    teams: list[tuple[str, int]] = []
+    matches: list[tuple[str, int]] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == "[":
+            j = text.find("]", i + 1)
+            if j == -1:
+                break
+            inner = text[i + 1 : j].strip()
+            teams.append((inner, i))
+            i = j + 1
+            continue
+        if c == "{":
+            j = text.find("}", i + 1)
+            if j == -1:
+                break
+            inner = text[i + 1 : j].strip()
+            matches.append((inner, i))
+            i = j + 1
+            continue
+        i += 1
+    return teams, matches
+
+
+def _check_references(text: str, event: str) -> list[str]:
+    """Return a list of warnings about unresolvable team/match references.
+
+    Skips MatchName::winner / MatchName::loser / tag::Foo (those legitimately
+    resolve symbolically). Plain team ids and match names should map to existing
+    rows; if not, we tell the user.
+    """
+    warnings: list[str] = []
+    teams, matches = _collect_literals(text)
+    for inner, pos in teams:
+        if not inner or "::" in inner:
+            continue
+        if not TeamDB.query.filter_by(id=inner).first():
+            all_names = [t.id for t in TeamDB.query.all()]
+            suggestion = _suggest_function(inner, all_names)
+            hint = f" Did you mean '{suggestion}'?" if suggestion else ""
+            warnings.append(f"Unknown team '[{inner}]' at {_format_position(text, pos)}.{hint}")
+    known_match_names = None
+    for inner, pos in matches:
+        if not inner:
+            continue
+        if not MatchDB.query.filter_by(name=inner, event=event).first():
+            if known_match_names is None:
+                known_match_names = [m.name for m in MatchDB.query.filter_by(event=event).all()]
+            suggestion = _suggest_function(inner, known_match_names)
+            hint = f" Did you mean '{{{suggestion}}}'?" if suggestion else ""
+            warnings.append(f"Unknown match '{{{inner}}}' at {_format_position(text, pos)}.{hint}")
+    return warnings
+
+
 def get_parser(event: str, match_resolver=None):
     """
     Create a parser for the given event (tournament URL).
@@ -1127,15 +1275,46 @@ def get_parser(event: str, match_resolver=None):
         parse_match = match_resolver if match_resolver is not None else (lambda x: parse_match_literal(x, event))
 
         def parse(text):
-            tree = parser.parse(text)
+            # Cheap structural check first — gives clean position-aware errors before Lark tries.
+            _check_balanced_brackets(text)
+            try:
+                tree = parser.parse(text)
+            except UnexpectedInput as e:
+                # Convert Lark's verbose dump to a one-line message with position.
+                pos = getattr(e, "pos_in_stream", None)
+                line = getattr(e, "line", None)
+                col = getattr(e, "column", None)
+                if line is not None and col is not None:
+                    where = f"line {line}, col {col}"
+                elif pos is not None:
+                    where = _format_position(text, pos)
+                else:
+                    where = "an unknown position"
+                got = ""
+                tok = getattr(e, "token", None)
+                if tok is not None and getattr(tok, "value", None):
+                    got = f" near `{tok.value}`"
+                raise DSLValidationError(f"Parse error at {where}{got}.") from e
+            except LarkError as e:
+                raise DSLValidationError(f"Parse error: {e}") from e
             interpreter = Simplifier(
                 lambda x: parse_team_literal(x, event),
                 parse_match,
             )
             return interpreter.visit(tree)
 
-        class Parser:
-            def __init__(self, parse_func):
-                self.parse = parse_func
+        def static_check(text):
+            """Quick lint pass: balanced brackets and reference existence.
 
-        return Parser(parse)
+            Raises DSLValidationError on unbalanced brackets. Returns a list of
+            soft warnings (typo-likely team/match names) without raising.
+            """
+            _check_balanced_brackets(text)
+            return _check_references(text, event)
+
+        class Parser:
+            def __init__(self, parse_func, static_check_func):
+                self.parse = parse_func
+                self.static_check = static_check_func
+
+        return Parser(parse, static_check)

--- a/app/utils/parser.py
+++ b/app/utils/parser.py
@@ -26,7 +26,8 @@ this is a lisp based language with the following simple options:
 
 (if COND IF_TRUE IF_FALSE)
 
-(cons *_) -> LIST
+(quote EXPR) -> the literal expression, unevaluated
+'EXPR        -> shorthand for (quote EXPR), as in normal Lisp
 (car LIST)
 (cdr LIST)
 (get INDEX LIST) -> gets val at index or NIL
@@ -71,6 +72,101 @@ class DSLValidationError(Exception):
     """Raised when DSL expression validation fails."""
 
     pass
+
+
+class Nil:
+    """Singleton representation of the NIL value."""
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self):
+        return "nil"
+
+    def __str__(self):
+        return "nil"
+
+    def __bool__(self):
+        return False
+
+    def __eq__(self, other):
+        return isinstance(other, Nil)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash("__nil__")
+
+
+NIL = Nil()
+
+
+def _format_value(value, *, quote_lists: bool = True) -> str:
+    """Render an interpreted DSL value as readable Lisp-like text.
+
+    A data list (`List`) renders with a leading `'` when `quote_lists=True`. We
+    only suppress the `'` when descending into *another data list*, since those
+    elements are already part of the outer quote and shouldn't accumulate their
+    own `'`. `Preserved` (deferred function calls) renders bare, but its children
+    are independent values — a child data list there should still be quoted.
+    """
+    if isinstance(value, Nil):
+        return "nil"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, Preserved):
+        # Children of a preserved expression are independent values — keep quoting.
+        return "(" + " ".join(_format_value(x, quote_lists=True) for x in value) + ")"
+    if isinstance(value, list):
+        # Children of a data list are part of the outer quote — don't re-quote them.
+        body = "(" + " ".join(_format_value(x, quote_lists=False) for x in value) + ")"
+        return ("'" + body) if quote_lists else body
+    if isinstance(value, Team):
+        return f"[{value.obj.id}]"
+    if isinstance(value, Match):
+        return f"{{{value.obj.name}}}"
+    if isinstance(value, SymbolicTeam):
+        return f"[{value.literal}]"
+    if isinstance(value, SymbolicMatch):
+        return f"{{{value.literal}}}"
+    if isinstance(value, Lambda):
+        params_str = " ".join(value.params) if value.params else ""
+        return f"(lambda ({params_str}) ...)"
+    return str(value)
+
+
+def _format_dsl_value(value) -> str:
+    """Display form for user-facing results (always quotes top-level data lists)."""
+    return _format_value(value, quote_lists=True)
+
+
+class List(list):
+    """A quoted/data list. Lisp-style space-separated parenthesized form, prefixed with `'`."""
+
+    def __repr__(self):
+        return _format_value(self, quote_lists=True)
+
+    __str__ = __repr__
+
+
+class Preserved(list):
+    """A deferred function-call expression, kept structurally because some argument is symbolic.
+
+    Renders as `(head arg arg ...)` without a quote prefix — distinguishes it from a
+    quoted data list, so type inference and pretty-printing don't conflate the two.
+    """
+
+    def __repr__(self):
+        return _format_value(self, quote_lists=False)
+
+    __str__ = __repr__
 
 
 # Bracket pairings that ASS supports.
@@ -152,57 +248,83 @@ def _suggest_function(name: str, candidates) -> str | None:
     return matches[0] if matches else None
 
 
-# Return-type tables for the parser's built-in functions. A return type is a `frozenset`
-# of type-name strings; functions whose return type is fully determined by argument types
-# (e.g. `if`, `or-default`) are not in these tables — they're handled in `_infer_types`.
-_RETURN_TYPE_FIXED: dict[str, frozenset[str]] = {
-    "wins": frozenset({"INT"}),
-    "losses": frozenset({"INT"}),
-    "points-won": frozenset({"INT"}),
-    "points-lost": frozenset({"INT"}),
-    "+": frozenset({"INT"}),
-    "-": frozenset({"INT"}),
-    "*": frozenset({"INT"}),
-    "/": frozenset({"INT"}),
-    "len": frozenset({"INT"}),
-    "==": frozenset({"BOOL"}),
-    ">": frozenset({"BOOL"}),
-    "<": frozenset({"BOOL"}),
-    ">=": frozenset({"BOOL"}),
-    "<=": frozenset({"BOOL"}),
-    "or": frozenset({"BOOL"}),
-    "and": frozenset({"BOOL"}),
-    "not": frozenset({"BOOL"}),
-    "is-skipped": frozenset({"BOOL"}),
-    "winner": frozenset({"TEAM"}),
-    "loser": frozenset({"TEAM"}),
-    "cons": frozenset({"LIST"}),
-    "cdr": frozenset({"LIST"}),
-    "map": frozenset({"LIST"}),
-    "lambda": frozenset({"FUNC"}),
+# Type-set shorthands used in the signature table below.
+_INT = frozenset({"INT"})
+_BOOL = frozenset({"BOOL"})
+_TEAM = frozenset({"TEAM"})
+_MATCH = frozenset({"MATCH"})
+_LIST = frozenset({"LIST"})
+_FUNC = frozenset({"FUNC"})
+_NIL = frozenset({"NIL"})
+_ANY = frozenset({"INT", "BOOL", "TEAM", "MATCH", "LIST", "FUNC", "NIL"})
+
+
+# Centralized signature table for all built-in functions. `args` is the per-position
+# expected type set for the *fixed* arguments. `min_args`/`max_args` allow optional or
+# variadic functions; `max_args = None` means unbounded. `return` is the declared
+# return type when statically known; functions whose return depends on the args
+# (`if`, `or-default`, `car`, `get`, `reduce`, `max`/`min`, `max-by`/`min-by`) are
+# omitted from the return-type lookup and computed in `_infer_types`.
+_SIGNATURES: dict[str, dict] = {
+    "+": {"args": (_INT, _INT), "return": _INT},
+    "-": {"args": (_INT, _INT), "return": _INT},
+    "*": {"args": (_INT, _INT), "return": _INT},
+    "/": {"args": (_INT, _INT), "return": _INT},
+    ">": {"args": (_INT, _INT), "return": _BOOL},
+    "<": {"args": (_INT, _INT), "return": _BOOL},
+    ">=": {"args": (_INT, _INT), "return": _BOOL},
+    "<=": {"args": (_INT, _INT), "return": _BOOL},
+    "==": {"args": (_ANY, _ANY), "return": _BOOL},
+    "or": {"args": (_BOOL, _BOOL), "return": _BOOL},
+    "and": {"args": (_BOOL, _BOOL), "return": _BOOL},
+    "not": {"args": (_BOOL,), "return": _BOOL},
+    "wins": {"args": (_TEAM,), "return": _INT},
+    "losses": {"args": (_TEAM,), "return": _INT},
+    "winner": {"args": (_MATCH,), "return": _TEAM},
+    "loser": {"args": (_MATCH,), "return": _TEAM},
+    "is-skipped": {"args": (_MATCH,), "return": _BOOL},
+    "points-won": {"args": (_TEAM, _MATCH), "min_args": 1, "return": _INT},
+    "points-lost": {"args": (_TEAM, _MATCH), "min_args": 1, "return": _INT},
+    "car": {"args": (_LIST,)},
+    "cdr": {"args": (_LIST,), "return": _LIST},
+    "get": {"args": (_INT, _LIST)},
+    "or-default": {"args": (_ANY, _ANY)},
+    "len": {"args": (_LIST,), "return": _INT},
+    "map": {"args": (_LIST, _FUNC), "return": _LIST},
+    "reduce": {"args": (_LIST, _FUNC)},
+    "max": {"args": (_LIST,)},
+    "min": {"args": (_LIST,)},
+    "max-by": {"args": (_LIST, _FUNC)},
+    "min-by": {"args": (_LIST, _FUNC)},
+    # `if` and `lambda` are handled as special forms, not validated through the table.
 }
+
+
+_RETURN_TYPE_FIXED: dict[str, frozenset[str]] = {
+    head: sig["return"] for head, sig in _SIGNATURES.items() if "return" in sig
+}
+# Special forms aren't in `_SIGNATURES` but have well-defined return types.
+_RETURN_TYPE_FIXED["lambda"] = _FUNC
+
+
+def _human_type_name(types: frozenset[str]) -> str:
+    """Pretty-print a type set for error messages."""
+    if not types:
+        return "?"
+    return " | ".join(sorted(types))
 
 
 def _infer_list_element_types(lst) -> frozenset[str]:
     """Infer the union of element types in a list-valued expression.
 
-    Handles both already-evaluated data lists (e.g. `[True, False, True]` from
-    a fully-concrete `cons`) and preserved `cons` expressions (`["cons", ...]`).
-    Returns `{"UNKNOWN"}` for anything else (e.g. a `map` preserved expression),
-    since the per-element type isn't visible without evaluating.
+    Handles already-evaluated data lists (e.g. `[True, False, True]` from a
+    quoted literal `'(true false true)`). Returns `{"UNKNOWN"}` for anything
+    else (e.g. a `map` preserved expression), since the per-element type isn't
+    visible without evaluating.
     """
-    if isinstance(lst, list):
-        if lst and isinstance(lst[0], str):
-            if lst[0] == "cons":
-                elements = lst[1:]
-            else:
-                return frozenset({"UNKNOWN"})
-        else:
-            elements = lst
-        if not elements:
-            return frozenset({"UNKNOWN"})
+    if isinstance(lst, list) and len(lst) > 0:
         types: frozenset[str] = frozenset()
-        for elem in elements:
+        for elem in lst:
             types |= _infer_types(elem)
         return types
     return frozenset({"UNKNOWN"})
@@ -225,7 +347,7 @@ def _infer_types(value) -> frozenset[str]:
         return frozenset({"BOOL"})
     if isinstance(value, int):
         return frozenset({"INT"})
-    if value is None:
+    if isinstance(value, Nil):
         return frozenset({"NIL"})
     if isinstance(value, (Team, SymbolicTeam)):
         return frozenset({"TEAM"})
@@ -233,9 +355,7 @@ def _infer_types(value) -> frozenset[str]:
         return frozenset({"MATCH"})
     if isinstance(value, Lambda):
         return frozenset({"FUNC"})
-    if isinstance(value, list):
-        # Distinguish a preserved expression (head is a function-name string) from a
-        # plain data list. `cons` produces a data list of varied content.
+    if isinstance(value, Preserved):
         if value and isinstance(value[0], str):
             head = value[0]
             args = value[1:]
@@ -267,8 +387,9 @@ def _infer_types(value) -> frozenset[str]:
                 return frozenset({"UNKNOWN"})
             if head in ("max", "min", "max-by", "min-by"):
                 return frozenset({"UNKNOWN"})
-            return frozenset({"UNKNOWN"})
-        # Plain data list (cons output, or similar).
+        return frozenset({"UNKNOWN"})
+    if isinstance(value, list):
+        # Plain data list (a quoted literal).
         return frozenset({"LIST"})
     return frozenset({"UNKNOWN"})
 
@@ -467,41 +588,7 @@ class Simplifier:
     """Evaluates DSL expressions by executing code and resolving symbols."""
 
     # Built-in function names that are valid identifiers
-    BUILTINS = {
-        "if",
-        "lambda",
-        "cons",
-        "car",
-        "cdr",
-        "get",
-        "or-default",
-        "len",
-        "map",
-        "reduce",
-        "max",
-        "min",
-        "max-by",
-        "min-by",
-        "+",
-        "-",
-        "*",
-        "/",
-        ">",
-        "<",
-        ">=",
-        "<=",
-        "==",
-        "or",
-        "and",
-        "not",
-        "wins",
-        "losses",
-        "winner",
-        "loser",
-        "points-won",
-        "points-lost",
-        "is-skipped",
-    }
+    BUILTINS = set(_SIGNATURES.keys()) | {"if", "lambda", "quote"}
 
     def __init__(self, parse_team_literal, parse_match_literal, env=None):
         self.parse_team_literal = parse_team_literal
@@ -560,48 +647,70 @@ class Simplifier:
         return params
 
     def _is_preserved_expression(self, value):
-        """Check if a value is a preserved expression (list starting with function name)."""
-        return isinstance(value, list) and len(value) > 0 and isinstance(value[0], str)
+        """Check if a value is a preserved (deferred function-call) expression."""
+        return isinstance(value, Preserved)
 
-    def _validate_arg_count(self, head, args, expected_count, optional_count=0):
+    def _is_unresolved_identifier(self, value):
+        """Free identifier — a string we couldn't bind to a builtin or a value in env."""
+        return isinstance(value, str) and value not in self.BUILTINS and value not in self.env
+
+    def _has_unresolved(self, args) -> bool:
+        """True if any argument can't be evaluated yet (symbolic, preserved, free)."""
+        for arg in args:
+            if isinstance(arg, (SymbolicTeam, SymbolicMatch)):
+                return True
+            if self._is_preserved_expression(arg):
+                return True
+            if self._is_unresolved_identifier(arg):
+                return True
+        return False
+
+    def _validate_arity(self, head: str, args, min_count: int, max_count, optional_count: int = 0):
         """Validate argument count. Raises DSLValidationError if invalid."""
-        min_count = expected_count - optional_count
-        max_count = expected_count
-        actual_count = len(args)
-        if actual_count < min_count or actual_count > max_count:
-            raise DSLValidationError(f"({head} ...) expects {expected_count} argument(s), got {actual_count}")
-
-    def _validate_type(self, value, expected_type, type_name, arg_position, allow_none=False):
-        """Validate argument type. Raises DSLValidationError if invalid.
-
-        Args:
-            value: The value to validate
-            expected_type: Expected type ("TEAM", "MATCH", "INT", "BOOL", "LIST", "ANY")
-            type_name: Human-readable type name for error messages
-            arg_position: Argument position (1-indexed) for error messages
-            allow_none: If True, None values are allowed (for unresolved references)
-        """
-        # Allow None if explicitly allowed (for unresolved references that can't be simplified yet)
-        if allow_none and value is None:
+        actual = len(args)
+        if max_count is None:
+            if actual < min_count:
+                raise DSLValidationError(f"({head} ...) expects at least {min_count} argument(s), got {actual}")
             return
+        if actual < min_count or actual > max_count:
+            if min_count == max_count:
+                expected_desc = f"{max_count}"
+            else:
+                expected_desc = f"{min_count} to {max_count}"
+            raise DSLValidationError(f"({head} ...) expects {expected_desc} argument(s), got {actual}")
 
-        if expected_type == "TEAM":
-            if not isinstance(value, Team):
-                raise DSLValidationError(f"Argument {arg_position} must be a TEAM, got {type(value).__name__}")
-        elif expected_type == "MATCH":
-            if not isinstance(value, Match):
-                raise DSLValidationError(f"Argument {arg_position} must be a MATCH, got {type(value).__name__}")
-        elif expected_type == "INT":
-            if not isinstance(value, int):
-                raise DSLValidationError(f"Argument {arg_position} must be an INT, got {type(value).__name__}")
-        elif expected_type == "BOOL":
-            if not isinstance(value, bool):
-                raise DSLValidationError(f"Argument {arg_position} must be a BOOL, got {type(value).__name__}")
-        elif expected_type == "LIST":
-            if not isinstance(value, list):
-                raise DSLValidationError(f"Argument {arg_position} must be a LIST, got {type(value).__name__}")
-        elif expected_type == "ANY":
-            pass  # No validation needed
+    def _validate_arg_types(self, head: str, args, expected_types):
+        """Exhaustively check each arg's inferred type against the expected per-position set.
+
+        For variadic positions (more args than `expected_types` entries) the last entry's
+        expected set is reused. An arg passes when its inferred types intersect the
+        expected set, or when inference yielded `UNKNOWN` (no information either way).
+        """
+        if not expected_types:
+            return
+        for i, arg in enumerate(args):
+            expected = expected_types[i] if i < len(expected_types) else expected_types[-1]
+            inferred = _infer_types(arg)
+            if "UNKNOWN" in inferred:
+                continue
+            if inferred & expected:
+                continue
+            raise DSLValidationError(
+                f"Argument {i + 1} of ({head} ...) must be {_human_type_name(expected)}, "
+                f"got {_human_type_name(inferred)}"
+            )
+
+    def _validate_call(self, head: str, args):
+        """Run arity + per-arg type validation against the signature table."""
+        sig = _SIGNATURES.get(head)
+        if sig is None:
+            return  # No signature (e.g. lambda/if special forms — handled separately).
+        expected_types = sig.get("args", ())
+        fixed_count = len(expected_types)
+        max_args = sig.get("max_args", fixed_count)
+        min_args = sig.get("min_args", fixed_count)
+        self._validate_arity(head, args, min_args, max_args)
+        self._validate_arg_types(head, args, expected_types)
 
     # Interpreter methods - top-down traversal with explicit control
 
@@ -609,7 +718,7 @@ class Simplifier:
         """Visit expression node - just visit the child."""
         if tree.children:
             return self.visit(tree.children[0])
-        return None
+        return Nil()
 
     # Atom transformations
     def int_atom(self, tree):
@@ -621,7 +730,7 @@ class Simplifier:
         return token.value == "true"
 
     def nil_atom(self, tree):
-        return None
+        return Nil()
 
     def team_atom(self, tree):
         token = tree.children[0]
@@ -643,7 +752,7 @@ class Simplifier:
         if name == "false":
             return False
         if name == "nil":
-            return None
+            return Nil()
         # Check if it's in the environment (lambda argument or closure variable)
         if name in self.env:
             return self.env[name]
@@ -653,16 +762,60 @@ class Simplifier:
         # Unknown symbol - return as string (will be resolved/error later)
         return name
 
+    def quoted(self, tree):
+        """Visit `'EXPR` syntactic-sugar form — same as `(quote EXPR)`."""
+        return self._quote_tree(tree.children[0])
+
+    def _quote_tree(self, tree):
+        """Return the literal data form of a parse tree without evaluating function calls.
+
+        Atoms become their concrete value (int_atom -> int, identifier_atom -> name as string,
+        team_atom / match_atom -> resolved Team/Match). Lists become `List` of recursively
+        quoted children. Nested `'EXPR` (or `(quote EXPR)`) collapses through `_quote_tree`
+        on the inner expression as well.
+        """
+        if not isinstance(tree, Tree):
+            return tree
+        if tree.data == "list":
+            return List([self._quote_tree(child) for child in tree.children])
+        if tree.data == "expression":
+            if tree.children:
+                return self._quote_tree(tree.children[0])
+            return Nil()
+        if tree.data == "quoted":
+            # `''x` desugars to `'(quote x)` → the literal 2-element list (quote x).
+            return List(["quote", self._quote_tree(tree.children[0])])
+        if tree.data == "identifier_atom":
+            # Quoted identifier — preserve the literal symbol as a string. The IDENTIFIER
+            # token also matches the keyword literals `true` / `false` / `nil`, which
+            # should still resolve to their literal value when quoted.
+            name = tree.children[0].value
+            if name == "true":
+                return True
+            if name == "false":
+                return False
+            if name == "nil":
+                return Nil()
+            return name
+        # Other atoms (int / bool / nil / team / match) carry their literal value either way.
+        return self.visit(tree)
+
     # Main expression handling
     def list(self, tree):
         """Process a list/s-expression with top-down control."""
         if not tree.children:
-            return []  # Empty list
+            return List()  # Empty list
 
         # Evaluate head first (top-down: check what we're calling before evaluating args)
         head_tree = tree.children[0]
         head = self.visit(head_tree)
         head = self._resolve_identifier(head)
+
+        # Handle quote special form — return the argument literally without evaluation.
+        if isinstance(head, str) and head == "quote":
+            if len(tree.children) != 2:
+                raise DSLValidationError("quote expects exactly 1 argument")
+            return self._quote_tree(tree.children[1])
 
         # Handle lambda special form - DON'T evaluate the body
         if isinstance(head, str) and head == "lambda":
@@ -691,6 +844,11 @@ class Simplifier:
             cond = self.visit(cond_tree)
             cond = self._resolve_identifier(cond)
 
+            # Validate that the condition can be a BOOL.
+            cond_types = _infer_types(cond)
+            if "UNKNOWN" not in cond_types and not (cond_types & _BOOL):
+                raise DSLValidationError(f"Argument 1 of (if ...) must be BOOL, got {_human_type_name(cond_types)}")
+
             # Evaluate appropriate branch based on condition
             if isinstance(cond, bool):
                 branch_tree = tree.children[2] if cond else tree.children[3]
@@ -699,20 +857,10 @@ class Simplifier:
                 # Condition is symbolic or not boolean - preserve expression
                 if_true = self.visit(tree.children[2])
                 if_false = self.visit(tree.children[3])
-                return [head, cond, if_true, if_false]
+                return Preserved([head, cond, if_true, if_false])
 
         # Regular function call - evaluate all arguments
-        args = []
-        for child in tree.children[1:]:
-            arg = self.visit(child)
-            # If argument is a single-element list like [10], unwrap it
-            # This handles cases where a value is parsed as (value) instead of just value
-            if isinstance(arg, list) and len(arg) == 1:
-                # Check if it's a data list (not a preserved expression)
-                if not self._is_preserved_expression(arg):
-                    # Unwrap the single element
-                    arg = arg[0]
-            args.append(arg)
+        args = [self.visit(child) for child in tree.children[1:]]
 
         # Resolve all arguments (they might be identifiers)
         args = [self._resolve_identifier(arg) for arg in args]
@@ -723,10 +871,11 @@ class Simplifier:
 
         # If head is a string (identifier), check if it's a function call
         if isinstance(head, str):
+            if head in _SIGNATURES:
+                # Validate against the centralized signature table before dispatching.
+                self._validate_call(head, args)
             # Handle built-in functions
-            if head == "cons":
-                return self._evaluate_cons(head, args)
-            elif head == "car":
+            if head == "car":
                 return self._evaluate_car(head, args)
             elif head == "cdr":
                 return self._evaluate_cdr(head, args)
@@ -749,8 +898,10 @@ class Simplifier:
             elif head == "min-by":
                 return self._evaluate_min_by(head, args)
             # Handle arithmetic and comparison operators
-            elif head in {"+", "-", "*", "/", ">", "<", ">=", "<=", "=="}:
-                return self._evaluate_binary_op(head, args)
+            elif head in {"+", "-", "*", "/", ">", "<", ">=", "<="}:
+                return self._evaluate_arith_or_cmp(head, args)
+            elif head == "==":
+                return self._evaluate_equality(head, args)
             elif head in {"or", "and", "not"}:
                 return self._evaluate_logical_op(head, args)
             # Handle team/match operations
@@ -833,7 +984,7 @@ class Simplifier:
         elif isinstance(value, list):
             # Could be a function call, preserved expression, or data list
             if not value:
-                return []
+                return List()
             # Check if it's a preserved expression (starts with function name)
             if self._is_preserved_expression(value):
                 return value  # Return as-is, it's already preserved
@@ -848,7 +999,7 @@ class Simplifier:
                 return value
             return value
         else:
-            # Literal value (int, bool, None, Team, Match, Lambda, etc.)
+            # Literal value (int, bool, Nil, Team, Match, Lambda, etc.)
             return value
 
     def _evaluate_lambda(self, head, params_expr, body_tree):
@@ -891,202 +1042,107 @@ class Simplifier:
 
     # Helper methods for evaluation
 
-    def _evaluate_binary_op(self, op, args):
-        """Evaluate binary operations."""
-        self._validate_arg_count(op, args, 2)
+    def _evaluate_arith_or_cmp(self, op, args):
+        """Evaluate arithmetic and ordered-comparison binary operators."""
+        if self._has_unresolved(args):
+            return Preserved([op, *args])
         a, b = args
+        if op == "+":
+            return a + b
+        elif op == "-":
+            return a - b
+        elif op == "*":
+            return a * b
+        elif op == "/":
+            if b == 0:
+                raise DSLValidationError("Division by zero")
+            return a // b
+        elif op == ">":
+            return a > b
+        elif op == "<":
+            return a < b
+        elif op == ">=":
+            return a >= b
+        elif op == "<=":
+            return a <= b
 
-        # Check for symbolic values or preserved expressions (lists) - preserve expression if found
-        # But distinguish between data lists (like [1, 2, 3]) and preserved expressions (like ['+', x, y])
-        if isinstance(a, (SymbolicTeam, SymbolicMatch)) or isinstance(b, (SymbolicTeam, SymbolicMatch)):
-            return [op, a, b]
-        # Check if it's a preserved expression (starts with function name) vs a data list
-        # Preserved expressions are lists that start with a function name (string)
-        if isinstance(a, list):
-            if self._is_preserved_expression(a):
-                return [op, a, b]
-            # It's a data list - can't do arithmetic on it
-            raise DSLValidationError(f"Argument 1 of ({op} ...) must be an INT, got LIST")
-        if isinstance(b, list):
-            if self._is_preserved_expression(b):
-                return [op, a, b]
-            # It's a data list - can't do arithmetic on it
-            raise DSLValidationError(f"Argument 2 of ({op} ...) must be an INT, got LIST")
-
-        # Check for unresolved identifiers (strings that aren't builtins or in environment)
-        # These might be lambda parameters that will be resolved when the lambda is called
-        if isinstance(a, str) and a not in self.BUILTINS and a not in self.env:
-            return [op, a, b]
-        if isinstance(b, str) and b not in self.BUILTINS and b not in self.env:
-            return [op, a, b]
-
-        # Arithmetic and comparison operators require integers
-        # Note: bool is a subclass of int in Python, so we need to check type explicitly
-        if op in {"+", "-", "*", "/", ">", "<", ">=", "<="}:
-            if type(a) is not int:  # Use 'is' to check exact type, not isinstance
-                raise DSLValidationError(f"Argument 1 of ({op} ...) must be an INT, got {type(a).__name__}")
-            if type(b) is not int:  # Use 'is' to check exact type, not isinstance
-                raise DSLValidationError(f"Argument 2 of ({op} ...) must be an INT, got {type(b).__name__}")
-            if op == "+":
-                return a + b
-            elif op == "-":
-                return a - b
-            elif op == "*":
-                return a * b
-            elif op == "/":
-                if b == 0:
-                    raise DSLValidationError("Division by zero")
-                return a // b
-            elif op == ">":
-                return a > b
-            elif op == "<":
-                return a < b
-            elif op == ">=":
-                return a >= b
-            elif op == "<=":
-                return a <= b
-        elif op == "==":
-            # == works on any comparable values
-            if isinstance(a, (int, bool, type(None))) and isinstance(b, (int, bool, type(None))):
-                return a == b
-            # For team objects, compare by team id (same team can be produced by different code paths)
-            elif isinstance(a, Team) and isinstance(b, Team):
-                return a.obj.id == b.obj.id
-            elif isinstance(a, Match) and isinstance(b, Match):
-                return a.obj.uuid == b.obj.uuid
-            else:
-                # Can't compare different types - preserve expression instead of returning False
-                return [op, a, b]
+    def _evaluate_equality(self, op, args):
+        """Evaluate (== ANY ANY) — preserves on unresolved, else delegates to value equality."""
+        if self._has_unresolved(args):
+            return Preserved([op, *args])
+        a, b = args
+        if isinstance(a, (int, bool, Nil)) and isinstance(b, (int, bool, Nil)):
+            return a == b
+        if isinstance(a, Team) and isinstance(b, Team):
+            return a.obj.id == b.obj.id
+        if isinstance(a, Match) and isinstance(b, Match):
+            return a.obj.uuid == b.obj.uuid
+        # Different concrete types (e.g. INT vs TEAM) — preserve rather than report False.
+        return Preserved([op, a, b])
 
     def _evaluate_logical_op(self, op, args):
         """Evaluate logical operations."""
+        if self._has_unresolved(args):
+            return Preserved([op, *args])
+
         if op == "not":
-            self._validate_arg_count(op, args, 1)
             (a,) = args
-            if isinstance(a, (SymbolicTeam, SymbolicMatch, list)):
-                return [op, a]
-            a_bool = a is not None and a is not False
-            return not a_bool
+            return not bool(a)
 
-        self._validate_arg_count(op, args, 2)
         a, b = args
-
-        # Check for symbolic values or preserved expressions - preserve if found
-        if isinstance(a, (SymbolicTeam, SymbolicMatch)) or isinstance(b, (SymbolicTeam, SymbolicMatch)):
-            return [op, a, b]
-        if isinstance(a, list) or isinstance(b, list):
-            # One of the operands is a preserved expression
-            return [op, a, b]
-
-        # Convert to boolean for logical operations
-        # In Lisp-like languages, anything non-nil is truthy
-        a_bool = a is not None and a is not False
-        b_bool = b is not None and b is not False
+        a_bool = bool(a)
+        b_bool = bool(b)
 
         if op == "or":
             return a_bool or b_bool
         elif op == "and":
             return a_bool and b_bool
-        else:
-            raise DSLValidationError(f"Unknown logical operator: {op}")
 
     def _evaluate_wins(self, head, args):
         """Evaluate (wins TEAM) expression."""
-        self._validate_arg_count(head, args, 1)
+        if self._has_unresolved(args):
+            return Preserved([head, *args])
         team = args[0]
-        if isinstance(team, SymbolicTeam):
-            # Can't evaluate, preserve expression
-            return [head, team]
-        if not isinstance(team, Team):
-            raise DSLValidationError(f"Argument 1 must be a TEAM, got {type(team).__name__}")
         return team.wins()
 
     def _evaluate_losses(self, head, args):
         """Evaluate (losses TEAM) expression."""
-        self._validate_arg_count(head, args, 1)
+        if self._has_unresolved(args):
+            return Preserved([head, *args])
         team = args[0]
-        if isinstance(team, SymbolicTeam):
-            # Can't evaluate, preserve expression
-            return [head, team]
-        if not isinstance(team, Team):
-            raise DSLValidationError(f"Argument 1 must be a TEAM, got {type(team).__name__}")
         return team.losses()
 
     def _evaluate_winner(self, head, args):
         """Evaluate (winner MATCH) expression."""
-        self._validate_arg_count(head, args, 1)
+        if self._has_unresolved(args):
+            return Preserved([head, *args])
         match = args[0]
-        if isinstance(match, SymbolicMatch):
-            # Can't evaluate, preserve expression
-            return [head, match]
-        if not isinstance(match, Match):
-            raise DSLValidationError(f"Argument 1 must be a MATCH, got {type(match).__name__}")
-        winner = match.winner()
-        # winner() returns SymbolicTeam if unknown, which is fine
-        return winner
+        return match.winner()
 
     def _evaluate_loser(self, head, args):
         """Evaluate (loser MATCH) expression."""
-        self._validate_arg_count(head, args, 1)
+        if self._has_unresolved(args):
+            return Preserved([head, *args])
         match = args[0]
-        if isinstance(match, SymbolicMatch):
-            # Can't evaluate, preserve expression
-            return [head, match]
-        if not isinstance(match, Match):
-            raise DSLValidationError(f"Argument 1 must be a MATCH, got {type(match).__name__}")
-        loser = match.loser()
-        # loser() returns SymbolicTeam if unknown, which is fine
-        return loser
+        return match.loser()
 
     def _evaluate_points_won(self, head, args):
         """Evaluate (points-won TEAM MATCH?) expression."""
+        if self._has_unresolved(args):
+            return Preserved([head, *args])
         if len(args) == 1:
-            # (points-won TEAM)
-            team = args[0]
-            if isinstance(team, SymbolicTeam):
-                # Can't evaluate, preserve expression
-                return [head, team]
-            if not isinstance(team, Team):
-                raise DSLValidationError(f"Argument 1 must be a TEAM, got {type(team).__name__}")
-            return team.points_won()
-        elif len(args) == 2:
-            # (points-won TEAM MATCH)
-            team, match = args
-            if isinstance(team, SymbolicTeam) or isinstance(match, SymbolicMatch):
-                # Can't evaluate, preserve expression
-                return [head, team, match]
-            if not isinstance(team, Team):
-                raise DSLValidationError(f"Argument 1 must be a TEAM, got {type(team).__name__}")
-            if not isinstance(match, Match):
-                raise DSLValidationError(f"Argument 2 must be a MATCH, got {type(match).__name__}")
-            return team.points_won(match)
-        else:
-            raise DSLValidationError(f"({head} ...) expects 1 or 2 arguments, got {len(args)}")
+            return args[0].points_won()
+        team, match = args
+        return team.points_won(match)
 
     def _evaluate_points_lost(self, head, args):
         """Evaluate (points-lost TEAM MATCH?) expression."""
+        if self._has_unresolved(args):
+            return Preserved([head, *args])
         if len(args) == 1:
-            # (points-lost TEAM)
-            team = args[0]
-            if isinstance(team, SymbolicTeam):
-                # Can't evaluate, preserve expression
-                return [head, team]
-            if not isinstance(team, Team):
-                raise DSLValidationError(f"Argument 1 must be a TEAM, got {type(team).__name__}")
-            return team.points_lost()
-        elif len(args) == 2:
-            # (points-lost TEAM MATCH)
-            team, match = args
-            if isinstance(team, SymbolicTeam) or isinstance(match, SymbolicMatch):
-                # Can't evaluate, preserve expression
-                return [head, team, match]
-            if not isinstance(team, Team):
-                raise DSLValidationError(f"Argument 1 must be a TEAM, got {type(team).__name__}")
-            if not isinstance(match, Match):
-                raise DSLValidationError(f"Argument 2 must be a MATCH, got {type(match).__name__}")
-            return team.points_lost(match)
-        else:
-            raise DSLValidationError(f"({head} ...) expects 1 or 2 arguments, got {len(args)}")
+            return args[0].points_lost()
+        team, match = args
+        return team.points_lost(match)
 
     def _evaluate_is_skipped(self, head, args):
         """Evaluate (is-skipped MATCH) expression.
@@ -1096,14 +1152,13 @@ class Simplifier:
         """
         from app.domain.enums import MatchStatus
 
-        self._validate_arg_count(head, args, 1)
+        if self._has_unresolved(args):
+            return Preserved([head, *args])
         match = args[0]
-        if not isinstance(match, Match):
-            return [head, match]  # Can't simplify if match is not resolved
 
         status = getattr(match.obj, "status", None)
         if status is None:
-            return [head, match]  # Stay symbolic
+            return Preserved([head, match])  # Stay symbolic
 
         # Normalize to string for comparison (DB may store as enum or string)
         status_str = str(status) if status else None
@@ -1112,181 +1167,112 @@ class Simplifier:
         if status_str in (MatchStatus.IN_PROGRESS, MatchStatus.COMPLETED):
             return False
         # NOT_STARTED, TIME_FINALIZED, READY_TO_START: stay symbolic
-        return [head, match]
-
-    def _evaluate_cons(self, head, args):
-        """Evaluate (cons ...) expression - creates a list from arguments."""
-        # Check if any argument is a preserved expression
-        for arg in args:
-            if self._is_preserved_expression(arg) or isinstance(arg, (SymbolicTeam, SymbolicMatch)):
-                return [head] + args
-        return list(args)
+        return Preserved([head, match])
 
     def _evaluate_car(self, head, args):
         """Evaluate (car LIST) expression."""
-        self._validate_arg_count(head, args, 1)
         lst = args[0]
-        # Check if it's a preserved expression
         if self._is_preserved_expression(lst):
-            return [head, lst]
-        if not isinstance(lst, list):
-            raise DSLValidationError(f"Argument 1 must be a LIST, got {type(lst).__name__}")
+            return Preserved([head, lst])
         if not lst:
             raise DSLValidationError("Cannot take car of empty list")
         return lst[0]
 
     def _evaluate_cdr(self, head, args):
         """Evaluate (cdr LIST) expression."""
-        self._validate_arg_count(head, args, 1)
         lst = args[0]
-        # Check if it's a preserved expression
         if self._is_preserved_expression(lst):
-            return [head, lst]
-        if not isinstance(lst, list):
-            raise DSLValidationError(f"Argument 1 must be a LIST, got {type(lst).__name__}")
+            return Preserved([head, lst])
         if not lst:
             raise DSLValidationError("Cannot take cdr of empty list")
-        return lst[1:]
+        return List(lst[1:])
 
     def _evaluate_get(self, head, args):
         """Evaluate (get INDEX LIST) expression."""
-        self._validate_arg_count(head, args, 2)
         index, lst = args
-        # Check if index or list is a preserved expression
         if self._is_preserved_expression(index) or self._is_preserved_expression(lst):
-            return [head, index, lst]
-        if not isinstance(index, int):
-            raise DSLValidationError(f"Argument 1 must be an INT, got {type(index).__name__}")
-        if not isinstance(lst, list):
-            raise DSLValidationError(f"Argument 2 must be a LIST, got {type(lst).__name__}")
+            return Preserved([head, index, lst])
         if 0 <= index < len(lst):
             return lst[index]
-        else:
-            # Out of bounds - return None (NIL) as this is a valid result
-            return None
+        # Out of bounds — NIL is a valid result.
+        return Nil()
 
     def _evaluate_or_default(self, head, args):
         """Evaluate (or-default VAL DEFAULT) expression."""
-        self._validate_arg_count(head, args, 2)
+        if self._has_unresolved(args):
+            return Preserved([head, *args])
         val, default = args
-        # Check if either argument is a preserved expression
-        if self._is_preserved_expression(val) or self._is_preserved_expression(default):
-            return [head, val, default]
-        # No type validation - accepts any types
-        if val is not None:  # NIL is represented as None
+        if not isinstance(val, Nil):
             return val
         return default
 
     def _evaluate_len(self, head, args):
         """Evaluate (len LIST) expression."""
-        self._validate_arg_count(head, args, 1)
         lst = args[0]
-        # Check if it's a preserved expression
         if self._is_preserved_expression(lst):
-            return [head, lst]
-        if not isinstance(lst, list):
-            raise DSLValidationError(f"Argument 1 must be a LIST, got {type(lst).__name__}")
+            return Preserved([head, lst])
         return len(lst)
 
     def _evaluate_max(self, head, args):
         """Evaluate (max LIST) expression."""
-        self._validate_arg_count(head, args, 1)
         lst = args[0]
-        # Check if it's a preserved expression
         if self._is_preserved_expression(lst):
-            return [head, lst]
-        if not isinstance(lst, list):
-            raise DSLValidationError(f"Argument 1 must be a LIST, got {type(lst).__name__}")
+            return Preserved([head, lst])
         if not lst:
             raise DSLValidationError("Cannot find max of empty list")
-        if not all(isinstance(x, int) for x in lst):
+        if not all(type(x) is int for x in lst):
             raise DSLValidationError("max requires a list of integers")
         return max(lst)
 
     def _evaluate_min(self, head, args):
         """Evaluate (min LIST) expression."""
-        self._validate_arg_count(head, args, 1)
         lst = args[0]
-        # Check if it's a preserved expression
         if self._is_preserved_expression(lst):
-            return [head, lst]
-        if not isinstance(lst, list):
-            raise DSLValidationError(f"Argument 1 must be a LIST, got {type(lst).__name__}")
+            return Preserved([head, lst])
         if not lst:
             raise DSLValidationError("Cannot find min of empty list")
-        if not all(isinstance(x, int) for x in lst):
+        if not all(type(x) is int for x in lst):
             raise DSLValidationError("min requires a list of integers")
         return min(lst)
 
     def _evaluate_map(self, head, args):
         """Evaluate (map LIST FUNC) expression."""
-        self._validate_arg_count(head, args, 2)
         lst, func = args
-
-        # Check if list is a preserved expression (func is Lambda, not a list, so don't check it)
         if self._is_preserved_expression(lst):
-            return [head, lst, func]
-        if not isinstance(lst, list):
-            raise DSLValidationError(f"Argument 1 must be a LIST, got {type(lst).__name__}")
-        if not isinstance(func, Lambda):
-            raise DSLValidationError(f"Argument 2 must be a Lambda, got {type(func).__name__}")
-
-        # Apply function to each element
-        result = []
+            return Preserved([head, lst, func])
+        result = List()
         for item in lst:
             result.append(self._call_lambda(func, [item]))
         return result
 
     def _evaluate_reduce(self, head, args):
         """Evaluate (reduce LIST FUNC) expression."""
-        self._validate_arg_count(head, args, 2)
         lst, func = args
-
-        # Check if list is a preserved expression (func is Lambda, not a list, so don't check it)
         if self._is_preserved_expression(lst):
-            return [head, lst, func]
-        if not isinstance(lst, list):
-            raise DSLValidationError(f"Argument 1 must be a LIST, got {type(lst).__name__}")
-        if not isinstance(func, Lambda):
-            raise DSLValidationError(f"Argument 2 must be a Lambda, got {type(func).__name__}")
-
+            return Preserved([head, lst, func])
         if not lst:
             raise DSLValidationError("Cannot reduce empty list")
-
-        # Reduce: apply function cumulatively
         accumulator = lst[0]
         for item in lst[1:]:
             accumulator = self._call_lambda(func, [accumulator, item])
         return accumulator
 
     def _evaluate_max_by(self, head, args):
-        """Evaluate (max_by LIST FUNC) expression."""
-        self._validate_arg_count(head, args, 2)
+        """Evaluate (max-by LIST FUNC) expression."""
         lst, func = args
-
-        # Check if list is a preserved expression (func is Lambda, not a list, so don't check it)
-        # Only preserve if it's actually a preserved expression (starts with function name string)
-        if isinstance(lst, list) and self._is_preserved_expression(lst):
-            return [head, lst, func]
-        # Also preserve if list contains symbolic values
-        if isinstance(lst, list):
-            for item in lst:
-                if isinstance(item, (SymbolicTeam, SymbolicMatch)):
-                    return [head, lst, func]
-        if not isinstance(lst, list):
-            raise DSLValidationError(f"Argument 1 must be a LIST, got {type(lst).__name__}")
-        if not isinstance(func, Lambda):
-            raise DSLValidationError(f"Argument 2 must be a Lambda, got {type(func).__name__}")
-
+        if self._is_preserved_expression(lst):
+            return Preserved([head, lst, func])
+        # Preserve if list contains symbolic elements that can't be ordered yet.
+        for item in lst:
+            if isinstance(item, (SymbolicTeam, SymbolicMatch)):
+                return Preserved([head, lst, func])
         if not lst:
             raise DSLValidationError("Cannot find max_by of empty list")
-
-        # Find element with maximum value according to function
         max_val = None
         max_elem = None
         for item in lst:
             val = self._call_lambda(func, [item])
-            if not isinstance(val, int):
+            if not isinstance(val, int) or isinstance(val, bool):
                 raise DSLValidationError("max_by function must return an integer")
             if max_val is None or val > max_val:
                 max_val = val
@@ -1294,27 +1280,20 @@ class Simplifier:
         return max_elem
 
     def _evaluate_min_by(self, head, args):
-        """Evaluate (min_by LIST FUNC) expression."""
-        self._validate_arg_count(head, args, 2)
+        """Evaluate (min-by LIST FUNC) expression."""
         lst, func = args
-
-        # Check if list is a preserved expression (func is Lambda, not a list, so don't check it)
         if self._is_preserved_expression(lst):
-            return [head, lst, func]
-        if not isinstance(lst, list):
-            raise DSLValidationError(f"Argument 1 must be a LIST, got {type(lst).__name__}")
-        if not isinstance(func, Lambda):
-            raise DSLValidationError(f"Argument 2 must be a Lambda, got {type(func).__name__}")
-
+            return Preserved([head, lst, func])
+        for item in lst:
+            if isinstance(item, (SymbolicTeam, SymbolicMatch)):
+                return Preserved([head, lst, func])
         if not lst:
             raise DSLValidationError("Cannot find min_by of empty list")
-
-        # Find element with minimum value according to function
         min_val = None
         min_elem = None
         for item in lst:
             val = self._call_lambda(func, [item])
-            if not isinstance(val, int):
+            if not isinstance(val, int) or isinstance(val, bool):
                 raise DSLValidationError("min_by function must return an integer")
             if min_val is None or val < min_val:
                 min_val = val

--- a/app/utils/parser.py
+++ b/app/utils/parser.py
@@ -152,6 +152,127 @@ def _suggest_function(name: str, candidates) -> str | None:
     return matches[0] if matches else None
 
 
+# Return-type tables for the parser's built-in functions. A return type is a `frozenset`
+# of type-name strings; functions whose return type is fully determined by argument types
+# (e.g. `if`, `or-default`) are not in these tables — they're handled in `_infer_types`.
+_RETURN_TYPE_FIXED: dict[str, frozenset[str]] = {
+    "wins": frozenset({"INT"}),
+    "losses": frozenset({"INT"}),
+    "points-won": frozenset({"INT"}),
+    "points-lost": frozenset({"INT"}),
+    "+": frozenset({"INT"}),
+    "-": frozenset({"INT"}),
+    "*": frozenset({"INT"}),
+    "/": frozenset({"INT"}),
+    "len": frozenset({"INT"}),
+    "==": frozenset({"BOOL"}),
+    ">": frozenset({"BOOL"}),
+    "<": frozenset({"BOOL"}),
+    ">=": frozenset({"BOOL"}),
+    "<=": frozenset({"BOOL"}),
+    "or": frozenset({"BOOL"}),
+    "and": frozenset({"BOOL"}),
+    "not": frozenset({"BOOL"}),
+    "is-skipped": frozenset({"BOOL"}),
+    "winner": frozenset({"TEAM"}),
+    "loser": frozenset({"TEAM"}),
+    "cons": frozenset({"LIST"}),
+    "cdr": frozenset({"LIST"}),
+    "map": frozenset({"LIST"}),
+    "lambda": frozenset({"FUNC"}),
+}
+
+
+def _infer_list_element_types(lst) -> frozenset[str]:
+    """Infer the union of element types in a list-valued expression.
+
+    Handles both already-evaluated data lists (e.g. `[True, False, True]` from
+    a fully-concrete `cons`) and preserved `cons` expressions (`["cons", ...]`).
+    Returns `{"UNKNOWN"}` for anything else (e.g. a `map` preserved expression),
+    since the per-element type isn't visible without evaluating.
+    """
+    if isinstance(lst, list):
+        if lst and isinstance(lst[0], str):
+            if lst[0] == "cons":
+                elements = lst[1:]
+            else:
+                return frozenset({"UNKNOWN"})
+        else:
+            elements = lst
+        if not elements:
+            return frozenset({"UNKNOWN"})
+        types: frozenset[str] = frozenset()
+        for elem in elements:
+            types |= _infer_types(elem)
+        return types
+    return frozenset({"UNKNOWN"})
+
+
+def _infer_types(value) -> frozenset[str]:
+    """Infer the set of possible types of an interpreted DSL value.
+
+    Concrete values map directly. Preserved expressions (lists starting with a
+    function name) dispatch on the head: most functions have a fixed return type;
+    the few whose result type depends on their args (`if`, `or-default`, `get`,
+    `car`, `reduce`, `max`/`min`/`max-by`/`min-by`) recurse into their branches
+    and union the possibilities.
+
+    Returns `frozenset({"UNKNOWN"})` when nothing better can be said — callers
+    should treat that as "don't enforce a type constraint".
+    """
+    # Order matters: bool is a subclass of int, so check bool first.
+    if isinstance(value, bool):
+        return frozenset({"BOOL"})
+    if isinstance(value, int):
+        return frozenset({"INT"})
+    if value is None:
+        return frozenset({"NIL"})
+    if isinstance(value, (Team, SymbolicTeam)):
+        return frozenset({"TEAM"})
+    if isinstance(value, (Match, SymbolicMatch)):
+        return frozenset({"MATCH"})
+    if isinstance(value, Lambda):
+        return frozenset({"FUNC"})
+    if isinstance(value, list):
+        # Distinguish a preserved expression (head is a function-name string) from a
+        # plain data list. `cons` produces a data list of varied content.
+        if value and isinstance(value[0], str):
+            head = value[0]
+            args = value[1:]
+            if head in _RETURN_TYPE_FIXED:
+                return _RETURN_TYPE_FIXED[head]
+            if head == "if":
+                # (if cond then else) — type is union of the two branches.
+                if len(args) >= 3:
+                    return _infer_types(args[1]) | _infer_types(args[2])
+                return frozenset({"UNKNOWN"})
+            if head == "or-default":
+                # (or-default val default) — val if non-nil, else default; union them
+                # but exclude NIL from the val side since or-default falls through.
+                if len(args) >= 2:
+                    val_types = _infer_types(args[0]) - {"NIL"}
+                    return val_types | _infer_types(args[1])
+                return frozenset({"UNKNOWN"})
+            if head == "get":
+                # (get index list) — union of element types in the list, plus NIL for out-of-bounds.
+                if len(args) >= 2:
+                    return _infer_list_element_types(args[1]) | {"NIL"}
+                return frozenset({"UNKNOWN", "NIL"})
+            if head == "car":
+                # First element of a list — element types of the underlying list if we can see them.
+                if len(args) >= 1:
+                    return _infer_list_element_types(args[0])
+                return frozenset({"UNKNOWN"})
+            if head == "reduce":
+                return frozenset({"UNKNOWN"})
+            if head in ("max", "min", "max-by", "min-by"):
+                return frozenset({"UNKNOWN"})
+            return frozenset({"UNKNOWN"})
+        # Plain data list (cons output, or similar).
+        return frozenset({"LIST"})
+    return frozenset({"UNKNOWN"})
+
+
 class Lambda:
     """Represents a lambda function closure."""
 
@@ -840,7 +961,7 @@ class Simplifier:
     def _evaluate_logical_op(self, op, args):
         """Evaluate logical operations."""
         if op == "not":
-            self.validate_arg_count(op, args, 1)
+            self._validate_arg_count(op, args, 1)
             (a,) = args
             if isinstance(a, (SymbolicTeam, SymbolicMatch, list)):
                 return [op, a]

--- a/docs/arctos-schedule-script.md
+++ b/docs/arctos-schedule-script.md
@@ -93,18 +93,17 @@ consistency; it is recommended to instead use `(winner
 
 ## Lists
 
-You can construct a list using the `cons` function.
+All code is already a list, but it gets evaluated by default. To write
+a data list, you can use the `quote` function or the standard
+shorthand prefix `'`.
 
 ```
-(cons 1 2 3) -> the bare list 1 2 3
+(quote (1 2 3)) -> the data list 1 2 3
+'(1 2 3) -> also the data list 1 2 3
 (1 2 3) -> cannot call 1 as a function
 ```
 
-this works because you can think of the parenthesis surrounding a
-written list as if they were instructions to the parser to call the
-first item in the list. The list returned by `cons` doesn't have
-parenthesis around it, so it's fine (but you can't write these as a
-literal).
+Lists can have any (potentially mixed) data inside them. 
 
 Now here are some fun things you can do with lists:
 
@@ -119,7 +118,8 @@ Now here are some fun things you can do with lists:
 Now, lists are only really useful if you can loop through them, but we
 haven't introduced any form of looping yet. Since this is a functional
 language, we don't have the familiar concepts like for loops and while
-loops, but we do have `map`, `reduce`, and `lambda`.
+loops, but we do have `map`, `reduce`, and `lambda`. These may be
+familiar to you if you've used Google Sheets or Excel.
 
 First, `lambda` creates a function. The following expression is a
 function that takes two arguments, `a`, `b`, and `c`, and returns
@@ -150,7 +150,7 @@ and we get the correct answer of `15`. Or we can take the max of the list by usi
 (reduce (cons 1 2 5 3 4) (lambda (a b) (if (> a b) a b)))
 ```
 
-Some of these can be tedious to impelment, so i've included some builtins:
+Some of these can be tedious to implement, so i've included some builtins:
 
 - `(max LIST)` - get the max value
 - `(min LIST)` - get the min value
@@ -200,7 +200,7 @@ or the skip condition evaluates to `true` and it gets skipped.
 
 - `(if CONDITION IF_TRUE IF_FALSE)` - If condition is true, return IF_TRUE, otherwise return IF_FALSE  
 - `(lambda (*args) (output))` - Define a lambda function  
-- `(cons *_ )` - Create a list from the arguments  
+- `(quote VALUE)` - interpret VALUE as data, not code. Typically used for list literals
 - `(car LIST)` - Get the first element of a list  
 - `(cdr LIST)` - Get the rest of a list  
 - `(get INDEX LIST)` - Get the element at index  
@@ -216,5 +216,3 @@ or the skip condition evaluates to `true` and it gets skipped.
 - `(== 0 (losses [TeamName]))` - Skip if team has no losses  
 - `(> (wins [TeamA]) (wins [TeamB]))` - Skip if TeamA has more wins than TeamB  
 - `(== (winner {Match1}) [TeamName])` - Skip if TeamName won Match1  
-
-

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -26,7 +26,8 @@ web-sys = { version = "0.3", features = [
     "AudioContext", "AudioContextState", "AudioBuffer", "AudioBufferSourceNode", "AudioDestinationNode",
     "BaseAudioContext", "AudioContextOptions", "MediaStreamAudioDestinationNode",
     "OscillatorNode", "GainNode", "OscillatorType", "AudioParam",
-    "HtmlAudioElement", "HtmlInputElement", "HtmlCanvasElement", "CanvasRenderingContext2d",
+    "HtmlAudioElement", "HtmlInputElement", "HtmlTextAreaElement", "HtmlCanvasElement", "CanvasRenderingContext2d",
+    "CssStyleDeclaration",
     "DomException", "Blob", "Response", "Request", "RequestInit", "RequestMode",
     "Headers", "ResponseType", "MouseEvent", "DomRect", "TouchEvent", "Touch", "TouchList", "CustomEvent",
     "Url", "HtmlAnchorElement",
@@ -51,4 +52,3 @@ strip = "debuginfo"
 codegen-units = 1
 panic = "abort"
 incremental = false
-

--- a/frontend/src/components.rs
+++ b/frontend/src/components.rs
@@ -1,5 +1,6 @@
 //! Reusable UI components.
 
+mod ass_entry;
 mod change_password_card;
 mod edit_registration_modal;
 mod event_about;
@@ -11,6 +12,7 @@ mod league_registration_buttons;
 mod penalty_display;
 mod team_token_input;
 
+pub use ass_entry::AssEntry;
 pub use change_password_card::ChangePasswordCard;
 pub use edit_registration_modal::{EditRegistrationContext, EditRegistrationModal};
 pub use event_about::EventAbout;

--- a/frontend/src/components/ass_entry.rs
+++ b/frontend/src/components/ass_entry.rs
@@ -54,6 +54,19 @@ const DSL_FUNCTIONS: &[(&str, &str, &str)] = &[
     ("lambda", "(lambda (args) body)", "Define a function"),
 ];
 
+/// Set a textarea's height to fit its content: clear `height`, then read `scrollHeight`
+/// and write it back. Caps at a max so a runaway expression doesn't take over the form.
+#[cfg(target_arch = "wasm32")]
+fn autosize_textarea(el: &web_sys::HtmlTextAreaElement) {
+    let style = el.style();
+    let _ = style.set_property("height", "auto");
+    let h = el.scroll_height();
+    let max = 400;
+    let h = h.max(0).min(max);
+    let _ = style.set_property("height", &format!("{h}px"));
+    let _ = style.set_property("overflow-y", if el.scroll_height() > max { "auto" } else { "hidden" });
+}
+
 /// Find matching close bracket from open_pos (byte index of open char). Returns byte index of close char.
 fn find_matching_close(s: &str, open_byte_pos: usize, open_c: char, close_c: char) -> Option<usize> {
     let after_open = open_byte_pos + open_c.len_utf8();
@@ -156,6 +169,9 @@ enum PreviewToken {
     LoserCall(String),
     OpenBracket(char),
     CloseBracket(char),
+    /// A literal newline in the input — rendered as a flex-row break so subsequent
+    /// chips wrap to a new line, mirroring the textarea layout.
+    Newline,
 }
 
 /// If `s[i..]` starts with `( <ws>* (winner|loser) <ws>+ {NAME} <ws>* )`, return
@@ -205,9 +221,23 @@ fn tokenize_preview(s: &str) -> Vec<PreviewToken> {
     let bytes = s.as_bytes();
     let mut i = 0;
     let mut text_buf = String::new();
+    // Split accumulated text at `\n` so each newline becomes its own token. Empty
+    // segments between consecutive newlines are still pushed as empty Text so the
+    // resulting layout has the right number of row breaks.
     let flush_text = |buf: &mut String, out: &mut Vec<PreviewToken>| {
-        if !buf.is_empty() {
-            out.push(PreviewToken::Text(std::mem::take(buf)));
+        if buf.is_empty() {
+            return;
+        }
+        let taken = std::mem::take(buf);
+        let mut first = true;
+        for line in taken.split('\n') {
+            if !first {
+                out.push(PreviewToken::Newline);
+            }
+            first = false;
+            if !line.is_empty() {
+                out.push(PreviewToken::Text(line.to_string()));
+            }
         }
     };
     while i < bytes.len() {
@@ -255,9 +285,7 @@ fn tokenize_preview(s: &str) -> Vec<PreviewToken> {
         text_buf.push(c);
         i += 1;
     }
-    if !text_buf.is_empty() {
-        out.push(PreviewToken::Text(text_buf));
-    }
+    flush_text(&mut text_buf, &mut out);
     out
 }
 
@@ -465,6 +493,11 @@ fn render_expression_chips(
             PreviewToken::Text(s) => {
                 let key = format!("{key_prefix}-{i}");
                 rsx! { span { key: "{key}", class: "ass-entry-preview-text", "{s}" } }
+            }
+            PreviewToken::Newline => {
+                let key = format!("{key_prefix}-{i}");
+                // Empty flex item that takes the full row, forcing subsequent siblings to wrap.
+                rsx! { span { key: "{key}", class: "ass-entry-preview-break" } }
             }
             PreviewToken::OpenBracket(c) | PreviewToken::CloseBracket(c) => {
                 let key = format!("{key_prefix}-{i}");
@@ -778,6 +811,28 @@ pub fn AssEntry(
     // Tagged with the input string the simplification was computed for, so we can hide it
     // when the user has typed something that no longer matches.
     let mut simplified_msg = use_signal(|| None::<(String, String)>);
+    // Bumped on every keystroke so debounced async tasks can detect they're stale.
+    let mut validate_gen = use_signal(|| 0u64);
+
+    // Initial autosize so a pre-filled value (edit modal) shows at the right height.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let id_init = input_id.clone();
+        use_hook(move || {
+            spawn(async move {
+                gloo_timers::future::TimeoutFuture::new(0).await;
+                if let Some(window) = web_sys::window() {
+                    if let Some(doc) = window.document() {
+                        if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id_init)) {
+                            if let Ok(ta) = el.dyn_into::<web_sys::HtmlTextAreaElement>() {
+                                autosize_textarea(&ta);
+                            }
+                        }
+                    }
+                }
+            });
+        });
+    }
 
     // After auto-close insertions, we need to reposition the cursor on the next tick.
     #[cfg(target_arch = "wasm32")]
@@ -792,45 +847,16 @@ pub fn AssEntry(
                     if let Some(window) = web_sys::window() {
                         if let Some(doc) = window.document() {
                             if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
+                                if let Ok(input) = el.dyn_into::<web_sys::HtmlTextAreaElement>() {
                                     let _ = input.set_selection_range(p as u32, p as u32);
                                     let _ = input.focus();
+                                    autosize_textarea(&input);
                                 }
                             }
                         }
                     }
                 });
             }
-        });
-    }
-
-    // Debounced re-validation: when the value settles for ~500ms, ask the server for a
-    // fresh simplification. Without this, the simplified row only refreshes on blur,
-    // which is rare while the user is actively editing.
-    #[cfg(target_arch = "wasm32")]
-    {
-        let v_for_effect = value_rc.as_ref().clone();
-        let url_for_effect = tournament_url.clone();
-        use_effect(move || {
-            let v = v_for_effect.clone();
-            let url = url_for_effect.clone();
-            if v.trim().is_empty() || url.is_empty() {
-                return;
-            }
-            spawn(async move {
-                gloo_timers::future::TimeoutFuture::new(500).await;
-                let validated_for = v.clone();
-                if let Ok(res) = api::validate_dsl(&url, &v).await {
-                    if res.valid {
-                        error_msg.set(None);
-                        if let Some(simp) = res.simplified {
-                            simplified_msg.set(Some((validated_for, simp)));
-                        }
-                    } else {
-                        error_msg.set(res.error);
-                    }
-                }
-            });
         });
     }
 
@@ -871,6 +897,8 @@ pub fn AssEntry(
     let v_for_oninput = v.clone();
     let value_rc_input = value_rc.clone();
     let on_change_input = on_change.clone();
+    let url_for_input = tournament_url.clone();
+    let id_for_oninput = input_id.clone();
     let oninput_handler = move |e: Event<FormData>| {
         let new_val = e.value();
         let old = value_rc_input.as_ref().clone();
@@ -894,16 +922,66 @@ pub fn AssEntry(
         } else {
             (new_val, None)
         };
-        on_change_input.call(out);
+        on_change_input.call(out.clone());
         ac_open.set(true);
         ac_index.set(0);
         error_msg.set(None);
+
+        // Resize the textarea to fit its content on the next tick (after the DOM applies the new value).
+        #[cfg(target_arch = "wasm32")]
+        {
+            let id_resize = id_for_oninput.clone();
+            spawn(async move {
+                gloo_timers::future::TimeoutFuture::new(0).await;
+                if let Some(window) = web_sys::window() {
+                    if let Some(doc) = window.document() {
+                        if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id_resize)) {
+                            if let Ok(ta) = el.dyn_into::<web_sys::HtmlTextAreaElement>() {
+                                autosize_textarea(&ta);
+                            }
+                        }
+                    }
+                }
+            });
+        }
         // Don't wipe simplified_msg here. It's tagged with the input it was computed for, so
         // the rsx guard hides it automatically once the input no longer matches; that's
         // gentler than the row blinking out on every keystroke.
         if let Some(byte_after_open) = after_open {
             // ASCII brackets only — byte position equals char position.
             pending_cursor.set(Some(byte_after_open));
+        }
+
+        // Debounced re-validation: bump the generation counter, wait 500ms, only validate
+        // if no further keystroke happened in that window. Also requires the value to
+        // still match what we captured — defends against late-arriving prior responses.
+        let gen = validate_gen() + 1;
+        validate_gen.set(gen);
+        let url = url_for_input.clone();
+        let validated_for = out;
+        if !validated_for.trim().is_empty() && !url.is_empty() {
+            #[cfg(target_arch = "wasm32")]
+            spawn(async move {
+                gloo_timers::future::TimeoutFuture::new(500).await;
+                if validate_gen() != gen {
+                    return;
+                }
+                if let Ok(res) = api::validate_dsl(&url, &validated_for).await {
+                    if validate_gen() != gen {
+                        return;
+                    }
+                    if res.valid {
+                        error_msg.set(None);
+                        if let Some(simp) = res.simplified {
+                            simplified_msg.set(Some((validated_for, simp)));
+                        }
+                    } else {
+                        error_msg.set(res.error);
+                    }
+                }
+            });
+            #[cfg(not(target_arch = "wasm32"))]
+            let _ = (url, validated_for, gen);
         }
     };
 
@@ -984,9 +1062,11 @@ pub fn AssEntry(
                 return;
             }
         }
-        // Block raw Enter so it doesn't submit the form (Shift+Enter still bubbles up).
+        // Plain Enter inserts a newline. Stop propagation so the parent form's
+        // Enter-handler (which prevents default to block submission) doesn't squash it.
+        // Shift+Enter still bubbles up so the modal's Save shortcut keeps working.
         if key == "Enter" && !ev.modifiers().contains(Modifiers::SHIFT) {
-            ev.prevent_default();
+            ev.stop_propagation();
         }
         let _ = id_for_keydown.clone();
     };
@@ -1001,7 +1081,7 @@ pub fn AssEntry(
                 if let Some(window) = web_sys::window() {
                     if let Some(doc) = window.document() {
                         if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                            if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
+                            if let Ok(input) = el.dyn_into::<web_sys::HtmlTextAreaElement>() {
                                 if let Ok(Some(sel)) = input.selection_start() {
                                     cursor_pos.set(Some(sel as usize));
                                 }
@@ -1026,7 +1106,7 @@ pub fn AssEntry(
                 if let Some(window) = web_sys::window() {
                     if let Some(doc) = window.document() {
                         if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                            if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
+                            if let Ok(input) = el.dyn_into::<web_sys::HtmlTextAreaElement>() {
                                 if let Ok(Some(sel)) = input.selection_start() {
                                     cursor_pos.set(Some(sel as usize));
                                 }
@@ -1298,10 +1378,10 @@ pub fn AssEntry(
 
     rsx! {
         div { class: "ass-entry position-relative",
-            input {
+            textarea {
                 id: "{input_id}",
                 class: "form-control font-monospace ass-entry-input",
-                "type": "text",
+                rows: "1",
                 placeholder: "{placeholder}",
                 value: "{value}",
                 oninput: oninput_handler,

--- a/frontend/src/components/ass_entry.rs
+++ b/frontend/src/components/ass_entry.rs
@@ -143,13 +143,61 @@ pub fn innermost_around_cursor(s: &str, cursor_char: usize) -> Option<InnermostB
 
 /// Tokenize the expression for the preview row. Each token is a chunk of text the user wrote,
 /// classified as a literal kind so we can render chips for [..] and {..}.
+///
+/// As a special case, the patterns `(winner {NAME})` and `(loser {NAME})` collapse into a
+/// single `WinnerCall`/`LoserCall` token — they're conceptually a single team-reference,
+/// just spelled differently from `[NAME::winner]` / `[NAME::loser]`.
 #[derive(Clone, Debug)]
 enum PreviewToken {
     Text(String),
-    Team(String),    // raw inside [..]
-    Match(String),   // raw inside {..}
+    Team(String),
+    Match(String),
+    WinnerCall(String),
+    LoserCall(String),
     OpenBracket(char),
     CloseBracket(char),
+}
+
+/// If `s[i..]` starts with `( <ws>* (winner|loser) <ws>+ {NAME} <ws>* )`, return
+/// `(winner_or_loser, name, end_byte)` so we can collapse it into a single chip.
+fn match_winner_loser_call(s: &str, i: usize) -> Option<(bool, String, usize)> {
+    let bytes = s.as_bytes();
+    if bytes.get(i).copied() != Some(b'(') {
+        return None;
+    }
+    let mut j = i + 1;
+    while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+        j += 1;
+    }
+    let is_winner = if s[j..].starts_with("winner") {
+        j += "winner".len();
+        true
+    } else if s[j..].starts_with("loser") {
+        j += "loser".len();
+        false
+    } else {
+        return None;
+    };
+    if !bytes.get(j).map_or(false, |c| c.is_ascii_whitespace()) {
+        return None;
+    }
+    while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+        j += 1;
+    }
+    if bytes.get(j).copied() != Some(b'{') {
+        return None;
+    }
+    let after_open = j + 1;
+    let close_rel = s[after_open..].find('}')?;
+    let name = s[after_open..after_open + close_rel].trim().to_string();
+    let mut k = after_open + close_rel + 1;
+    while k < bytes.len() && bytes[k].is_ascii_whitespace() {
+        k += 1;
+    }
+    if bytes.get(k).copied() != Some(b')') {
+        return None;
+    }
+    Some((is_winner, name, k + 1))
 }
 
 fn tokenize_preview(s: &str) -> Vec<PreviewToken> {
@@ -157,17 +205,32 @@ fn tokenize_preview(s: &str) -> Vec<PreviewToken> {
     let bytes = s.as_bytes();
     let mut i = 0;
     let mut text_buf = String::new();
+    let flush_text = |buf: &mut String, out: &mut Vec<PreviewToken>| {
+        if !buf.is_empty() {
+            out.push(PreviewToken::Text(std::mem::take(buf)));
+        }
+    };
     while i < bytes.len() {
         let c = bytes[i] as char;
+        if c == '(' {
+            if let Some((is_winner, name, end)) = match_winner_loser_call(s, i) {
+                flush_text(&mut text_buf, &mut out);
+                if is_winner {
+                    out.push(PreviewToken::WinnerCall(name));
+                } else {
+                    out.push(PreviewToken::LoserCall(name));
+                }
+                i = end;
+                continue;
+            }
+        }
         if c == '[' || c == '{' {
             let close_c = if c == '[' { ']' } else { '}' };
             // Find first close in same kind without trying to support nesting (literals don't nest).
             let after = i + 1;
             if let Some(rel) = s[after..].find(close_c) {
                 let inner = &s[after..after + rel];
-                if !text_buf.is_empty() {
-                    out.push(PreviewToken::Text(std::mem::take(&mut text_buf)));
-                }
+                flush_text(&mut text_buf, &mut out);
                 if c == '[' {
                     out.push(PreviewToken::Team(inner.to_string()));
                 } else {
@@ -177,18 +240,14 @@ fn tokenize_preview(s: &str) -> Vec<PreviewToken> {
                 continue;
             } else {
                 // Unclosed: render as open bracket then continue rendering remaining text
-                if !text_buf.is_empty() {
-                    out.push(PreviewToken::Text(std::mem::take(&mut text_buf)));
-                }
+                flush_text(&mut text_buf, &mut out);
                 out.push(PreviewToken::OpenBracket(c));
                 i += 1;
                 continue;
             }
         }
         if c == ']' || c == '}' {
-            if !text_buf.is_empty() {
-                out.push(PreviewToken::Text(std::mem::take(&mut text_buf)));
-            }
+            flush_text(&mut text_buf, &mut out);
             out.push(PreviewToken::CloseBracket(c));
             i += 1;
             continue;
@@ -280,6 +339,289 @@ enum TeamRefKind {
     Loser(String),
 }
 
+/// Compact display name for a team — prefer `shortname` when present, then `pseudonym`, then id.
+fn team_short_label(t: &TeamOption) -> String {
+    t.shortname
+        .clone()
+        .or_else(|| t.pseudonym.clone())
+        .unwrap_or_else(|| t.id.clone())
+}
+
+/// One ASS atom (the kind of thing that can stand in for a team in a match): a team id,
+/// `tag::TagName`, or `MatchName::winner` / `MatchName::loser`. Used to render compact
+/// inline references in the match autocomplete.
+#[derive(Clone, Debug)]
+enum AssAtom {
+    Team(String),       // team id
+    Tag(String),        // tag name (without the "tag::" prefix)
+    Winner(String),     // match name
+    Loser(String),      // match name
+}
+
+fn parse_ass_atom(raw: &str) -> AssAtom {
+    let s = raw.trim();
+    if let Some(rest) = s.strip_suffix("::winner") {
+        return AssAtom::Winner(rest.trim().to_string());
+    }
+    if let Some(rest) = s.strip_suffix("::loser") {
+        return AssAtom::Loser(rest.trim().to_string());
+    }
+    if s.len() >= 5 && s[..5].eq_ignore_ascii_case("tag::") {
+        return AssAtom::Tag(s[5..].trim().to_string());
+    }
+    AssAtom::Team(s.to_string())
+}
+
+/// Render an ASS atom as a compact inline pill: avatar + shortname for teams, an
+/// icon + label for tags / winner / loser. Used in the match autocomplete to show
+/// who's playing and reffing without taking much space.
+fn render_atom_compact(
+    raw: &str,
+    base_url: &str,
+    team_options: &[TeamOption],
+    tags: &[TagSetupData],
+) -> Element {
+    let atom = parse_ass_atom(raw);
+    match atom {
+        AssAtom::Team(id) => {
+            if let Some(t) = team_options.iter().find(|t| t.id.eq_ignore_ascii_case(&id)) {
+                let label = team_short_label(t);
+                if let Some(p) = t.profile_photo.clone() {
+                    rsx! {
+                        span { class: "ass-atom",
+                            img {
+                                src: "{base_url}/static/{p}",
+                                alt: "",
+                                class: "ass-atom-avatar rounded-circle",
+                            }
+                            span { class: "ass-atom-label", "{label}" }
+                        }
+                    }
+                } else {
+                    let initial = label.chars().next().unwrap_or('?').to_string();
+                    rsx! {
+                        span { class: "ass-atom",
+                            span { class: "ass-atom-avatar ass-atom-avatar-text", "{initial}" }
+                            span { class: "ass-atom-label", "{label}" }
+                        }
+                    }
+                }
+            } else {
+                rsx! {
+                    span { class: "ass-atom ass-atom-unknown",
+                        span { class: "ass-atom-avatar ass-atom-avatar-text", "?" }
+                        span { class: "ass-atom-label", "{id}" }
+                    }
+                }
+            }
+        }
+        AssAtom::Tag(name) => {
+            let known = tags.iter().any(|t| t.name.eq_ignore_ascii_case(&name));
+            let cls = if known { "ass-atom" } else { "ass-atom ass-atom-unknown" };
+            rsx! {
+                span { class: "{cls}",
+                    img { class: "ass-atom-icon icon-primary-svg", src: "{base_url}/static/tag.svg", alt: "" }
+                    span { class: "ass-atom-label", "{name}" }
+                }
+            }
+        }
+        AssAtom::Winner(name) => rsx! {
+            span { class: "ass-atom",
+                img { class: "ass-atom-icon icon-primary-svg", src: "{base_url}/static/reference.svg", alt: "" }
+                span { class: "ass-atom-label", "{name}" }
+                span { class: "ass-atom-badge winner-badge", "W" }
+            }
+        },
+        AssAtom::Loser(name) => rsx! {
+            span { class: "ass-atom",
+                img { class: "ass-atom-icon icon-primary-svg", src: "{base_url}/static/reference.svg", alt: "" }
+                span { class: "ass-atom-label", "{name}" }
+                span { class: "ass-atom-badge loser-badge", "L" }
+            }
+        },
+    }
+}
+
+/// Split a comma-separated list of ASS atoms ("team1, tag::Foo, Match1::winner") into trimmed pieces.
+fn split_atoms(raw: &str) -> Vec<String> {
+    raw.split(',').map(str::trim).filter(|s| !s.is_empty()).map(str::to_string).collect()
+}
+
+/// Render an ASS expression string as a row of chips: literals (`[..]`/`{..}`) and the
+/// `(winner ...)` / `(loser ...)` patterns become labeled chips with resolution arrows;
+/// everything else passes through as plain text.
+fn render_expression_chips(
+    s: &str,
+    team_options: &[TeamOption],
+    tags: &[TagSetupData],
+    matches: &[MatchSetupData],
+    base_url: &str,
+    key_prefix: &str,
+) -> Vec<Element> {
+    tokenize_preview(s)
+        .into_iter()
+        .enumerate()
+        .map(|(i, tok)| match tok {
+            PreviewToken::Text(s) => {
+                let key = format!("{key_prefix}-{i}");
+                rsx! { span { key: "{key}", class: "ass-entry-preview-text", "{s}" } }
+            }
+            PreviewToken::OpenBracket(c) | PreviewToken::CloseBracket(c) => {
+                let key = format!("{key_prefix}-{i}");
+                let txt = c.to_string();
+                rsx! { span { key: "{key}", class: "ass-entry-preview-bracket text-warning", "{txt}" } }
+            }
+            PreviewToken::Team(inner) => {
+                let key = format!("{key_prefix}-{i}");
+                let (kind, resolved) = resolve_team_literal(&inner, team_options, tags, matches);
+                let (chip_class, label, icon) = match &kind {
+                    TeamRefKind::Team(name) => ("team-token-chip team-token-chip-team", name.clone(), None),
+                    TeamRefKind::Tag(name) => (
+                        "team-token-chip team-token-chip-tag",
+                        name.clone(),
+                        Some(("tag.svg", "Tag")),
+                    ),
+                    TeamRefKind::Winner(name) => (
+                        "team-token-chip team-token-chip-winner",
+                        format!("{} winner", name),
+                        Some(("reference.svg", "Reference")),
+                    ),
+                    TeamRefKind::Loser(name) => (
+                        "team-token-chip team-token-chip-loser",
+                        format!("{} loser", name),
+                        Some(("reference.svg", "Reference")),
+                    ),
+                };
+                let avatar = match (&kind, &resolved) {
+                    (TeamRefKind::Team(_), Some(r)) => {
+                        if let Some(p) = r.profile_photo.clone() {
+                            rsx! { img {
+                                src: "{base_url}/static/{p}",
+                                alt: "",
+                                class: "team-token-avatar rounded-circle",
+                                style: "width: 1.4em; height: 1.4em; object-fit: cover;"
+                            } }
+                        } else {
+                            rsx! { span { class: "team-token-avatar", "{r.display.chars().next().unwrap_or('?')}" } }
+                        }
+                    }
+                    (TeamRefKind::Team(name), None) => {
+                        rsx! { span { class: "team-token-avatar", "{name.chars().next().unwrap_or('?')}" } }
+                    }
+                    _ => {
+                        if let Some((icon_name, alt)) = icon {
+                            rsx! { img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/{icon_name}", alt: "{alt}" } }
+                        } else {
+                            rsx! {}
+                        }
+                    }
+                };
+                let resolved_arrow = match (&kind, resolved.clone()) {
+                    (TeamRefKind::Team(_), _) => rsx! {},
+                    (_, Some(r)) => {
+                        let disp = r.display.clone();
+                        let photo = r.profile_photo.clone();
+                        rsx! {
+                            span { class: "team-token-resolved text-muted ms-1",
+                                " → "
+                                if let Some(p) = photo {
+                                    img {
+                                        src: "{base_url}/static/{p}",
+                                        alt: "",
+                                        class: "team-token-avatar small rounded-circle ms-1",
+                                        style: "width: 1em; height: 1em; object-fit: cover; vertical-align: middle;"
+                                    }
+                                } else {
+                                    span { class: "team-token-avatar small ms-1", style: "display: inline-flex; width: 1em; height: 1em; align-items: center; justify-content: center; font-size: 0.85em;", "{disp.chars().next().unwrap_or('?')}" }
+                                }
+                                span { "{disp}" }
+                            }
+                        }
+                    }
+                    _ => rsx! {},
+                };
+                rsx! {
+                    span { key: "{key}", class: "{chip_class}",
+                        {avatar}
+                        span { class: "team-token-label", "{label}" }
+                        {resolved_arrow}
+                    }
+                }
+            }
+            PreviewToken::Match(inner) => {
+                let key = format!("{key_prefix}-{i}");
+                let name = inner.trim().to_string();
+                let known = matches.iter().any(|m| m.name.eq_ignore_ascii_case(&name));
+                let extra_class = if known { "" } else { " ass-entry-preview-unknown" };
+                rsx! {
+                    span { key: "{key}", class: "team-token-chip team-token-chip-match{extra_class}",
+                        img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/reference.svg", alt: "Match" }
+                        span { class: "team-token-label", "{name}" }
+                    }
+                }
+            }
+            ref tok @ (PreviewToken::WinnerCall(_) | PreviewToken::LoserCall(_)) => {
+                let key = format!("{key_prefix}-{i}");
+                let (name, is_winner) = match tok {
+                    PreviewToken::WinnerCall(n) => (n.clone(), true),
+                    PreviewToken::LoserCall(n) => (n.clone(), false),
+                    _ => unreachable!(),
+                };
+                let chip_class = if is_winner {
+                    "team-token-chip team-token-chip-winner"
+                } else {
+                    "team-token-chip team-token-chip-loser"
+                };
+                let label = if is_winner {
+                    format!("{} winner", name)
+                } else {
+                    format!("{} loser", name)
+                };
+                let resolved = matches
+                    .iter()
+                    .find(|m| m.name.eq_ignore_ascii_case(&name) && m.status.eq_ignore_ascii_case("COMPLETED"))
+                    .and_then(|m| {
+                        let side = m.match_winner.as_deref()?;
+                        let id = if is_winner {
+                            if side.eq_ignore_ascii_case("TEAM1") { m.team1.clone() } else if side.eq_ignore_ascii_case("TEAM2") { m.team2.clone() } else { None }
+                        } else if side.eq_ignore_ascii_case("TEAM1") { m.team2.clone() } else if side.eq_ignore_ascii_case("TEAM2") { m.team1.clone() } else { None }?;
+                        Some(id)
+                    })
+                    .and_then(|tid| team_options.iter().find(|t| t.id == tid).cloned());
+                let resolved_arrow = if let Some(t) = resolved {
+                    let team_label = team_short_label(&t);
+                    let photo = t.profile_photo.clone();
+                    rsx! {
+                        span { class: "team-token-resolved text-muted ms-1",
+                            " → "
+                            if let Some(p) = photo {
+                                img {
+                                    src: "{base_url}/static/{p}",
+                                    alt: "",
+                                    class: "team-token-avatar small rounded-circle ms-1",
+                                    style: "width: 1em; height: 1em; object-fit: cover; vertical-align: middle;"
+                                }
+                            } else {
+                                span { class: "team-token-avatar small ms-1", style: "display: inline-flex; width: 1em; height: 1em; align-items: center; justify-content: center; font-size: 0.85em;", "{team_label.chars().next().unwrap_or('?')}" }
+                            }
+                            span { "{team_label}" }
+                        }
+                    }
+                } else {
+                    rsx! {}
+                };
+                rsx! {
+                    span { key: "{key}", class: "{chip_class}",
+                        img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/reference.svg", alt: "Reference" }
+                        span { class: "team-token-label", "{label}" }
+                        {resolved_arrow}
+                    }
+                }
+            }
+        })
+        .collect()
+}
+
 #[derive(Clone, Debug)]
 enum AcOption {
     Function {
@@ -295,6 +637,7 @@ enum AcOption {
     Tag {
         insert: String,
         display: String,
+        resolved_team: Option<String>,
     },
     MatchRef {
         insert: String,
@@ -304,6 +647,10 @@ enum AcOption {
     Match {
         insert: String,
         display: String,
+        field: Option<String>,
+        team1: Option<String>,
+        team2: Option<String>,
+        refs: Vec<String>,
     },
 }
 
@@ -328,55 +675,57 @@ fn collect_team_options(
     matches: &[MatchSetupData],
 ) -> Vec<AcOption> {
     let q = query.to_lowercase();
-    let mut out: Vec<AcOption> = Vec::new();
-    for t in team_options.iter() {
-        let id_lower = t.id.to_lowercase();
-        let pseudo_lower = t.pseudonym.as_deref().unwrap_or("").to_lowercase();
-        if q.is_empty() || id_lower.contains(&q) || pseudo_lower.contains(&q) {
-            let display = t
+    // Build each kind separately, then interleave with per-kind caps so tags/matches always
+    // get a fair slice when there's no query (otherwise a long team list can starve them).
+    let team_opts: Vec<AcOption> = team_options
+        .iter()
+        .filter(|t| {
+            q.is_empty()
+                || t.id.to_lowercase().contains(&q)
+                || t.pseudonym.as_deref().unwrap_or("").to_lowercase().contains(&q)
+        })
+        .map(|t| AcOption::Team {
+            insert: t.id.clone(),
+            display: t
                 .pseudonym
                 .clone()
                 .map(|p| format!("{p} ({})", t.id))
-                .unwrap_or_else(|| t.id.clone());
-            out.push(AcOption::Team {
-                insert: t.id.clone(),
-                display,
-                photo: t.profile_photo.clone(),
-            });
-        }
-        if out.len() >= 20 {
-            break;
-        }
-    }
+                .unwrap_or_else(|| t.id.clone()),
+            photo: t.profile_photo.clone(),
+        })
+        .collect();
+    let tag_opts: Vec<AcOption> = tags
+        .iter()
+        .filter(|tag| q.is_empty() || tag.name.to_lowercase().contains(&q))
+        .map(|tag| AcOption::Tag {
+            insert: format!("tag::{}", tag.name),
+            display: tag.name.clone(),
+            resolved_team: tag.team.clone(),
+        })
+        .collect();
+    let mut match_ref_opts: Vec<AcOption> = Vec::new();
     for m in matches.iter() {
         if q.is_empty() || m.name.to_lowercase().contains(&q) {
-            out.push(AcOption::MatchRef {
+            match_ref_opts.push(AcOption::MatchRef {
                 insert: format!("{}::winner", m.name),
                 display: format!("{} winner", m.name),
                 is_winner: true,
             });
-            out.push(AcOption::MatchRef {
+            match_ref_opts.push(AcOption::MatchRef {
                 insert: format!("{}::loser", m.name),
                 display: format!("{} loser", m.name),
                 is_winner: false,
             });
         }
-        if out.len() >= 30 {
-            break;
-        }
     }
-    for tag in tags.iter() {
-        if q.is_empty() || tag.name.to_lowercase().contains(&q) {
-            out.push(AcOption::Tag {
-                insert: format!("tag::{}", tag.name),
-                display: tag.name.clone(),
-            });
-        }
-        if out.len() >= 35 {
-            break;
-        }
-    }
-    out.into_iter().take(25).collect()
+    // Caps: when the query is empty, give each kind a fair slice. With a query, prefer the
+    // best matches but keep tag/match-ref space available.
+    let (team_cap, tag_cap, match_cap) = if q.is_empty() { (12, 8, 10) } else { (15, 8, 10) };
+    let mut out: Vec<AcOption> = Vec::new();
+    out.extend(team_opts.into_iter().take(team_cap));
+    out.extend(tag_opts.into_iter().take(tag_cap));
+    out.extend(match_ref_opts.into_iter().take(match_cap));
+    out.into_iter().take(30).collect()
 }
 
 fn collect_match_options(query: &str, matches: &[MatchSetupData]) -> Vec<AcOption> {
@@ -388,6 +737,15 @@ fn collect_match_options(query: &str, matches: &[MatchSetupData]) -> Vec<AcOptio
         .map(|m| AcOption::Match {
             insert: m.name.clone(),
             display: m.name.clone(),
+            field: m.field.clone(),
+            team1: m.team1_initial.clone().or_else(|| m.team1.clone()),
+            team2: m.team2_initial.clone().or_else(|| m.team2.clone()),
+            refs: m
+                .refs_initial
+                .as_deref()
+                .or(m.refs.as_deref())
+                .map(split_atoms)
+                .unwrap_or_default(),
         })
         .collect()
 }
@@ -417,7 +775,9 @@ pub fn AssEntry(
     let mut ac_index = use_signal(|| 0usize);
     let mut ac_open = use_signal(|| false);
     let mut error_msg = use_signal(|| None::<String>);
-    let mut simplified_msg = use_signal(|| None::<String>);
+    // Tagged with the input string the simplification was computed for, so we can hide it
+    // when the user has typed something that no longer matches.
+    let mut simplified_msg = use_signal(|| None::<(String, String)>);
 
     // After auto-close insertions, we need to reposition the cursor on the next tick.
     #[cfg(target_arch = "wasm32")]
@@ -441,6 +801,36 @@ pub fn AssEntry(
                     }
                 });
             }
+        });
+    }
+
+    // Debounced re-validation: when the value settles for ~500ms, ask the server for a
+    // fresh simplification. Without this, the simplified row only refreshes on blur,
+    // which is rare while the user is actively editing.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let v_for_effect = value_rc.as_ref().clone();
+        let url_for_effect = tournament_url.clone();
+        use_effect(move || {
+            let v = v_for_effect.clone();
+            let url = url_for_effect.clone();
+            if v.trim().is_empty() || url.is_empty() {
+                return;
+            }
+            spawn(async move {
+                gloo_timers::future::TimeoutFuture::new(500).await;
+                let validated_for = v.clone();
+                if let Ok(res) = api::validate_dsl(&url, &v).await {
+                    if res.valid {
+                        error_msg.set(None);
+                        if let Some(simp) = res.simplified {
+                            simplified_msg.set(Some((validated_for, simp)));
+                        }
+                    } else {
+                        error_msg.set(res.error);
+                    }
+                }
+            });
         });
     }
 
@@ -508,7 +898,9 @@ pub fn AssEntry(
         ac_open.set(true);
         ac_index.set(0);
         error_msg.set(None);
-        simplified_msg.set(None);
+        // Don't wipe simplified_msg here. It's tagged with the input it was computed for, so
+        // the rsx guard hides it automatically once the input no longer matches; that's
+        // gentler than the row blinking out on every keystroke.
         if let Some(byte_after_open) = after_open {
             // ASCII brackets only — byte position equals char position.
             pending_cursor.set(Some(byte_after_open));
@@ -663,11 +1055,12 @@ pub fn AssEntry(
             return;
         }
         spawn(async move {
+            let validated_for = expr.clone();
             match api::validate_dsl(&url, &expr).await {
                 Ok(res) => {
                     if res.valid {
                         error_msg.set(None);
-                        simplified_msg.set(res.simplified);
+                        simplified_msg.set(res.simplified.map(|s| (validated_for, s)));
                     } else {
                         error_msg.set(res.error);
                         simplified_msg.set(None);
@@ -780,11 +1173,36 @@ pub fn AssEntry(
                         }
                     }
                 }
-                AcOption::Tag { display, .. } => {
+                AcOption::Tag { display, resolved_team, .. } => {
                     let d = display.clone();
+                    let resolved_node = resolved_team
+                        .as_ref()
+                        .and_then(|tid| team_options_for_render.iter().find(|t| &t.id == tid))
+                        .map(|t| {
+                            let label = team_short_label(t);
+                            let photo = t.profile_photo.clone();
+                            rsx! {
+                                span { class: "ass-entry-ac-resolved text-muted ms-2",
+                                    " → "
+                                    if let Some(p) = photo {
+                                        img {
+                                            src: "{base_url}/static/{p}",
+                                            alt: "",
+                                            class: "ass-atom-avatar rounded-circle",
+                                        }
+                                    } else {
+                                        span { class: "ass-atom-avatar ass-atom-avatar-text", "{label.chars().next().unwrap_or('?')}" }
+                                    }
+                                    span { "{label}" }
+                                }
+                            }
+                        });
                     rsx! {
-                        img { class: "icon-primary-svg me-1", src: "{base_url}/static/tag.svg", alt: "Tag", style: "width: 1.25em; height: 1.25em;" }
-                        span { "{d}" }
+                        span { class: "ass-entry-ac-row",
+                            img { class: "icon-primary-svg me-1", src: "{base_url}/static/tag.svg", alt: "Tag", style: "width: 1.25em; height: 1.25em;" }
+                            span { "{d}" }
+                            if let Some(r) = resolved_node { {r} }
+                        }
                     }
                 }
                 AcOption::MatchRef { display, is_winner, .. } => {
@@ -796,11 +1214,43 @@ pub fn AssEntry(
                         span { class: "team-token-badge ms-1 {badge}-badge small", "{badge}" }
                     }
                 }
-                AcOption::Match { display, .. } => {
+                AcOption::Match { display, field, team1, team2, refs, .. } => {
                     let d = display.clone();
+                    let field_str = field.clone().unwrap_or_default();
+                    let teams_for_atom = team_options_for_render.clone();
+                    let tags_for_atom = tags_for_render.clone();
+                    let team1_node = team1.as_deref().map(|raw| render_atom_compact(raw, &base_url, teams_for_atom.as_ref(), tags_for_atom.as_ref()));
+                    let teams_for_atom2 = team_options_for_render.clone();
+                    let tags_for_atom2 = tags_for_render.clone();
+                    let team2_node = team2.as_deref().map(|raw| render_atom_compact(raw, &base_url, teams_for_atom2.as_ref(), tags_for_atom2.as_ref()));
+                    let teams_for_refs = team_options_for_render.clone();
+                    let tags_for_refs = tags_for_render.clone();
+                    let refs_clone = refs.clone();
+                    let ref_nodes: Vec<_> = refs_clone
+                        .iter()
+                        .map(|raw| render_atom_compact(raw, &base_url, teams_for_refs.as_ref(), tags_for_refs.as_ref()))
+                        .collect();
                     rsx! {
-                        img { class: "icon-primary-svg me-1", src: "{base_url}/static/reference.svg", alt: "Match", style: "width: 1.25em; height: 1.25em;" }
-                        span { "{d}" }
+                        div { class: "ass-entry-ac-match-head",
+                            img { class: "icon-primary-svg me-1", src: "{base_url}/static/reference.svg", alt: "Match", style: "width: 1.25em; height: 1.25em;" }
+                            span { class: "ass-entry-ac-match-name", "{d}" }
+                            if !field_str.is_empty() {
+                                span { class: "ass-entry-ac-match-field text-muted ms-2", "on {field_str}" }
+                            }
+                        }
+                        div { class: "ass-entry-ac-match-meta small text-muted",
+                            if let Some(t) = team1_node { {t} }
+                            span { class: "ass-entry-ac-vs mx-1", "vs" }
+                            if let Some(t) = team2_node { {t} }
+                            if !ref_nodes.is_empty() {
+                                span { class: "ass-entry-ac-refs ms-2",
+                                    span { class: "me-1", "refs:" }
+                                    for ref_n in ref_nodes.iter() {
+                                        {ref_n.clone()}
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             };
@@ -817,120 +1267,34 @@ pub fn AssEntry(
         })
         .collect();
 
-    let preview_chips: Vec<_> = preview_tokens
-        .iter()
-        .enumerate()
-        .map(|(i, tok)| {
-            match tok {
-                PreviewToken::Text(s) => {
-                    let s = s.clone();
-                    rsx! { span { key: "{i}", class: "ass-entry-preview-text", "{s}" } }
-                }
-                PreviewToken::OpenBracket(c) => {
-                    let s = c.to_string();
-                    rsx! { span { key: "{i}", class: "ass-entry-preview-bracket text-warning", "{s}" } }
-                }
-                PreviewToken::CloseBracket(c) => {
-                    let s = c.to_string();
-                    rsx! { span { key: "{i}", class: "ass-entry-preview-bracket text-warning", "{s}" } }
-                }
-                PreviewToken::Team(inner) => {
-                    let (kind, resolved) = resolve_team_literal(
-                        inner,
-                        team_options_for_render.as_ref(),
-                        tags_for_render.as_ref(),
-                        matches_for_render.as_ref(),
-                    );
-                    let (chip_class, label, icon) = match &kind {
-                        TeamRefKind::Team(name) => ("team-token-chip team-token-chip-team", name.clone(), None),
-                        TeamRefKind::Tag(name) => (
-                            "team-token-chip team-token-chip-tag",
-                            name.clone(),
-                            Some(("tag.svg", "Tag")),
-                        ),
-                        TeamRefKind::Winner(name) => (
-                            "team-token-chip team-token-chip-winner",
-                            format!("{} winner", name),
-                            Some(("reference.svg", "Reference")),
-                        ),
-                        TeamRefKind::Loser(name) => (
-                            "team-token-chip team-token-chip-loser",
-                            format!("{} loser", name),
-                            Some(("reference.svg", "Reference")),
-                        ),
-                    };
-                    let avatar = match (&kind, &resolved) {
-                        (TeamRefKind::Team(_), Some(r)) => {
-                            if let Some(p) = r.profile_photo.clone() {
-                                rsx! { img {
-                                    src: "{base_url}/static/{p}",
-                                    alt: "",
-                                    class: "team-token-avatar rounded-circle",
-                                    style: "width: 1.4em; height: 1.4em; object-fit: cover;"
-                                } }
-                            } else {
-                                rsx! { span { class: "team-token-avatar", "{r.display.chars().next().unwrap_or('?')}" } }
-                            }
-                        }
-                        (TeamRefKind::Team(name), None) => {
-                            rsx! { span { class: "team-token-avatar", "{name.chars().next().unwrap_or('?')}" } }
-                        }
-                        _ => {
-                            if let Some((icon_name, alt)) = icon {
-                                rsx! { img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/{icon_name}", alt: "{alt}" } }
-                            } else {
-                                rsx! { }
-                            }
-                        }
-                    };
-                    let resolved_arrow = if let Some(r) = resolved.clone() {
-                        if !matches!(kind, TeamRefKind::Team(_)) {
-                            let disp = r.display.clone();
-                            let photo = r.profile_photo.clone();
-                            rsx! {
-                                span { class: "team-token-resolved text-muted ms-1",
-                                    " → "
-                                    if let Some(p) = photo {
-                                        img {
-                                            src: "{base_url}/static/{p}",
-                                            alt: "",
-                                            class: "team-token-avatar small rounded-circle ms-1",
-                                            style: "width: 1em; height: 1em; object-fit: cover; vertical-align: middle;"
-                                        }
-                                    } else {
-                                        span { class: "team-token-avatar small ms-1", style: "display: inline-flex; width: 1em; height: 1em; align-items: center; justify-content: center; font-size: 0.85em;", "{disp.chars().next().unwrap_or('?')}" }
-                                    }
-                                    span { "{disp}" }
-                                }
-                            }
-                        } else {
-                            rsx! { }
-                        }
-                    } else {
-                        rsx! { }
-                    };
-                    rsx! {
-                        span { key: "{i}", class: "{chip_class}",
-                            {avatar}
-                            span { class: "team-token-label", "{label}" }
-                            {resolved_arrow}
-                        }
-                    }
-                }
-                PreviewToken::Match(inner) => {
-                    let name = inner.trim().to_string();
-                    let known = matches_for_render.iter().any(|m| m.name.eq_ignore_ascii_case(&name));
-                    let extra_class = if known { "" } else { " ass-entry-preview-unknown" };
-                    rsx! {
-                        span { key: "{i}", class: "team-token-chip team-token-chip-match{extra_class}",
-                            img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/reference.svg", alt: "Match" }
-                            span { class: "team-token-label", "{name}" }
-                        }
-                    }
-                }
-            }
-        })
-        .collect();
+    let preview_chips = render_expression_chips(
+        &v,
+        team_options_for_render.as_ref(),
+        tags_for_render.as_ref(),
+        matches_for_render.as_ref(),
+        &base_url,
+        "input",
+    );
+    // Show the simplified row only when the cached simplification was computed for the
+    // exact value currently in the input — keeps stale results from confusing the user.
+    let simplified_value: Option<String> = simplified_msg().and_then(|(input_at, simp)| {
+        if input_at.trim() == v.trim() {
+            Some(simp)
+        } else {
+            None
+        }
+    });
+    let simplified_chips = simplified_value.as_deref().map(|simp| {
+        render_expression_chips(
+            simp,
+            team_options_for_render.as_ref(),
+            tags_for_render.as_ref(),
+            matches_for_render.as_ref(),
+            &base_url,
+            "simp",
+        )
+    });
+    let _ = preview_tokens;
 
     rsx! {
         div { class: "ass-entry position-relative",
@@ -960,10 +1324,18 @@ pub fn AssEntry(
                     }
                 }
             }
+            if let Some(chips) = simplified_chips.as_ref() {
+                div { class: "ass-entry-simplified small",
+                    span { class: "ass-entry-simplified-label text-muted me-1", "simplified:" }
+                    for chip in chips.iter() {
+                        {chip.clone()}
+                    }
+                }
+            }
             if let Some(err) = error_msg() {
                 div { class: "form-text text-danger ass-entry-error", "✗ {err}" }
-            } else if let Some(simp) = simplified_msg() {
-                div { class: "form-text text-success", "✓ Valid (simplified: {simp})" }
+            } else if simplified_value.is_some() {
+                div { class: "form-text text-success", "✓ Valid" }
             } else if !value.trim().is_empty() {
                 div { class: "form-text text-success", "✓" }
             }

--- a/frontend/src/components/ass_entry.rs
+++ b/frontend/src/components/ass_entry.rs
@@ -55,7 +55,7 @@ const DSL_FUNCTIONS: &[(&str, &str, &str)] = &[
     ("-", "(- INT INT) -> INT", "Subtraction"),
     ("*", "(* INT INT) -> INT", "Multiplication"),
     ("/", "(/ INT INT) -> INT", "Integer division"),
-    ("cons", "(cons *_) -> LIST", "Build a list from arguments"),
+    ("quote", "(quote EXPR) / 'EXPR", "Literal expression, unevaluated"),
     ("car", "(car LIST)", "First element"),
     ("cdr", "(cdr LIST)", "All but the first element"),
     ("get", "(get INDEX LIST)", "Element at INDEX, or NIL"),

--- a/frontend/src/components/ass_entry.rs
+++ b/frontend/src/components/ass_entry.rs
@@ -20,12 +20,28 @@ use wasm_bindgen::JsCast as _;
 /// (name, signature, short description)
 const DSL_FUNCTIONS: &[(&str, &str, &str)] = &[
     ("wins", "(wins TEAM) -> INT", "Wins for a team this event"),
-    ("losses", "(losses TEAM) -> INT", "Losses for a team this event"),
+    (
+        "losses",
+        "(losses TEAM) -> INT",
+        "Losses for a team this event",
+    ),
     ("winner", "(winner MATCH) -> TEAM", "Winner of a match"),
     ("loser", "(loser MATCH) -> TEAM", "Loser of a match"),
-    ("points-won", "(points-won TEAM MATCH?) -> INT", "Points won (optionally in MATCH)"),
-    ("points-lost", "(points-lost TEAM MATCH?) -> INT", "Points lost (optionally in MATCH)"),
-    ("is-skipped", "(is-skipped MATCH) -> BOOL", "True if match was skipped"),
+    (
+        "points-won",
+        "(points-won TEAM MATCH?) -> INT",
+        "Points won (optionally in MATCH)",
+    ),
+    (
+        "points-lost",
+        "(points-lost TEAM MATCH?) -> INT",
+        "Points lost (optionally in MATCH)",
+    ),
+    (
+        "is-skipped",
+        "(is-skipped MATCH) -> BOOL",
+        "True if match was skipped",
+    ),
     ("if", "(if COND IF_TRUE IF_FALSE)", "Conditional"),
     ("and", "(and BOOL BOOL) -> BOOL", "Logical and"),
     ("or", "(or BOOL BOOL) -> BOOL", "Logical or"),
@@ -44,15 +60,101 @@ const DSL_FUNCTIONS: &[(&str, &str, &str)] = &[
     ("cdr", "(cdr LIST)", "All but the first element"),
     ("get", "(get INDEX LIST)", "Element at INDEX, or NIL"),
     ("len", "(len LIST) -> INT", "Length of a list"),
-    ("or-default", "(or-default VAL DEFAULT)", "VAL if not NIL else DEFAULT"),
-    ("map", "(map LIST FUNC) -> LIST", "Apply FUNC to each element"),
+    (
+        "or-default",
+        "(or-default VAL DEFAULT)",
+        "VAL if not NIL else DEFAULT",
+    ),
+    (
+        "map",
+        "(map LIST FUNC) -> LIST",
+        "Apply FUNC to each element",
+    ),
     ("reduce", "(reduce LIST FUNC)", "Combine elements with FUNC"),
     ("max", "(max LIST)", "Maximum of a list"),
     ("min", "(min LIST)", "Minimum of a list"),
-    ("max-by", "(max-by LIST FUNC)", "Element with max FUNC value"),
-    ("min-by", "(min-by LIST FUNC)", "Element with min FUNC value"),
+    (
+        "max-by",
+        "(max-by LIST FUNC)",
+        "Element with max FUNC value",
+    ),
+    (
+        "min-by",
+        "(min-by LIST FUNC)",
+        "Element with min FUNC value",
+    ),
     ("lambda", "(lambda (args) body)", "Define a function"),
 ];
+
+/// Format a "type mismatch" message for the validity row.
+fn type_mismatch_message(expected: &[String], got: &[String]) -> String {
+    let exp_label = expected.join(" or ");
+    if got.is_empty() || got.iter().any(|t| t == "UNKNOWN") {
+        format!("Expected {exp_label}, but the type couldn't be determined.")
+    } else {
+        let got_label = got.join(" | ");
+        format!("Expected {exp_label}, got {got_label}.")
+    }
+}
+
+/// Returns Ok(()) when `got` is a non-empty subset of `expected` (with no UNKNOWN);
+/// otherwise Err with a human-readable explanation. `expected` empty means no constraint.
+fn check_expected_type(expected: Option<&[String]>, got: &[String]) -> Result<(), String> {
+    let Some(exp) = expected else {
+        return Ok(());
+    };
+    if exp.is_empty() {
+        return Ok(());
+    }
+    if got.is_empty() || got.iter().any(|t| t == "UNKNOWN") {
+        return Err(type_mismatch_message(exp, got));
+    }
+    if got.iter().all(|t| exp.iter().any(|e| e == t)) {
+        Ok(())
+    } else {
+        Err(type_mismatch_message(exp, got))
+    }
+}
+
+/// Apply a successful validate-dsl response to the ass-entry signals: surface error / simplified
+/// chips, run the expected-type check, and report the final verdict via `on_validity_change`.
+fn apply_validation_response(
+    res: ValidateDslResponse,
+    validated_for: String,
+    expected: Option<&[String]>,
+    mut error_msg: Signal<Option<String>>,
+    mut simplified_msg: Signal<Option<(String, String)>>,
+    on_validity_change: Option<EventHandler<Option<Result<(), String>>>>,
+) {
+    if !res.valid {
+        let err = res
+            .error
+            .unwrap_or_else(|| "invalid expression".to_string());
+        error_msg.set(Some(err.clone()));
+        simplified_msg.set(None);
+        if let Some(h) = on_validity_change {
+            h.call(Some(Err(err)));
+        }
+        return;
+    }
+    if let Some(simp) = res.simplified.clone() {
+        simplified_msg.set(Some((validated_for, simp)));
+    }
+    match check_expected_type(expected, &res.result_type) {
+        Ok(()) => {
+            error_msg.set(None);
+            if let Some(h) = on_validity_change {
+                h.call(Some(Ok(())));
+            }
+        }
+        Err(msg) => {
+            error_msg.set(Some(msg.clone()));
+            if let Some(h) = on_validity_change {
+                h.call(Some(Err(msg)));
+            }
+        }
+    }
+}
 
 /// Set a textarea's height to fit its content: clear `height`, then read `scrollHeight`
 /// and write it back. Caps at a max so a runaway expression doesn't take over the form.
@@ -64,11 +166,23 @@ fn autosize_textarea(el: &web_sys::HtmlTextAreaElement) {
     let max = 400;
     let h = h.max(0).min(max);
     let _ = style.set_property("height", &format!("{h}px"));
-    let _ = style.set_property("overflow-y", if el.scroll_height() > max { "auto" } else { "hidden" });
+    let _ = style.set_property(
+        "overflow-y",
+        if el.scroll_height() > max {
+            "auto"
+        } else {
+            "hidden"
+        },
+    );
 }
 
 /// Find matching close bracket from open_pos (byte index of open char). Returns byte index of close char.
-fn find_matching_close(s: &str, open_byte_pos: usize, open_c: char, close_c: char) -> Option<usize> {
+fn find_matching_close(
+    s: &str,
+    open_byte_pos: usize,
+    open_c: char,
+    close_c: char,
+) -> Option<usize> {
     let after_open = open_byte_pos + open_c.len_utf8();
     let rest = s.get(after_open..)?;
     let mut depth = 1u32;
@@ -87,7 +201,10 @@ fn find_matching_close(s: &str, open_byte_pos: usize, open_c: char, close_c: cha
 
 /// Convert a cursor position in characters to byte offset.
 fn cursor_byte(s: &str, cursor_char: usize) -> usize {
-    s.char_indices().nth(cursor_char).map(|(i, _)| i).unwrap_or(s.len())
+    s.char_indices()
+        .nth(cursor_char)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len())
 }
 
 /// Index in `new` (byte offset) of the inserted character when `new.len() == old.len() + 1`.
@@ -125,7 +242,11 @@ pub fn innermost_around_cursor(s: &str, cursor_char: usize) -> Option<InnermostB
     let cb = cursor_byte(s, cursor_char);
     let mut best: Option<(usize, InnermostBracket)> = None;
 
-    let consider = |open_c: char, close_c: char, best: &mut Option<(usize, InnermostBracket)>, s: &str, cb: usize| {
+    let consider = |open_c: char,
+                    close_c: char,
+                    best: &mut Option<(usize, InnermostBracket)>,
+                    s: &str,
+                    cb: usize| {
         let Some(open_pos) = s[..cb].rfind(open_c) else {
             return;
         };
@@ -308,7 +429,9 @@ fn resolve_team_literal(
         let name = rest.trim();
         let resolved = matches
             .iter()
-            .find(|m| m.name.eq_ignore_ascii_case(name) && m.status.eq_ignore_ascii_case("COMPLETED"))
+            .find(|m| {
+                m.name.eq_ignore_ascii_case(name) && m.status.eq_ignore_ascii_case("COMPLETED")
+            })
             .and_then(|m| match m.match_winner.as_deref() {
                 Some(s) if s.eq_ignore_ascii_case("TEAM1") => m.team1.clone(),
                 Some(s) if s.eq_ignore_ascii_case("TEAM2") => m.team2.clone(),
@@ -317,7 +440,11 @@ fn resolve_team_literal(
             .and_then(|tid| team_options.iter().find(|t| t.id == tid))
             .map(|t| TeamRefResolved {
                 profile_photo: t.profile_photo.clone(),
-                display: t.pseudonym.clone().map(|p| format!("{p} ({})", t.id)).unwrap_or_else(|| t.id.clone()),
+                display: t
+                    .pseudonym
+                    .clone()
+                    .map(|p| format!("{p} ({})", t.id))
+                    .unwrap_or_else(|| t.id.clone()),
             });
         return (TeamRefKind::Winner(name.to_string()), resolved);
     }
@@ -325,7 +452,9 @@ fn resolve_team_literal(
         let name = rest.trim();
         let resolved = matches
             .iter()
-            .find(|m| m.name.eq_ignore_ascii_case(name) && m.status.eq_ignore_ascii_case("COMPLETED"))
+            .find(|m| {
+                m.name.eq_ignore_ascii_case(name) && m.status.eq_ignore_ascii_case("COMPLETED")
+            })
             .and_then(|m| match m.match_winner.as_deref() {
                 Some(s) if s.eq_ignore_ascii_case("TEAM1") => m.team2.clone(),
                 Some(s) if s.eq_ignore_ascii_case("TEAM2") => m.team1.clone(),
@@ -334,7 +463,11 @@ fn resolve_team_literal(
             .and_then(|tid| team_options.iter().find(|t| t.id == tid))
             .map(|t| TeamRefResolved {
                 profile_photo: t.profile_photo.clone(),
-                display: t.pseudonym.clone().map(|p| format!("{p} ({})", t.id)).unwrap_or_else(|| t.id.clone()),
+                display: t
+                    .pseudonym
+                    .clone()
+                    .map(|p| format!("{p} ({})", t.id))
+                    .unwrap_or_else(|| t.id.clone()),
             });
         return (TeamRefKind::Loser(name.to_string()), resolved);
     }
@@ -347,14 +480,24 @@ fn resolve_team_literal(
             .and_then(|tid| team_options.iter().find(|t| t.id == tid).cloned())
             .map(|t| TeamRefResolved {
                 profile_photo: t.profile_photo.clone(),
-                display: t.pseudonym.clone().map(|p| format!("{p} ({})", t.id)).unwrap_or_else(|| t.id.clone()),
+                display: t
+                    .pseudonym
+                    .clone()
+                    .map(|p| format!("{p} ({})", t.id))
+                    .unwrap_or_else(|| t.id.clone()),
             });
         return (TeamRefKind::Tag(name.to_string()), resolved);
     }
-    let team = team_options.iter().find(|t| t.id.eq_ignore_ascii_case(trimmed));
+    let team = team_options
+        .iter()
+        .find(|t| t.id.eq_ignore_ascii_case(trimmed));
     let resolved = team.map(|t| TeamRefResolved {
         profile_photo: t.profile_photo.clone(),
-        display: t.pseudonym.clone().map(|p| format!("{p} ({})", t.id)).unwrap_or_else(|| t.id.clone()),
+        display: t
+            .pseudonym
+            .clone()
+            .map(|p| format!("{p} ({})", t.id))
+            .unwrap_or_else(|| t.id.clone()),
     });
     (TeamRefKind::Team(trimmed.to_string()), resolved)
 }
@@ -380,10 +523,10 @@ fn team_short_label(t: &TeamOption) -> String {
 /// inline references in the match autocomplete.
 #[derive(Clone, Debug)]
 enum AssAtom {
-    Team(String),       // team id
-    Tag(String),        // tag name (without the "tag::" prefix)
-    Winner(String),     // match name
-    Loser(String),      // match name
+    Team(String),   // team id
+    Tag(String),    // tag name (without the "tag::" prefix)
+    Winner(String), // match name
+    Loser(String),  // match name
 }
 
 fn parse_ass_atom(raw: &str) -> AssAtom {
@@ -445,7 +588,11 @@ fn render_atom_compact(
         }
         AssAtom::Tag(name) => {
             let known = tags.iter().any(|t| t.name.eq_ignore_ascii_case(&name));
-            let cls = if known { "ass-atom" } else { "ass-atom ass-atom-unknown" };
+            let cls = if known {
+                "ass-atom"
+            } else {
+                "ass-atom ass-atom-unknown"
+            };
             rsx! {
                 span { class: "{cls}",
                     img { class: "ass-atom-icon icon-primary-svg", src: "{base_url}/static/tag.svg", alt: "" }
@@ -472,7 +619,11 @@ fn render_atom_compact(
 
 /// Split a comma-separated list of ASS atoms ("team1, tag::Foo, Match1::winner") into trimmed pieces.
 fn split_atoms(raw: &str) -> Vec<String> {
-    raw.split(',').map(str::trim).filter(|s| !s.is_empty()).map(str::to_string).collect()
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 /// Render an ASS expression string as a row of chips: literals (`[..]`/`{..}`) and the
@@ -715,7 +866,11 @@ fn collect_team_options(
         .filter(|t| {
             q.is_empty()
                 || t.id.to_lowercase().contains(&q)
-                || t.pseudonym.as_deref().unwrap_or("").to_lowercase().contains(&q)
+                || t.pseudonym
+                    .as_deref()
+                    .unwrap_or("")
+                    .to_lowercase()
+                    .contains(&q)
         })
         .map(|t| AcOption::Team {
             insert: t.id.clone(),
@@ -753,7 +908,11 @@ fn collect_team_options(
     }
     // Caps: when the query is empty, give each kind a fair slice. With a query, prefer the
     // best matches but keep tag/match-ref space available.
-    let (team_cap, tag_cap, match_cap) = if q.is_empty() { (12, 8, 10) } else { (15, 8, 10) };
+    let (team_cap, tag_cap, match_cap) = if q.is_empty() {
+        (12, 8, 10)
+    } else {
+        (15, 8, 10)
+    };
     let mut out: Vec<AcOption> = Vec::new();
     out.extend(team_opts.into_iter().take(team_cap));
     out.extend(tag_opts.into_iter().take(tag_cap));
@@ -795,6 +954,18 @@ pub fn AssEntry(
     /// For server-side validate-dsl on blur. Pass empty to skip server validation.
     tournament_url: String,
     #[props(default = String::from("e.g. (== 0 (losses [Team]))"))] placeholder: String,
+    /// If set, the expression is valid only when its result type is a subset of this list.
+    /// Type names match the backend: "INT" | "BOOL" | "NIL" | "TEAM" | "MATCH" | "LIST" | "FUNC".
+    /// "UNKNOWN" is always treated as a mismatch (we can't prove it's the right type).
+    /// Leave None to skip type checking.
+    #[props(optional)]
+    expected_type: Option<Vec<String>>,
+    /// Reports the latest validation status to the parent. `Some(Ok(()))` means the
+    /// expression validated and matched `expected_type`; `Some(Err(msg))` means it
+    /// failed (parse error, server error, or type mismatch); `None` means no result
+    /// yet (empty input or in-flight). Useful for blocking form submission.
+    #[props(optional)]
+    on_validity_change: Option<EventHandler<Option<Result<(), String>>>>,
 ) -> Element {
     let input_id = format!("ass-entry-{}", id_suffix);
 
@@ -876,7 +1047,12 @@ pub fn AssEntry(
             Some(InnermostBracket::Square(cs, ce)) => {
                 let end = (*ce).min(cursor_b).max(*cs);
                 let q = v[*cs..end].trim();
-                collect_team_options(q, team_options_rc.as_ref(), tags_rc.as_ref(), matches_rc.as_ref())
+                collect_team_options(
+                    q,
+                    team_options_rc.as_ref(),
+                    tags_rc.as_ref(),
+                    matches_rc.as_ref(),
+                )
             }
             Some(InnermostBracket::Curly(cs, ce)) => {
                 let end = (*ce).min(cursor_b).max(*cs);
@@ -899,6 +1075,7 @@ pub fn AssEntry(
     let on_change_input = on_change.clone();
     let url_for_input = tournament_url.clone();
     let id_for_oninput = input_id.clone();
+    let expected_type_input = expected_type.clone();
     let oninput_handler = move |e: Event<FormData>| {
         let new_val = e.value();
         let old = value_rc_input.as_ref().clone();
@@ -914,7 +1091,12 @@ pub fn AssEntry(
             };
             if let Some(close_c) = closing {
                 let char_end = byte_i + open_c.len_utf8();
-                let out_str = format!("{}{}{}", &new_val[..char_end], close_c, &new_val[char_end..]);
+                let out_str = format!(
+                    "{}{}{}",
+                    &new_val[..char_end],
+                    close_c,
+                    &new_val[char_end..]
+                );
                 (out_str, Some(char_end))
             } else {
                 (new_val, None)
@@ -958,6 +1140,7 @@ pub fn AssEntry(
         let gen = validate_gen() + 1;
         validate_gen.set(gen);
         let url = url_for_input.clone();
+        let expected = expected_type_input.clone();
         let validated_for = out;
         if !validated_for.trim().is_empty() && !url.is_empty() {
             #[cfg(target_arch = "wasm32")]
@@ -970,18 +1153,18 @@ pub fn AssEntry(
                     if validate_gen() != gen {
                         return;
                     }
-                    if res.valid {
-                        error_msg.set(None);
-                        if let Some(simp) = res.simplified {
-                            simplified_msg.set(Some((validated_for, simp)));
-                        }
-                    } else {
-                        error_msg.set(res.error);
-                    }
+                    apply_validation_response(
+                        res,
+                        validated_for,
+                        expected.as_deref(),
+                        error_msg,
+                        simplified_msg,
+                        on_validity_change,
+                    );
                 }
             });
             #[cfg(not(target_arch = "wasm32"))]
-            let _ = (url, validated_for, gen);
+            let _ = (url, validated_for, gen, expected);
         }
     };
 
@@ -1011,7 +1194,10 @@ pub fn AssEntry(
                     let cur_b = cursor_byte(&v_now, cur_char);
                     let inn_now = innermost_around_cursor(&v_now, cur_char);
                     match (opt, inn_now) {
-                        (AcOption::Function { name, .. }, Some(InnermostBracket::Paren(cs, ce))) => {
+                        (
+                            AcOption::Function { name, .. },
+                            Some(InnermostBracket::Paren(cs, ce)),
+                        ) => {
                             // Replace the prefix word inside the parens with the function name.
                             let end = ce.min(cur_b).max(cs);
                             let prefix_end = v_now[cs..end]
@@ -1122,13 +1308,18 @@ pub fn AssEntry(
 
     let url_for_blur = tournament_url.clone();
     let value_rc_blur = value_rc.clone();
+    let expected_type_blur = expected_type.clone();
     let onblur_handler = move |_| {
         ac_open.set(false);
         let expr = value_rc_blur.as_ref().clone();
         let url = url_for_blur.clone();
+        let expected = expected_type_blur.clone();
         if expr.trim().is_empty() {
             error_msg.set(None);
             simplified_msg.set(None);
+            if let Some(h) = on_validity_change {
+                h.call(None);
+            }
             return;
         }
         if url.is_empty() {
@@ -1138,17 +1329,21 @@ pub fn AssEntry(
             let validated_for = expr.clone();
             match api::validate_dsl(&url, &expr).await {
                 Ok(res) => {
-                    if res.valid {
-                        error_msg.set(None);
-                        simplified_msg.set(res.simplified.map(|s| (validated_for, s)));
-                    } else {
-                        error_msg.set(res.error);
-                        simplified_msg.set(None);
-                    }
+                    apply_validation_response(
+                        res,
+                        validated_for,
+                        expected.as_deref(),
+                        error_msg,
+                        simplified_msg,
+                        on_validity_change,
+                    );
                 }
                 Err(e) => {
-                    error_msg.set(Some(e));
+                    error_msg.set(Some(e.clone()));
                     simplified_msg.set(None);
+                    if let Some(h) = on_validity_change {
+                        h.call(Some(Err(e)));
+                    }
                 }
             }
         });

--- a/frontend/src/components/ass_entry.rs
+++ b/frontend/src/components/ass_entry.rs
@@ -207,23 +207,83 @@ fn cursor_byte(s: &str, cursor_char: usize) -> usize {
         .unwrap_or(s.len())
 }
 
-/// Index in `new` (byte offset) of the inserted character when `new.len() == old.len() + 1`.
-fn new_char_index(old: &str, new: &str) -> Option<usize> {
-    if new.len() != old.len() + 1 {
+/// Diff `old` and `new` as one contiguous edit: `(byte_pos, replaced_old, inserted_new)`.
+///
+/// Computes the longest common prefix and suffix (snapped to char boundaries) and
+/// reports the differing middle. Handles plain insertions, deletions, and selection
+/// replacements uniformly — the cases that broke the old `new_char_index` length check.
+fn detect_change(old: &str, new: &str) -> Option<(usize, String, String)> {
+    let old_bytes = old.as_bytes();
+    let new_bytes = new.as_bytes();
+
+    let max_prefix = old_bytes.len().min(new_bytes.len());
+    let mut prefix = 0;
+    while prefix < max_prefix && old_bytes[prefix] == new_bytes[prefix] {
+        prefix += 1;
+    }
+    while prefix > 0 && (!old.is_char_boundary(prefix) || !new.is_char_boundary(prefix)) {
+        prefix -= 1;
+    }
+
+    let max_suffix = (old_bytes.len() - prefix).min(new_bytes.len() - prefix);
+    let mut suffix = 0;
+    while suffix < max_suffix
+        && old_bytes[old_bytes.len() - 1 - suffix] == new_bytes[new_bytes.len() - 1 - suffix]
+    {
+        suffix += 1;
+    }
+    while suffix > 0
+        && (!old.is_char_boundary(old_bytes.len() - suffix)
+            || !new.is_char_boundary(new_bytes.len() - suffix))
+    {
+        suffix -= 1;
+    }
+
+    let replaced = old[prefix..old_bytes.len() - suffix].to_string();
+    let inserted = new[prefix..new_bytes.len() - suffix].to_string();
+    if replaced.is_empty() && inserted.is_empty() {
         return None;
     }
-    let mut new_chars = new.char_indices();
-    let mut old_chars = old.char_indices();
-    loop {
-        match (new_chars.next(), old_chars.next()) {
-            (Some((i, c_new)), Some((_, c_old))) => {
-                if c_new != c_old {
-                    return Some(i);
-                }
-            }
-            (Some((i, _)), None) => return Some(i),
-            (None, _) => return None,
-        }
+    Some((prefix, replaced, inserted))
+}
+
+/// Read the textarea's current value and selection synchronously from the DOM.
+/// Returns (value, selection_start, selection_end) in UTF-16 code units (which equal
+/// chars and bytes for the ASCII text we expect in this DSL).
+#[cfg(target_arch = "wasm32")]
+fn read_textarea_state(id: &str) -> Option<(String, usize, usize)> {
+    let window = web_sys::window()?;
+    let doc = window.document()?;
+    let el = doc.query_selector(&format!("#{}", id)).ok()??;
+    let ta: web_sys::HtmlTextAreaElement = el.dyn_into().ok()?;
+    let value = ta.value();
+    let start = ta.selection_start().ok().flatten()? as usize;
+    let end = ta.selection_end().ok().flatten()? as usize;
+    Some((value, start, end))
+}
+
+/// Byte offset of the Nth char in `s`, clamped to `s.len()`.
+fn nth_char_byte(s: &str, n: usize) -> usize {
+    s.char_indices().nth(n).map(|(i, _)| i).unwrap_or(s.len())
+}
+
+/// Closing bracket paired with `c`, if any.
+fn matching_close(c: char) -> Option<char> {
+    match c {
+        '(' => Some(')'),
+        '[' => Some(']'),
+        '{' => Some('}'),
+        _ => None,
+    }
+}
+
+/// Opening bracket paired with `c`, if any.
+fn matching_open(c: char) -> Option<char> {
+    match c {
+        ')' => Some('('),
+        ']' => Some('['),
+        '}' => Some('{'),
+        _ => None,
     }
 }
 
@@ -1080,29 +1140,67 @@ pub fn AssEntry(
         let new_val = e.value();
         let old = value_rc_input.as_ref().clone();
         let _ = v_for_oninput;
-        // Auto-close brackets on single-char insert.
-        let (out, after_open) = if let Some(byte_i) = new_char_index(&old, &new_val) {
-            let open_c = new_val[byte_i..].chars().next().unwrap_or('\0');
-            let closing = match open_c {
-                '(' => Some(')'),
-                '[' => Some(']'),
-                '{' => Some('}'),
-                _ => None,
-            };
-            if let Some(close_c) = closing {
-                let char_end = byte_i + open_c.len_utf8();
-                let out_str = format!(
-                    "{}{}{}",
-                    &new_val[..char_end],
-                    close_c,
-                    &new_val[char_end..]
+        // The longest-common-prefix diff is structurally ambiguous when the inserted
+        // character matches the char already at that position (e.g. typing `(` right
+        // before another `(`). Read the live cursor to anchor the actual insertion site.
+        #[cfg(target_arch = "wasm32")]
+        let cursor_after_input: Option<usize> =
+            read_textarea_state(&id_for_oninput).map(|(_, s, _)| s);
+        #[cfg(not(target_arch = "wasm32"))]
+        let cursor_after_input: Option<usize> = None;
+
+        let (out, after_open) = match detect_change(&old, &new_val) {
+            Some((diff_byte_i, replaced, inserted))
+                if inserted.chars().count() == 1
+                    && matching_close(inserted.chars().next().unwrap()).is_some() =>
+            {
+                let open_c = inserted.chars().next().unwrap();
+                let close_c = matching_close(open_c).unwrap();
+                // Real insertion site = cursor after typing − inserted length. Falls
+                // back to the diff position if we can't read the cursor.
+                let actual_open_byte = match cursor_after_input {
+                    Some(cur) => {
+                        let insert_char = cur.saturating_sub(inserted.chars().count());
+                        nth_char_byte(&new_val, insert_char)
+                    }
+                    None => diff_byte_i,
+                };
+                let after_open_byte = actual_open_byte + open_c.len_utf8();
+                // Standard editor heuristic: don't auto-close before a word char or
+                // another opening bracket — those are cases where the user is
+                // grouping/prefixing existing content rather than starting a new pair.
+                let next_char = new_val[after_open_byte..].chars().next();
+                let blocks_close = matches!(
+                    next_char,
+                    Some(c) if c.is_alphanumeric() || c == '_' || matches!(c, '(' | '[' | '{')
                 );
-                (out_str, Some(char_end))
-            } else {
-                (new_val, None)
+
+                if replaced.is_empty() && blocks_close {
+                    (new_val, None)
+                } else if replaced.is_empty() {
+                    // Plain auto-close: insert close right after the open. Cursor goes between them.
+                    let out_str = format!(
+                        "{}{}{}",
+                        &new_val[..after_open_byte],
+                        close_c,
+                        &new_val[after_open_byte..]
+                    );
+                    (out_str, Some(after_open_byte))
+                } else {
+                    // Wrap the just-replaced selection: re-insert it between the brackets.
+                    // Cursor lands right before the close, at the end of the wrapped content.
+                    // Suppression doesn't apply — the user explicitly selected text to wrap.
+                    let out_str = format!(
+                        "{}{}{}{}",
+                        &new_val[..after_open_byte],
+                        replaced,
+                        close_c,
+                        &new_val[after_open_byte..]
+                    );
+                    (out_str, Some(after_open_byte + replaced.len()))
+                }
             }
-        } else {
-            (new_val, None)
+            _ => (new_val, None),
         };
         on_change_input.call(out.clone());
         ac_open.set(true);
@@ -1248,6 +1346,57 @@ pub fn AssEntry(
                 return;
             }
         }
+
+        // Standard editor auto-bracket behaviors driven off the live textarea state.
+        // Reading from the DOM here (rather than the prop / cursor signal) is the only
+        // way to get the cursor position synchronously before the keypress is applied.
+        #[cfg(target_arch = "wasm32")]
+        {
+            // Skip-over: typing a closing bracket when it's already the next character
+            // advances the cursor instead of inserting a duplicate.
+            if let Some(close_c) = key.chars().next().filter(|c| matching_open(*c).is_some()) {
+                if key.chars().count() == 1 {
+                    if let Some((value, sel_start, sel_end)) = read_textarea_state(&id_for_keydown) {
+                        if sel_start == sel_end {
+                            let byte_pos = nth_char_byte(&value, sel_start);
+                            if value[byte_pos..].chars().next() == Some(close_c) {
+                                ev.prevent_default();
+                                pending_cursor.set(Some(sel_start + 1));
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+            // Pair-delete: backspace between an empty auto-inserted pair removes both.
+            if key == "Backspace" && !ev.modifiers().contains(Modifiers::SHIFT) {
+                if let Some((value, sel_start, sel_end)) = read_textarea_state(&id_for_keydown) {
+                    if sel_start == sel_end && sel_start > 0 {
+                        let cur_byte = nth_char_byte(&value, sel_start);
+                        let prev_byte = nth_char_byte(&value, sel_start - 1);
+                        let prev_char = value[prev_byte..cur_byte].chars().next();
+                        let next_char = value[cur_byte..].chars().next();
+                        let pair = match (prev_char, next_char) {
+                            (Some(p), Some(n)) => matching_close(p) == Some(n),
+                            _ => false,
+                        };
+                        if pair {
+                            ev.prevent_default();
+                            let next_len = next_char.map(|c| c.len_utf8()).unwrap_or(0);
+                            let new_v = format!(
+                                "{}{}",
+                                &value[..prev_byte],
+                                &value[cur_byte + next_len..]
+                            );
+                            on_change_kd.call(new_v);
+                            pending_cursor.set(Some(sel_start - 1));
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
         // Plain Enter inserts a newline. Stop propagation so the parent form's
         // Enter-handler (which prevents default to block submission) doesn't squash it.
         // Shift+Enter still bubbles up so the modal's Save shortcut keeps working.

--- a/frontend/src/components/ass_entry.rs
+++ b/frontend/src/components/ass_entry.rs
@@ -1,0 +1,972 @@
+//! ASS (Arctos Schedule Script) expression editor.
+//!
+//! Single-input component for entering skip conditions:
+//! - Auto-closes `(`, `[`, `{`.
+//! - Pops up a function dropdown when the cursor is inside `( ... )`.
+//! - Pops up a team/tag/match-ref dropdown inside `[ ... ]`.
+//! - Pops up a match dropdown inside `{ ... }`.
+//! - Renders parsed `[...]` and `{...}` literals as chips in a live preview.
+//! - Calls `validate_dsl` on blur and shows error/simplified output.
+
+use crate::api;
+use crate::types::*;
+use dioxus::html::ModifiersInteraction;
+use dioxus::prelude::*;
+use std::cell::RefCell;
+use std::rc::Rc;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast as _;
+
+/// (name, signature, short description)
+const DSL_FUNCTIONS: &[(&str, &str, &str)] = &[
+    ("wins", "(wins TEAM) -> INT", "Wins for a team this event"),
+    ("losses", "(losses TEAM) -> INT", "Losses for a team this event"),
+    ("winner", "(winner MATCH) -> TEAM", "Winner of a match"),
+    ("loser", "(loser MATCH) -> TEAM", "Loser of a match"),
+    ("points-won", "(points-won TEAM MATCH?) -> INT", "Points won (optionally in MATCH)"),
+    ("points-lost", "(points-lost TEAM MATCH?) -> INT", "Points lost (optionally in MATCH)"),
+    ("is-skipped", "(is-skipped MATCH) -> BOOL", "True if match was skipped"),
+    ("if", "(if COND IF_TRUE IF_FALSE)", "Conditional"),
+    ("and", "(and BOOL BOOL) -> BOOL", "Logical and"),
+    ("or", "(or BOOL BOOL) -> BOOL", "Logical or"),
+    ("not", "(not BOOL) -> BOOL", "Logical not"),
+    ("==", "(== ANY ANY) -> BOOL", "Equality"),
+    (">", "(> INT INT) -> BOOL", "Greater than"),
+    ("<", "(< INT INT) -> BOOL", "Less than"),
+    (">=", "(>= INT INT) -> BOOL", "Greater or equal"),
+    ("<=", "(<= INT INT) -> BOOL", "Less or equal"),
+    ("+", "(+ INT INT) -> INT", "Addition"),
+    ("-", "(- INT INT) -> INT", "Subtraction"),
+    ("*", "(* INT INT) -> INT", "Multiplication"),
+    ("/", "(/ INT INT) -> INT", "Integer division"),
+    ("cons", "(cons *_) -> LIST", "Build a list from arguments"),
+    ("car", "(car LIST)", "First element"),
+    ("cdr", "(cdr LIST)", "All but the first element"),
+    ("get", "(get INDEX LIST)", "Element at INDEX, or NIL"),
+    ("len", "(len LIST) -> INT", "Length of a list"),
+    ("or-default", "(or-default VAL DEFAULT)", "VAL if not NIL else DEFAULT"),
+    ("map", "(map LIST FUNC) -> LIST", "Apply FUNC to each element"),
+    ("reduce", "(reduce LIST FUNC)", "Combine elements with FUNC"),
+    ("max", "(max LIST)", "Maximum of a list"),
+    ("min", "(min LIST)", "Minimum of a list"),
+    ("max-by", "(max-by LIST FUNC)", "Element with max FUNC value"),
+    ("min-by", "(min-by LIST FUNC)", "Element with min FUNC value"),
+    ("lambda", "(lambda (args) body)", "Define a function"),
+];
+
+/// Find matching close bracket from open_pos (byte index of open char). Returns byte index of close char.
+fn find_matching_close(s: &str, open_byte_pos: usize, open_c: char, close_c: char) -> Option<usize> {
+    let after_open = open_byte_pos + open_c.len_utf8();
+    let rest = s.get(after_open..)?;
+    let mut depth = 1u32;
+    for (i, c) in rest.char_indices() {
+        if c == open_c {
+            depth += 1;
+        } else if c == close_c {
+            depth -= 1;
+            if depth == 0 {
+                return Some(after_open + i);
+            }
+        }
+    }
+    None
+}
+
+/// Convert a cursor position in characters to byte offset.
+fn cursor_byte(s: &str, cursor_char: usize) -> usize {
+    s.char_indices().nth(cursor_char).map(|(i, _)| i).unwrap_or(s.len())
+}
+
+/// Index in `new` (byte offset) of the inserted character when `new.len() == old.len() + 1`.
+fn new_char_index(old: &str, new: &str) -> Option<usize> {
+    if new.len() != old.len() + 1 {
+        return None;
+    }
+    let mut new_chars = new.char_indices();
+    let mut old_chars = old.char_indices();
+    loop {
+        match (new_chars.next(), old_chars.next()) {
+            (Some((i, c_new)), Some((_, c_old))) => {
+                if c_new != c_old {
+                    return Some(i);
+                }
+            }
+            (Some((i, _)), None) => return Some(i),
+            (None, _) => return None,
+        }
+    }
+}
+
+/// Innermost bracket whose content contains the cursor, recorded as (content_start_byte, content_end_byte).
+/// content_end_byte is the byte position of the closing char, or s.len() if unclosed.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum InnermostBracket {
+    Paren(usize, usize),
+    Square(usize, usize),
+    Curly(usize, usize),
+}
+
+/// Pick the bracket whose open is closest to the cursor (largest content_start ≤ cursor) among
+/// brackets that either contain the cursor (close ≥ cursor) or are unclosed.
+pub fn innermost_around_cursor(s: &str, cursor_char: usize) -> Option<InnermostBracket> {
+    let cb = cursor_byte(s, cursor_char);
+    let mut best: Option<(usize, InnermostBracket)> = None;
+
+    let consider = |open_c: char, close_c: char, best: &mut Option<(usize, InnermostBracket)>, s: &str, cb: usize| {
+        let Some(open_pos) = s[..cb].rfind(open_c) else {
+            return;
+        };
+        let close = find_matching_close(s, open_pos, open_c, close_c);
+        let end = close.unwrap_or(s.len());
+        if close.is_some() && end < cb {
+            return;
+        }
+        let content_start = open_pos + open_c.len_utf8();
+        if content_start > cb {
+            return;
+        }
+        let bracket = match open_c {
+            '(' => InnermostBracket::Paren(content_start, end),
+            '[' => InnermostBracket::Square(content_start, end),
+            '{' => InnermostBracket::Curly(content_start, end),
+            _ => return,
+        };
+        if best.map_or(true, |(cs, _)| content_start > cs) {
+            *best = Some((content_start, bracket));
+        }
+    };
+    consider('(', ')', &mut best, s, cb);
+    consider('[', ']', &mut best, s, cb);
+    consider('{', '}', &mut best, s, cb);
+    best.map(|(_, b)| b)
+}
+
+/// Tokenize the expression for the preview row. Each token is a chunk of text the user wrote,
+/// classified as a literal kind so we can render chips for [..] and {..}.
+#[derive(Clone, Debug)]
+enum PreviewToken {
+    Text(String),
+    Team(String),    // raw inside [..]
+    Match(String),   // raw inside {..}
+    OpenBracket(char),
+    CloseBracket(char),
+}
+
+fn tokenize_preview(s: &str) -> Vec<PreviewToken> {
+    let mut out: Vec<PreviewToken> = Vec::new();
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    let mut text_buf = String::new();
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if c == '[' || c == '{' {
+            let close_c = if c == '[' { ']' } else { '}' };
+            // Find first close in same kind without trying to support nesting (literals don't nest).
+            let after = i + 1;
+            if let Some(rel) = s[after..].find(close_c) {
+                let inner = &s[after..after + rel];
+                if !text_buf.is_empty() {
+                    out.push(PreviewToken::Text(std::mem::take(&mut text_buf)));
+                }
+                if c == '[' {
+                    out.push(PreviewToken::Team(inner.to_string()));
+                } else {
+                    out.push(PreviewToken::Match(inner.to_string()));
+                }
+                i = after + rel + 1;
+                continue;
+            } else {
+                // Unclosed: render as open bracket then continue rendering remaining text
+                if !text_buf.is_empty() {
+                    out.push(PreviewToken::Text(std::mem::take(&mut text_buf)));
+                }
+                out.push(PreviewToken::OpenBracket(c));
+                i += 1;
+                continue;
+            }
+        }
+        if c == ']' || c == '}' {
+            if !text_buf.is_empty() {
+                out.push(PreviewToken::Text(std::mem::take(&mut text_buf)));
+            }
+            out.push(PreviewToken::CloseBracket(c));
+            i += 1;
+            continue;
+        }
+        text_buf.push(c);
+        i += 1;
+    }
+    if !text_buf.is_empty() {
+        out.push(PreviewToken::Text(text_buf));
+    }
+    out
+}
+
+#[derive(Clone, Debug)]
+struct TeamRefResolved {
+    profile_photo: Option<String>,
+    display: String,
+}
+
+/// Resolve a `[...]` literal to display info: pseudonym, tag→team, MatchName::winner/loser.
+/// Returns the kind label and resolved team if available.
+fn resolve_team_literal(
+    inner: &str,
+    team_options: &[TeamOption],
+    tags: &[TagSetupData],
+    matches: &[MatchSetupData],
+) -> (TeamRefKind, Option<TeamRefResolved>) {
+    let trimmed = inner.trim();
+    if let Some(rest) = trimmed.strip_suffix("::winner") {
+        let name = rest.trim();
+        let resolved = matches
+            .iter()
+            .find(|m| m.name.eq_ignore_ascii_case(name) && m.status.eq_ignore_ascii_case("COMPLETED"))
+            .and_then(|m| match m.match_winner.as_deref() {
+                Some(s) if s.eq_ignore_ascii_case("TEAM1") => m.team1.clone(),
+                Some(s) if s.eq_ignore_ascii_case("TEAM2") => m.team2.clone(),
+                _ => None,
+            })
+            .and_then(|tid| team_options.iter().find(|t| t.id == tid))
+            .map(|t| TeamRefResolved {
+                profile_photo: t.profile_photo.clone(),
+                display: t.pseudonym.clone().map(|p| format!("{p} ({})", t.id)).unwrap_or_else(|| t.id.clone()),
+            });
+        return (TeamRefKind::Winner(name.to_string()), resolved);
+    }
+    if let Some(rest) = trimmed.strip_suffix("::loser") {
+        let name = rest.trim();
+        let resolved = matches
+            .iter()
+            .find(|m| m.name.eq_ignore_ascii_case(name) && m.status.eq_ignore_ascii_case("COMPLETED"))
+            .and_then(|m| match m.match_winner.as_deref() {
+                Some(s) if s.eq_ignore_ascii_case("TEAM1") => m.team2.clone(),
+                Some(s) if s.eq_ignore_ascii_case("TEAM2") => m.team1.clone(),
+                _ => None,
+            })
+            .and_then(|tid| team_options.iter().find(|t| t.id == tid))
+            .map(|t| TeamRefResolved {
+                profile_photo: t.profile_photo.clone(),
+                display: t.pseudonym.clone().map(|p| format!("{p} ({})", t.id)).unwrap_or_else(|| t.id.clone()),
+            });
+        return (TeamRefKind::Loser(name.to_string()), resolved);
+    }
+    if trimmed.len() >= 5 && trimmed[..5].eq_ignore_ascii_case("tag::") {
+        let name = trimmed[5..].trim();
+        let resolved = tags
+            .iter()
+            .find(|t| t.name.eq_ignore_ascii_case(name))
+            .and_then(|t| t.team.clone())
+            .and_then(|tid| team_options.iter().find(|t| t.id == tid).cloned())
+            .map(|t| TeamRefResolved {
+                profile_photo: t.profile_photo.clone(),
+                display: t.pseudonym.clone().map(|p| format!("{p} ({})", t.id)).unwrap_or_else(|| t.id.clone()),
+            });
+        return (TeamRefKind::Tag(name.to_string()), resolved);
+    }
+    let team = team_options.iter().find(|t| t.id.eq_ignore_ascii_case(trimmed));
+    let resolved = team.map(|t| TeamRefResolved {
+        profile_photo: t.profile_photo.clone(),
+        display: t.pseudonym.clone().map(|p| format!("{p} ({})", t.id)).unwrap_or_else(|| t.id.clone()),
+    });
+    (TeamRefKind::Team(trimmed.to_string()), resolved)
+}
+
+#[derive(Clone, Debug)]
+enum TeamRefKind {
+    Team(String),
+    Tag(String),
+    Winner(String),
+    Loser(String),
+}
+
+#[derive(Clone, Debug)]
+enum AcOption {
+    Function {
+        name: String,
+        signature: String,
+        description: String,
+    },
+    Team {
+        insert: String,
+        display: String,
+        photo: Option<String>,
+    },
+    Tag {
+        insert: String,
+        display: String,
+    },
+    MatchRef {
+        insert: String,
+        display: String,
+        is_winner: bool,
+    },
+    Match {
+        insert: String,
+        display: String,
+    },
+}
+
+fn collect_function_options(prefix: &str) -> Vec<AcOption> {
+    let q = prefix.to_lowercase();
+    DSL_FUNCTIONS
+        .iter()
+        .filter(|(n, _, _)| q.is_empty() || n.to_lowercase().starts_with(&q))
+        .take(20)
+        .map(|(n, s, d)| AcOption::Function {
+            name: (*n).to_string(),
+            signature: (*s).to_string(),
+            description: (*d).to_string(),
+        })
+        .collect()
+}
+
+fn collect_team_options(
+    query: &str,
+    team_options: &[TeamOption],
+    tags: &[TagSetupData],
+    matches: &[MatchSetupData],
+) -> Vec<AcOption> {
+    let q = query.to_lowercase();
+    let mut out: Vec<AcOption> = Vec::new();
+    for t in team_options.iter() {
+        let id_lower = t.id.to_lowercase();
+        let pseudo_lower = t.pseudonym.as_deref().unwrap_or("").to_lowercase();
+        if q.is_empty() || id_lower.contains(&q) || pseudo_lower.contains(&q) {
+            let display = t
+                .pseudonym
+                .clone()
+                .map(|p| format!("{p} ({})", t.id))
+                .unwrap_or_else(|| t.id.clone());
+            out.push(AcOption::Team {
+                insert: t.id.clone(),
+                display,
+                photo: t.profile_photo.clone(),
+            });
+        }
+        if out.len() >= 20 {
+            break;
+        }
+    }
+    for m in matches.iter() {
+        if q.is_empty() || m.name.to_lowercase().contains(&q) {
+            out.push(AcOption::MatchRef {
+                insert: format!("{}::winner", m.name),
+                display: format!("{} winner", m.name),
+                is_winner: true,
+            });
+            out.push(AcOption::MatchRef {
+                insert: format!("{}::loser", m.name),
+                display: format!("{} loser", m.name),
+                is_winner: false,
+            });
+        }
+        if out.len() >= 30 {
+            break;
+        }
+    }
+    for tag in tags.iter() {
+        if q.is_empty() || tag.name.to_lowercase().contains(&q) {
+            out.push(AcOption::Tag {
+                insert: format!("tag::{}", tag.name),
+                display: tag.name.clone(),
+            });
+        }
+        if out.len() >= 35 {
+            break;
+        }
+    }
+    out.into_iter().take(25).collect()
+}
+
+fn collect_match_options(query: &str, matches: &[MatchSetupData]) -> Vec<AcOption> {
+    let q = query.to_lowercase();
+    matches
+        .iter()
+        .filter(|m| q.is_empty() || m.name.to_lowercase().contains(&q))
+        .take(25)
+        .map(|m| AcOption::Match {
+            insert: m.name.clone(),
+            display: m.name.clone(),
+        })
+        .collect()
+}
+
+#[component]
+pub fn AssEntry(
+    /// Unique suffix for input ID (e.g. "create", "edit", "modal"). Multiple instances need distinct IDs.
+    id_suffix: String,
+    value: String,
+    on_change: EventHandler<String>,
+    team_options: Vec<TeamOption>,
+    tags: Vec<TagSetupData>,
+    matches: Vec<MatchSetupData>,
+    /// For server-side validate-dsl on blur. Pass empty to skip server validation.
+    tournament_url: String,
+    #[props(default = String::from("e.g. (== 0 (losses [Team]))"))] placeholder: String,
+) -> Element {
+    let input_id = format!("ass-entry-{}", id_suffix);
+
+    let value_rc = Rc::new(value.clone());
+    let team_options_rc = Rc::new(team_options);
+    let tags_rc = Rc::new(tags);
+    let matches_rc = Rc::new(matches);
+
+    let mut cursor_pos = use_signal(|| None::<usize>);
+    let mut pending_cursor = use_signal(|| None::<usize>);
+    let mut ac_index = use_signal(|| 0usize);
+    let mut ac_open = use_signal(|| false);
+    let mut error_msg = use_signal(|| None::<String>);
+    let mut simplified_msg = use_signal(|| None::<String>);
+
+    // After auto-close insertions, we need to reposition the cursor on the next tick.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let id_eff = input_id.clone();
+        use_effect(move || {
+            if let Some(p) = pending_cursor() {
+                pending_cursor.set(None);
+                let id = id_eff.clone();
+                spawn(async move {
+                    gloo_timers::future::TimeoutFuture::new(0).await;
+                    if let Some(window) = web_sys::window() {
+                        if let Some(doc) = window.document() {
+                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
+                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
+                                    let _ = input.set_selection_range(p as u32, p as u32);
+                                    let _ = input.focus();
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    // Compute autocomplete state from the current value and cursor.
+    let v = value_rc.as_ref().clone();
+    let cur = cursor_pos();
+    let inn = cur.and_then(|c| innermost_around_cursor(&v, c));
+    let cursor_b = cur.map(|c| cursor_byte(&v, c)).unwrap_or(0);
+
+    let ac_options: Vec<AcOption> = if ac_open() {
+        match &inn {
+            Some(InnermostBracket::Paren(cs, ce)) => {
+                let end = (*ce).min(cursor_b).max(*cs);
+                let prefix = v[*cs..end].split_whitespace().next().unwrap_or("");
+                collect_function_options(prefix)
+            }
+            Some(InnermostBracket::Square(cs, ce)) => {
+                let end = (*ce).min(cursor_b).max(*cs);
+                let q = v[*cs..end].trim();
+                collect_team_options(q, team_options_rc.as_ref(), tags_rc.as_ref(), matches_rc.as_ref())
+            }
+            Some(InnermostBracket::Curly(cs, ce)) => {
+                let end = (*ce).min(cursor_b).max(*cs);
+                let q = v[*cs..end].trim();
+                collect_match_options(q, matches_rc.as_ref())
+            }
+            None => vec![],
+        }
+    } else {
+        vec![]
+    };
+
+    let ac_idx = ac_index().min(ac_options.len().saturating_sub(1));
+
+    let preview_tokens = tokenize_preview(&v);
+    let base_url = api::base_url();
+
+    let v_for_oninput = v.clone();
+    let value_rc_input = value_rc.clone();
+    let on_change_input = on_change.clone();
+    let oninput_handler = move |e: Event<FormData>| {
+        let new_val = e.value();
+        let old = value_rc_input.as_ref().clone();
+        let _ = v_for_oninput;
+        // Auto-close brackets on single-char insert.
+        let (out, after_open) = if let Some(byte_i) = new_char_index(&old, &new_val) {
+            let open_c = new_val[byte_i..].chars().next().unwrap_or('\0');
+            let closing = match open_c {
+                '(' => Some(')'),
+                '[' => Some(']'),
+                '{' => Some('}'),
+                _ => None,
+            };
+            if let Some(close_c) = closing {
+                let char_end = byte_i + open_c.len_utf8();
+                let out_str = format!("{}{}{}", &new_val[..char_end], close_c, &new_val[char_end..]);
+                (out_str, Some(char_end))
+            } else {
+                (new_val, None)
+            }
+        } else {
+            (new_val, None)
+        };
+        on_change_input.call(out);
+        ac_open.set(true);
+        ac_index.set(0);
+        error_msg.set(None);
+        simplified_msg.set(None);
+        if let Some(byte_after_open) = after_open {
+            // ASCII brackets only — byte position equals char position.
+            pending_cursor.set(Some(byte_after_open));
+        }
+    };
+
+    let id_for_keydown = input_id.clone();
+    let value_rc_kd = value_rc.clone();
+    let on_change_kd = on_change.clone();
+    let ac_options_kd = ac_options.clone();
+    let onkeydown_handler = move |ev: Event<KeyboardData>| {
+        let key = ev.key().to_string();
+        let n = ac_options_kd.len();
+        if ac_open() && n > 0 {
+            if key == "ArrowDown" {
+                ev.prevent_default();
+                ac_index.set((ac_idx + 1) % n);
+                return;
+            }
+            if key == "ArrowUp" {
+                ev.prevent_default();
+                ac_index.set((ac_idx + n - 1) % n);
+                return;
+            }
+            if key == "Tab" || (key == "Enter" && !ev.modifiers().contains(Modifiers::SHIFT)) {
+                if let Some(opt) = ac_options_kd.get(ac_idx) {
+                    ev.prevent_default();
+                    let v_now = value_rc_kd.as_ref().clone();
+                    let cur_char = cursor_pos().unwrap_or(0);
+                    let cur_b = cursor_byte(&v_now, cur_char);
+                    let inn_now = innermost_around_cursor(&v_now, cur_char);
+                    match (opt, inn_now) {
+                        (AcOption::Function { name, .. }, Some(InnermostBracket::Paren(cs, ce))) => {
+                            // Replace the prefix word inside the parens with the function name.
+                            let end = ce.min(cur_b).max(cs);
+                            let prefix_end = v_now[cs..end]
+                                .find(|c: char| c.is_whitespace())
+                                .map(|i| cs + i)
+                                .unwrap_or(end);
+                            let new_v = format!("{}{}{}", &v_now[..cs], name, &v_now[prefix_end..]);
+                            let cs_chars = v_now[..cs].chars().count();
+                            let new_cursor = cs_chars + name.chars().count();
+                            on_change_kd.call(new_v);
+                            pending_cursor.set(Some(new_cursor));
+                            ac_open.set(false);
+                            return;
+                        }
+                        (
+                            AcOption::Team { insert, .. }
+                            | AcOption::Tag { insert, .. }
+                            | AcOption::MatchRef { insert, .. },
+                            Some(InnermostBracket::Square(cs, ce)),
+                        ) => {
+                            let end = ce.min(cur_b).max(cs);
+                            // Replace from cs to end with insert
+                            let new_v = format!("{}{}{}", &v_now[..cs], insert, &v_now[end..]);
+                            let cs_chars = v_now[..cs].chars().count();
+                            let new_cursor = cs_chars + insert.chars().count();
+                            on_change_kd.call(new_v);
+                            pending_cursor.set(Some(new_cursor));
+                            ac_open.set(false);
+                            return;
+                        }
+                        (AcOption::Match { insert, .. }, Some(InnermostBracket::Curly(cs, ce))) => {
+                            let end = ce.min(cur_b).max(cs);
+                            let new_v = format!("{}{}{}", &v_now[..cs], insert, &v_now[end..]);
+                            let cs_chars = v_now[..cs].chars().count();
+                            let new_cursor = cs_chars + insert.chars().count();
+                            on_change_kd.call(new_v);
+                            pending_cursor.set(Some(new_cursor));
+                            ac_open.set(false);
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            if key == "Escape" {
+                ev.prevent_default();
+                ac_open.set(false);
+                return;
+            }
+        }
+        // Block raw Enter so it doesn't submit the form (Shift+Enter still bubbles up).
+        if key == "Enter" && !ev.modifiers().contains(Modifiers::SHIFT) {
+            ev.prevent_default();
+        }
+        let _ = id_for_keydown.clone();
+    };
+
+    let id_for_keyup = input_id.clone();
+    let onkeyup_handler = move |_| {
+        let id = id_for_keyup.clone();
+        spawn(async move {
+            #[cfg(target_arch = "wasm32")]
+            {
+                gloo_timers::future::TimeoutFuture::new(0).await;
+                if let Some(window) = web_sys::window() {
+                    if let Some(doc) = window.document() {
+                        if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
+                            if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
+                                if let Ok(Some(sel)) = input.selection_start() {
+                                    cursor_pos.set(Some(sel as usize));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            let _ = id;
+        });
+    };
+
+    let id_for_focus = input_id.clone();
+    let onfocus_handler = move |_| {
+        ac_open.set(true);
+        let id = id_for_focus.clone();
+        spawn(async move {
+            #[cfg(target_arch = "wasm32")]
+            {
+                gloo_timers::future::TimeoutFuture::new(0).await;
+                if let Some(window) = web_sys::window() {
+                    if let Some(doc) = window.document() {
+                        if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
+                            if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
+                                if let Ok(Some(sel)) = input.selection_start() {
+                                    cursor_pos.set(Some(sel as usize));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            let _ = id;
+        });
+    };
+
+    let url_for_blur = tournament_url.clone();
+    let value_rc_blur = value_rc.clone();
+    let onblur_handler = move |_| {
+        ac_open.set(false);
+        let expr = value_rc_blur.as_ref().clone();
+        let url = url_for_blur.clone();
+        if expr.trim().is_empty() {
+            error_msg.set(None);
+            simplified_msg.set(None);
+            return;
+        }
+        if url.is_empty() {
+            return;
+        }
+        spawn(async move {
+            match api::validate_dsl(&url, &expr).await {
+                Ok(res) => {
+                    if res.valid {
+                        error_msg.set(None);
+                        simplified_msg.set(res.simplified);
+                    } else {
+                        error_msg.set(res.error);
+                        simplified_msg.set(None);
+                    }
+                }
+                Err(e) => {
+                    error_msg.set(Some(e));
+                    simplified_msg.set(None);
+                }
+            }
+        });
+    };
+
+    // Build dropdown items.
+    let team_options_for_render = team_options_rc.clone();
+    let tags_for_render = tags_rc.clone();
+    let matches_for_render = matches_rc.clone();
+    let value_rc_click = value_rc.clone();
+    let on_change_click = on_change.clone();
+    let click_rc: Rc<RefCell<Box<dyn FnMut(usize)>>> = {
+        let opts = ac_options.clone();
+        Rc::new(RefCell::new(Box::new(move |idx: usize| {
+            let Some(opt) = opts.get(idx).cloned() else {
+                return;
+            };
+            let v_now = value_rc_click.as_ref().clone();
+            let cur_char = cursor_pos().unwrap_or(v_now.chars().count());
+            let cur_b = cursor_byte(&v_now, cur_char);
+            let inn_now = innermost_around_cursor(&v_now, cur_char);
+            match (opt, inn_now) {
+                (AcOption::Function { name, .. }, Some(InnermostBracket::Paren(cs, ce))) => {
+                    let end = ce.min(cur_b).max(cs);
+                    let prefix_end = v_now[cs..end]
+                        .find(|c: char| c.is_whitespace())
+                        .map(|i| cs + i)
+                        .unwrap_or(end);
+                    let new_v = format!("{}{}{}", &v_now[..cs], name, &v_now[prefix_end..]);
+                    let cs_chars = v_now[..cs].chars().count();
+                    let new_cursor = cs_chars + name.chars().count();
+                    on_change_click.call(new_v);
+                    pending_cursor.set(Some(new_cursor));
+                    ac_open.set(false);
+                }
+                (
+                    AcOption::Team { insert, .. }
+                    | AcOption::Tag { insert, .. }
+                    | AcOption::MatchRef { insert, .. },
+                    Some(InnermostBracket::Square(cs, ce)),
+                ) => {
+                    let end = ce.min(cur_b).max(cs);
+                    let new_v = format!("{}{}{}", &v_now[..cs], insert, &v_now[end..]);
+                    let cs_chars = v_now[..cs].chars().count();
+                    let new_cursor = cs_chars + insert.chars().count();
+                    on_change_click.call(new_v);
+                    pending_cursor.set(Some(new_cursor));
+                    ac_open.set(false);
+                }
+                (AcOption::Match { insert, .. }, Some(InnermostBracket::Curly(cs, ce))) => {
+                    let end = ce.min(cur_b).max(cs);
+                    let new_v = format!("{}{}{}", &v_now[..cs], insert, &v_now[end..]);
+                    let cs_chars = v_now[..cs].chars().count();
+                    let new_cursor = cs_chars + insert.chars().count();
+                    on_change_click.call(new_v);
+                    pending_cursor.set(Some(new_cursor));
+                    ac_open.set(false);
+                }
+                _ => {}
+            }
+        })))
+    };
+
+    let dropdown_items: Vec<_> = ac_options
+        .iter()
+        .enumerate()
+        .map(|(idx, opt)| {
+            let click = click_rc.clone();
+            let is_active = idx == ac_idx;
+            let li_class = if is_active {
+                "ass-entry-ac-item ass-entry-ac-item-active"
+            } else {
+                "ass-entry-ac-item"
+            };
+            let inner = match opt {
+                AcOption::Function { name, signature, description } => {
+                    let n = name.clone();
+                    let s = signature.clone();
+                    let d = description.clone();
+                    rsx! {
+                        span { class: "ass-entry-ac-fn-name", "{n}" }
+                        span { class: "ass-entry-ac-fn-sig text-muted", " {s}" }
+                        div { class: "ass-entry-ac-fn-desc text-muted small", "{d}" }
+                    }
+                }
+                AcOption::Team { display, photo, .. } => {
+                    let d = display.clone();
+                    if let Some(p) = photo.clone() {
+                        rsx! {
+                            img {
+                                class: "team-token-avatar small me-1 rounded-circle",
+                                style: "width: 1.4em; height: 1.4em; object-fit: cover;",
+                                src: "{base_url}/static/{p}",
+                                alt: "{d}",
+                            }
+                            span { "{d}" }
+                        }
+                    } else {
+                        rsx! {
+                            span { class: "team-token-avatar small me-1", "{d.chars().next().unwrap_or('?')}" }
+                            span { "{d}" }
+                        }
+                    }
+                }
+                AcOption::Tag { display, .. } => {
+                    let d = display.clone();
+                    rsx! {
+                        img { class: "icon-primary-svg me-1", src: "{base_url}/static/tag.svg", alt: "Tag", style: "width: 1.25em; height: 1.25em;" }
+                        span { "{d}" }
+                    }
+                }
+                AcOption::MatchRef { display, is_winner, .. } => {
+                    let d = display.clone();
+                    let badge = if *is_winner { "winner" } else { "loser" };
+                    rsx! {
+                        img { class: "icon-primary-svg me-1", src: "{base_url}/static/reference.svg", alt: "Reference", style: "width: 1.25em; height: 1.25em;" }
+                        span { "{d}" }
+                        span { class: "team-token-badge ms-1 {badge}-badge small", "{badge}" }
+                    }
+                }
+                AcOption::Match { display, .. } => {
+                    let d = display.clone();
+                    rsx! {
+                        img { class: "icon-primary-svg me-1", src: "{base_url}/static/reference.svg", alt: "Match", style: "width: 1.25em; height: 1.25em;" }
+                        span { "{d}" }
+                    }
+                }
+            };
+            rsx! {
+                li {
+                    key: "{idx}",
+                    class: "{li_class}",
+                    onmousedown: move |ev: Event<MouseData>| { ev.prevent_default(); },
+                    onclick: move |_| { click.borrow_mut()(idx); },
+                    onmouseenter: move |_| { ac_index.set(idx); },
+                    {inner}
+                }
+            }
+        })
+        .collect();
+
+    let preview_chips: Vec<_> = preview_tokens
+        .iter()
+        .enumerate()
+        .map(|(i, tok)| {
+            match tok {
+                PreviewToken::Text(s) => {
+                    let s = s.clone();
+                    rsx! { span { key: "{i}", class: "ass-entry-preview-text", "{s}" } }
+                }
+                PreviewToken::OpenBracket(c) => {
+                    let s = c.to_string();
+                    rsx! { span { key: "{i}", class: "ass-entry-preview-bracket text-warning", "{s}" } }
+                }
+                PreviewToken::CloseBracket(c) => {
+                    let s = c.to_string();
+                    rsx! { span { key: "{i}", class: "ass-entry-preview-bracket text-warning", "{s}" } }
+                }
+                PreviewToken::Team(inner) => {
+                    let (kind, resolved) = resolve_team_literal(
+                        inner,
+                        team_options_for_render.as_ref(),
+                        tags_for_render.as_ref(),
+                        matches_for_render.as_ref(),
+                    );
+                    let (chip_class, label, icon) = match &kind {
+                        TeamRefKind::Team(name) => ("team-token-chip team-token-chip-team", name.clone(), None),
+                        TeamRefKind::Tag(name) => (
+                            "team-token-chip team-token-chip-tag",
+                            name.clone(),
+                            Some(("tag.svg", "Tag")),
+                        ),
+                        TeamRefKind::Winner(name) => (
+                            "team-token-chip team-token-chip-winner",
+                            format!("{} winner", name),
+                            Some(("reference.svg", "Reference")),
+                        ),
+                        TeamRefKind::Loser(name) => (
+                            "team-token-chip team-token-chip-loser",
+                            format!("{} loser", name),
+                            Some(("reference.svg", "Reference")),
+                        ),
+                    };
+                    let avatar = match (&kind, &resolved) {
+                        (TeamRefKind::Team(_), Some(r)) => {
+                            if let Some(p) = r.profile_photo.clone() {
+                                rsx! { img {
+                                    src: "{base_url}/static/{p}",
+                                    alt: "",
+                                    class: "team-token-avatar rounded-circle",
+                                    style: "width: 1.4em; height: 1.4em; object-fit: cover;"
+                                } }
+                            } else {
+                                rsx! { span { class: "team-token-avatar", "{r.display.chars().next().unwrap_or('?')}" } }
+                            }
+                        }
+                        (TeamRefKind::Team(name), None) => {
+                            rsx! { span { class: "team-token-avatar", "{name.chars().next().unwrap_or('?')}" } }
+                        }
+                        _ => {
+                            if let Some((icon_name, alt)) = icon {
+                                rsx! { img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/{icon_name}", alt: "{alt}" } }
+                            } else {
+                                rsx! { }
+                            }
+                        }
+                    };
+                    let resolved_arrow = if let Some(r) = resolved.clone() {
+                        if !matches!(kind, TeamRefKind::Team(_)) {
+                            let disp = r.display.clone();
+                            let photo = r.profile_photo.clone();
+                            rsx! {
+                                span { class: "team-token-resolved text-muted ms-1",
+                                    " → "
+                                    if let Some(p) = photo {
+                                        img {
+                                            src: "{base_url}/static/{p}",
+                                            alt: "",
+                                            class: "team-token-avatar small rounded-circle ms-1",
+                                            style: "width: 1em; height: 1em; object-fit: cover; vertical-align: middle;"
+                                        }
+                                    } else {
+                                        span { class: "team-token-avatar small ms-1", style: "display: inline-flex; width: 1em; height: 1em; align-items: center; justify-content: center; font-size: 0.85em;", "{disp.chars().next().unwrap_or('?')}" }
+                                    }
+                                    span { "{disp}" }
+                                }
+                            }
+                        } else {
+                            rsx! { }
+                        }
+                    } else {
+                        rsx! { }
+                    };
+                    rsx! {
+                        span { key: "{i}", class: "{chip_class}",
+                            {avatar}
+                            span { class: "team-token-label", "{label}" }
+                            {resolved_arrow}
+                        }
+                    }
+                }
+                PreviewToken::Match(inner) => {
+                    let name = inner.trim().to_string();
+                    let known = matches_for_render.iter().any(|m| m.name.eq_ignore_ascii_case(&name));
+                    let extra_class = if known { "" } else { " ass-entry-preview-unknown" };
+                    rsx! {
+                        span { key: "{i}", class: "team-token-chip team-token-chip-match{extra_class}",
+                            img { class: "team-token-icon icon-primary-svg", src: "{base_url}/static/reference.svg", alt: "Match" }
+                            span { class: "team-token-label", "{name}" }
+                        }
+                    }
+                }
+            }
+        })
+        .collect();
+
+    rsx! {
+        div { class: "ass-entry position-relative",
+            input {
+                id: "{input_id}",
+                class: "form-control font-monospace ass-entry-input",
+                "type": "text",
+                placeholder: "{placeholder}",
+                value: "{value}",
+                oninput: oninput_handler,
+                onkeydown: onkeydown_handler,
+                onkeyup: onkeyup_handler,
+                onfocus: onfocus_handler,
+                onblur: onblur_handler,
+            }
+            if ac_open() && !ac_options.is_empty() {
+                ul { class: "ass-entry-ac dropdown-menu show",
+                    for item in dropdown_items.iter() {
+                        {item.clone()}
+                    }
+                }
+            }
+            if !value.trim().is_empty() {
+                div { class: "ass-entry-preview small",
+                    for chip in preview_chips.iter() {
+                        {chip.clone()}
+                    }
+                }
+            }
+            if let Some(err) = error_msg() {
+                div { class: "form-text text-danger ass-entry-error", "✗ {err}" }
+            } else if let Some(simp) = simplified_msg() {
+                div { class: "form-text text-success", "✓ Valid (simplified: {simp})" }
+            } else if !value.trim().is_empty() {
+                div { class: "form-text text-success", "✓" }
+            }
+        }
+    }
+}

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -662,6 +662,7 @@ fn CreateMatchModal(
     let ribbon = use_signal(|| false);
     let mut skip_condition = use_signal(|| "".to_string());
     let mut skip_condition_help_open = use_signal(|| false);
+    let mut skip_condition_validity = use_signal(|| None::<Result<(), String>>);
 
     let mut error = use_signal(|| None::<String>);
     let mut saving = use_signal(|| false);
@@ -757,10 +758,21 @@ fn CreateMatchModal(
             saving.set(true);
             error.set(None);
             if (schedule_type() == "SAFE" || schedule_type() == "FAST") && !skip_condition().trim().is_empty() {
+                if let Some(Err(msg)) = skip_condition_validity() {
+                    error.set(Some(format!("Skip condition: {msg}")));
+                    saving.set(false);
+                    return;
+                }
                 match api::validate_dsl(&tournament_url, &skip_condition()).await {
                     Ok(res) => {
                         if !res.valid {
                             error.set(Some(format!("Skip condition: {}", res.error.unwrap_or_else(|| "invalid".to_string()))));
+                            saving.set(false);
+                            return;
+                        }
+                        if !res.result_type.iter().any(|t| t == "BOOL") {
+                            let got = if res.result_type.is_empty() { "unknown".to_string() } else { res.result_type.join(" | ") };
+                            error.set(Some(format!("Skip condition must evaluate to BOOL, got {got}.")));
                             saving.set(false);
                             return;
                         }
@@ -829,9 +841,20 @@ fn CreateMatchModal(
             saving.set(true);
             error.set(None);
             if (schedule_type() == "SAFE" || schedule_type() == "FAST") && !skip_condition().trim().is_empty() {
+                if let Some(Err(msg)) = skip_condition_validity() {
+                    error.set(Some(format!("Skip condition: {msg}")));
+                    saving.set(false);
+                    return;
+                }
                 if let Ok(res) = api::validate_dsl(&tournament_url, &skip_condition()).await {
                     if !res.valid {
                         error.set(Some(format!("Skip condition: {}", res.error.unwrap_or_else(|| "invalid".to_string()))));
+                        saving.set(false);
+                        return;
+                    }
+                    if !res.result_type.iter().any(|t| t == "BOOL") {
+                        let got = if res.result_type.is_empty() { "unknown".to_string() } else { res.result_type.join(" | ") };
+                        error.set(Some(format!("Skip condition must evaluate to BOOL, got {got}.")));
                         saving.set(false);
                         return;
                     }
@@ -1093,6 +1116,8 @@ fn CreateMatchModal(
                                             matches: data.matches.clone(),
                                             tournament_url: tournament_url.clone(),
                                             placeholder: "e.g. (== 0 (losses [Team]))".to_string(),
+                                            expected_type: vec!["BOOL".to_string()],
+                                            on_validity_change: move |v: Option<Result<(), String>>| skip_condition_validity.set(v),
                                         }
                                     }
                                 }
@@ -2973,6 +2998,7 @@ fn EditMatchModal(
     let ribbon = use_signal(|| m.ribbon);
     let mut skip_condition = use_signal(|| m.skip_condition.clone().unwrap_or_default());
     let mut skip_condition_help_open = use_signal(|| false);
+    let mut skip_condition_validity = use_signal(|| None::<Result<(), String>>);
 
     let mut error = use_signal(|| None::<String>);
     let mut saving = use_signal(|| false);
@@ -3034,10 +3060,21 @@ fn EditMatchModal(
         error.set(None);
         spawn(async move {
             if (schedule_type() == "SAFE" || schedule_type() == "FAST") && !skip_condition().trim().is_empty() {
+                if let Some(Err(msg)) = skip_condition_validity() {
+                    error.set(Some(format!("Skip condition: {msg}")));
+                    saving.set(false);
+                    return;
+                }
                 match api::validate_dsl(&tournament_url, &skip_condition()).await {
                     Ok(res) => {
                         if !res.valid {
                             error.set(Some(format!("Skip condition: {}", res.error.unwrap_or_else(|| "invalid".to_string()))));
+                            saving.set(false);
+                            return;
+                        }
+                        if !res.result_type.iter().any(|t| t == "BOOL") {
+                            let got = if res.result_type.is_empty() { "unknown".to_string() } else { res.result_type.join(" | ") };
+                            error.set(Some(format!("Skip condition must evaluate to BOOL, got {got}.")));
                             saving.set(false);
                             return;
                         }
@@ -3302,6 +3339,8 @@ fn EditMatchModal(
                                             matches: data.matches.clone(),
                                             tournament_url: tournament_url.clone(),
                                             placeholder: "e.g. (== 0 (losses [Team]))".to_string(),
+                                            expected_type: vec!["BOOL".to_string()],
+                                            on_validity_change: move |v: Option<Result<(), String>>| skip_condition_validity.set(v),
                                         }
                                     }
                                 }

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -1,7 +1,9 @@
+use super::TeamSelectionField;
+use crate::Route;
 use crate::api;
+use crate::components::AssEntry;
 use crate::display::short_or_truncate;
 use crate::types::*;
-use crate::Route;
 use dioxus::html::ModifiersInteraction;
 use dioxus::prelude::*;
 #[cfg(target_arch = "wasm32")]
@@ -10,8 +12,6 @@ use serde::Serialize;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-use super::TeamSelectionField;
-use crate::components::AssEntry;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsCast as _;
 
@@ -44,7 +44,12 @@ fn local_datetime_to_utc_iso(local_str: &str) -> Option<String> {
     let offset_secs = schedule_tz_offset_minutes() * 60;
     let offset = FixedOffset::east_opt(offset_secs as i32)?;
     let local = offset.from_local_datetime(&ndt).single()?;
-    Some(local.with_timezone(&Utc).format("%Y-%m-%dT%H:%M:%SZ").to_string())
+    Some(
+        local
+            .with_timezone(&Utc)
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string(),
+    )
 }
 
 /// Convert a UTC-ish ISO datetime string from the API into a `datetime-local` value (local time, no timezone).
@@ -77,7 +82,9 @@ fn utc_iso_to_local_datetime_input(iso: &str) -> Option<String> {
 
 /// Effective start time for timeline/date nav: confirmed when set, else nominal.
 fn effective_start_str(m: &MatchSetupData) -> Option<&str> {
-    m.confirmed_start_time.as_deref().or(m.nominal_start_time.as_deref())
+    m.confirmed_start_time
+        .as_deref()
+        .or(m.nominal_start_time.as_deref())
 }
 
 /// Format ISO timestamp in user's local time, without seconds (e.g. "14:30" or "2025-02-16 14:30").
@@ -107,9 +114,9 @@ pub fn Schedule(url: String) -> Element {
     let mut edit_mode = use_signal(|| false);
     let mut selected_field = use_signal(|| "all".to_string());
     let mut highlight_team = use_signal(|| "".to_string());
-    
+
     let mut is_to = use_signal(|| false);
-    
+
     let mut active_modal = use_signal(|| "none".to_string());
     let mut selected_match_id = use_signal(|| "".to_string());
     let mut key_nav = use_signal(|| None::<String>);
@@ -261,7 +268,9 @@ pub fn Schedule(url: String) -> Element {
                                                 &parts.into(),
                                                 &blob_opts,
                                             ).expect("Blob");
-                                            let url = web_sys::Url::create_object_url_with_blob(&blob).expect("object URL");
+                                            let url =
+                                                web_sys::Url::create_object_url_with_blob(&blob)
+                                                    .expect("object URL");
                                             let filename = format!(
                                                 "{}_schedule_{}.toml",
                                                 u,
@@ -270,7 +279,9 @@ pub fn Schedule(url: String) -> Element {
                                             if let Ok(a) = doc.create_element("a") {
                                                 let _ = a.set_attribute("href", &url);
                                                 let _ = a.set_attribute("download", &filename);
-                                                if let Some(anchor) = a.dyn_ref::<web_sys::HtmlAnchorElement>() {
+                                                if let Some(anchor) =
+                                                    a.dyn_ref::<web_sys::HtmlAnchorElement>()
+                                                {
                                                     anchor.click();
                                                 }
                                             }
@@ -303,7 +314,7 @@ pub fn Schedule(url: String) -> Element {
                 }
             };
 
-             rsx! {
+            rsx! {
                 style { {SCHEDULE_PAGE_CSS} }
                 div {
                     class: "container-fluid mt-3 position-relative schedule-keyboard-focus",
@@ -452,9 +463,9 @@ pub fn Schedule(url: String) -> Element {
                             on_key_nav_consumed: move |_| key_nav.set(None),
                         }
                     } else {
-                        TableView { 
-                            data: data.clone(), 
-                            selected_field: selected_field(), 
+                        TableView {
+                            data: data.clone(),
+                            selected_field: selected_field(),
                             highlight_team: highlight_team(),
                             edit_mode: edit_mode(),
                             tournament_url: url.clone(),
@@ -464,12 +475,12 @@ pub fn Schedule(url: String) -> Element {
                             }
                         }
                     }
-                    
+
                     // Modals (key forces remount so Edit modal gets fresh state from match)
                     if active_modal() == "match_edit" {
                         div { key: "{selected_match_id()}",
-                            EditMatchModal { 
-                                tournament_url: url.clone(), 
+                            EditMatchModal {
+                                tournament_url: url.clone(),
                                 match_id: selected_match_id(),
                                 data: data.clone(),
                                 on_close: move |_| active_modal.set("none".to_string()),
@@ -521,11 +532,11 @@ pub fn Schedule(url: String) -> Element {
             }
         }
         None => {
-             // Check if it was an error or loading
-             match val.read().as_ref() {
+            // Check if it was an error or loading
+            match val.read().as_ref() {
                 Some(Err(e)) => rsx! { div { class: "alert alert-danger", "Error: {e}" } },
-                _ => rsx! { div { class: "text-center mt-5", "Loading..." } }
-             }
+                _ => rsx! { div { class: "text-center mt-5", "Loading..." } },
+            }
         }
     }
 }
@@ -546,11 +557,15 @@ fn matches_on_field_sorted<'a>(
         .filter(|m| m.field.as_deref() == Some(field_name))
         .filter(|m| exclude_uuid.map_or(true, |id| m.uuid != id))
         .collect();
-    v.sort_by(|a, b| b.nominal_start_time.as_deref().cmp(&a.nominal_start_time.as_deref()));
+    v.sort_by(|a, b| {
+        b.nominal_start_time
+            .as_deref()
+            .cmp(&a.nominal_start_time.as_deref())
+    });
     v
 }
 
-/// Skip condition help modal (same content as Flask #dslHelpModal).
+/// Skip condition help modal
 #[component]
 fn SkipConditionHelpModal(on_close: EventHandler<()>) -> Element {
     rsx! {
@@ -567,56 +582,14 @@ fn SkipConditionHelpModal(on_close: EventHandler<()>) -> Element {
                         button { class: "btn-close", "type": "button", onclick: move |_| on_close.call(()) }
                     }
                     div { class: "modal-body",
-                        p { "The skip condition uses a Lisp-like language to express boolean conditions. If it evaluates to true, the match will be skipped." }
-
-                        h6 { class: "mt-3", "Basic Values" }
-                        ul {
-                            li { code { "true" } " - True" }
-                            li { code { "false" } " - False" }
-                            li { code { "nil" } " - Nil" }
-                            li { code { "[TeamName]" } " - Team name (username, " code { "tag::TagName" } ", or " code { "MatchName::winner" } "/" code { "MatchName::loser" } ")" }
-                            li { code { "{{MatchName}}" } " - Match name" }
-                        }
-
-                        h6 { class: "mt-3", "Basic Operations" }
-                        ul {
-                            li { code { "(== A B)" } " - Equality comparison" }
-                            li { code { "(> A B)" } ", " code { "(< A B)" } ", " code { "(>= A B)" } ", " code { "(<= A B)" } " - Numeric comparisons" }
-                            li { code { "(and A B)" } ", " code { "(or A B)" } ", " code { "(not A)" } " - Logical operations" }
-                        }
-
-                        h6 { class: "mt-3", "Team Operations" }
-                        ul {
-                            li { code { "(wins [TeamName])" } " - Number of wins for a team" }
-                            li { code { "(losses [TeamName])" } " - Number of losses for a team" }
-                            li { code { "(points-won [TeamName])" } " - Total points won by a team" }
-                            li { code { "(points-lost [TeamName])" } " - Total points lost by a team" }
-                            li { code { "(points-won [TeamName] {{MatchName}})" } " - Points won in a specific match" }
-                            li { code { "(points-lost [TeamName] {{MatchName}})" } " - Points lost in a specific match" }
-                            li { code { "(is-skipped {{MatchName}})" } " - True if match status is SKIPPED, false if IN_PROGRESS or COMPLETED" }
-                        }
-
-                        h6 { class: "mt-3", "Match Operations" }
-                        ul {
-                            li { code { "(winner {{MatchName}})" } " - Winner team of a match (returns team or NIL)" }
-                            li { code { "(loser {{MatchName}})" } " - Loser team of a match (returns team or NIL)" }
-                        }
-
-                        h6 { class: "mt-3", "Other Operations" }
-                        ul {
-                            li { code { "(if CONDITION IF_TRUE IF_FALSE)" } " - If condition is true, return IF_TRUE, otherwise return IF_FALSE" }
-                            li { code { "(lambda (*args) (output))" } " - Define a lambda function" }
-                            li { code { "(quote EXPR)" } " or " code { "'EXPR" } " - Literal expression, unevaluated (use " code { "'(1 2 3)" } " to build a list)" }
-                            li { code { "(car LIST)" } " - Get the first element of a list" }
-                            li { code { "(cdr LIST)" } " - Get the rest of a list" }
-                            li { code { "(get INDEX LIST)" } " - Get the element at index" }
-                            li { code { "(or-default VAL DEFAULT)" } " - Returns VAL if VAL is not NIL else DEFAULT" }
-                            li { code { "(len LIST)" } " - Length of a list" }
-                            li { code { "(map LIST FUNC)" } " - Apply a function to each element of a list" }
-                            li { code { "(reduce LIST FUNC)" } " - Reduce a list to a single value" }
-                            li { code { "(max LIST)" } ", " code { "(min LIST)" } " - Max/min value in a list" }
-                            li { code { "(max_by LIST FUNC)" } ", " code { "(min_by LIST FUNC)" } " - Max/min by a function" }
-                        }
+                          p {
+                  "The skip condition uses "
+                  Link {
+                  to: Route::ArctosScheduleScript {},
+                  "Arctos Schedule Script"
+                  }
+                  " to express boolean conditions. If it evaluates to true, the match will be skipped. This evaluation happens when this match's last dependency becomes finished or skipped. If this match is not skipped, the skip condition will be re-evaluated every time a match starts or finishes until it is started or the skip condition evaluates to true and it gets skipped."
+              }
 
                         h6 { class: "mt-3", "Examples" }
                         ul {
@@ -722,28 +695,40 @@ fn CreateMatchModal(
     };
 
     let data_create_validate = data.clone();
-    let validate_create_rc: Rc<RefCell<Box<dyn FnMut() -> bool>>> = Rc::new(RefCell::new(Box::new(move || {
-        let st = schedule_type();
-        if st == "BREAK" || st == "JOIN" || st == "FAST" || st == "SAFE" {
-            let prev_id = previous_match_id().trim().to_string();
-            if prev_id.is_empty() {
-                error.set(Some("Previous match is required for Break, Join, Fast, and Safe matches.".to_string()));
-                return false;
-            }
-            let current_field = field();
-            if current_field.is_empty() {
-                error.set(Some("Field is required when using a previous match.".to_string()));
-                return false;
-            }
-            if let Some(prev_m) = data_create_validate.matches.iter().find(|x| x.uuid == prev_id) {
-                if prev_m.field.as_deref() != Some(current_field.as_str()) {
-                    error.set(Some("Previous match must be on the same field.".to_string()));
+    let validate_create_rc: Rc<RefCell<Box<dyn FnMut() -> bool>>> =
+        Rc::new(RefCell::new(Box::new(move || {
+            let st = schedule_type();
+            if st == "BREAK" || st == "JOIN" || st == "FAST" || st == "SAFE" {
+                let prev_id = previous_match_id().trim().to_string();
+                if prev_id.is_empty() {
+                    error.set(Some(
+                        "Previous match is required for Break, Join, Fast, and Safe matches."
+                            .to_string(),
+                    ));
                     return false;
                 }
+                let current_field = field();
+                if current_field.is_empty() {
+                    error.set(Some(
+                        "Field is required when using a previous match.".to_string(),
+                    ));
+                    return false;
+                }
+                if let Some(prev_m) = data_create_validate
+                    .matches
+                    .iter()
+                    .find(|x| x.uuid == prev_id)
+                {
+                    if prev_m.field.as_deref() != Some(current_field.as_str()) {
+                        error.set(Some(
+                            "Previous match must be on the same field.".to_string(),
+                        ));
+                        return false;
+                    }
+                }
             }
-        }
-        true
-    })));
+            true
+        })));
     let validate_create_rc2 = validate_create_rc.clone();
 
     let tournament_url_submit = tournament_url.clone();
@@ -757,7 +742,9 @@ fn CreateMatchModal(
         spawn(async move {
             saving.set(true);
             error.set(None);
-            if (schedule_type() == "SAFE" || schedule_type() == "FAST") && !skip_condition().trim().is_empty() {
+            if (schedule_type() == "SAFE" || schedule_type() == "FAST")
+                && !skip_condition().trim().is_empty()
+            {
                 if let Some(Err(msg)) = skip_condition_validity() {
                     error.set(Some(format!("Skip condition: {msg}")));
                     saving.set(false);
@@ -766,13 +753,22 @@ fn CreateMatchModal(
                 match api::validate_dsl(&tournament_url, &skip_condition()).await {
                     Ok(res) => {
                         if !res.valid {
-                            error.set(Some(format!("Skip condition: {}", res.error.unwrap_or_else(|| "invalid".to_string()))));
+                            error.set(Some(format!(
+                                "Skip condition: {}",
+                                res.error.unwrap_or_else(|| "invalid".to_string())
+                            )));
                             saving.set(false);
                             return;
                         }
                         if !res.result_type.iter().any(|t| t == "BOOL") {
-                            let got = if res.result_type.is_empty() { "unknown".to_string() } else { res.result_type.join(" | ") };
-                            error.set(Some(format!("Skip condition must evaluate to BOOL, got {got}.")));
+                            let got = if res.result_type.is_empty() {
+                                "unknown".to_string()
+                            } else {
+                                res.result_type.join(" | ")
+                            };
+                            error.set(Some(format!(
+                                "Skip condition must evaluate to BOOL, got {got}."
+                            )));
                             saving.set(false);
                             return;
                         }
@@ -796,7 +792,11 @@ fn CreateMatchModal(
             };
             let req = CreateMatchRequest {
                 name: name(),
-                field: if field().is_empty() { None } else { Some(field()) },
+                field: if field().is_empty() {
+                    None
+                } else {
+                    Some(field())
+                },
                 schedule_type: Some(schedule_type()),
                 length: len,
                 start_time: if start_time().is_empty() {
@@ -810,8 +810,16 @@ fn CreateMatchModal(
                     Some(previous_match_id())
                 },
                 refs: Some(refs_vec),
-                team1: if team1().is_empty() { None } else { Some(team1()) },
-                team2: if team2().is_empty() { None } else { Some(team2()) },
+                team1: if team1().is_empty() {
+                    None
+                } else {
+                    Some(team1())
+                },
+                team2: if team2().is_empty() {
+                    None
+                } else {
+                    Some(team2())
+                },
                 set_type: Some(set_type()),
                 nsets: Some(nsets()),
                 stones_per_set: Some(stones_per_set()),
@@ -831,81 +839,105 @@ fn CreateMatchModal(
         });
     };
     let tournament_url_keydown = tournament_url.clone();
-    let submit_create_rc: Rc<RefCell<Box<dyn FnMut()>>> = Rc::new(RefCell::new(Box::new(move || {
-        if !validate_create_rc2.borrow_mut()() {
-            return;
-        }
-        let tournament_url = tournament_url_keydown.clone();
-        let on_save = on_save.clone();
-        spawn(async move {
-            saving.set(true);
-            error.set(None);
-            if (schedule_type() == "SAFE" || schedule_type() == "FAST") && !skip_condition().trim().is_empty() {
-                if let Some(Err(msg)) = skip_condition_validity() {
-                    error.set(Some(format!("Skip condition: {msg}")));
-                    saving.set(false);
-                    return;
-                }
-                if let Ok(res) = api::validate_dsl(&tournament_url, &skip_condition()).await {
-                    if !res.valid {
-                        error.set(Some(format!("Skip condition: {}", res.error.unwrap_or_else(|| "invalid".to_string()))));
+    let submit_create_rc: Rc<RefCell<Box<dyn FnMut()>>> =
+        Rc::new(RefCell::new(Box::new(move || {
+            if !validate_create_rc2.borrow_mut()() {
+                return;
+            }
+            let tournament_url = tournament_url_keydown.clone();
+            let on_save = on_save.clone();
+            spawn(async move {
+                saving.set(true);
+                error.set(None);
+                if (schedule_type() == "SAFE" || schedule_type() == "FAST")
+                    && !skip_condition().trim().is_empty()
+                {
+                    if let Some(Err(msg)) = skip_condition_validity() {
+                        error.set(Some(format!("Skip condition: {msg}")));
                         saving.set(false);
                         return;
                     }
-                    if !res.result_type.iter().any(|t| t == "BOOL") {
-                        let got = if res.result_type.is_empty() { "unknown".to_string() } else { res.result_type.join(" | ") };
-                        error.set(Some(format!("Skip condition must evaluate to BOOL, got {got}.")));
-                        saving.set(false);
-                        return;
+                    if let Ok(res) = api::validate_dsl(&tournament_url, &skip_condition()).await {
+                        if !res.valid {
+                            error.set(Some(format!(
+                                "Skip condition: {}",
+                                res.error.unwrap_or_else(|| "invalid".to_string())
+                            )));
+                            saving.set(false);
+                            return;
+                        }
+                        if !res.result_type.iter().any(|t| t == "BOOL") {
+                            let got = if res.result_type.is_empty() {
+                                "unknown".to_string()
+                            } else {
+                                res.result_type.join(" | ")
+                            };
+                            error.set(Some(format!(
+                                "Skip condition must evaluate to BOOL, got {got}."
+                            )));
+                            saving.set(false);
+                            return;
+                        }
                     }
                 }
-            }
-            let refs_vec: Vec<String> = refs()
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-            let len = if schedule_type() == "JOIN" {
-                Some(0u32)
-            } else {
-                Some(length())
-            };
-            let req = CreateMatchRequest {
-                name: name(),
-                field: if field().is_empty() { None } else { Some(field()) },
-                schedule_type: Some(schedule_type()),
-                length: len,
-                start_time: if start_time().is_empty() {
-                    None
+                let refs_vec: Vec<String> = refs()
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                let len = if schedule_type() == "JOIN" {
+                    Some(0u32)
                 } else {
-                    local_datetime_to_utc_iso(&start_time()).or_else(|| Some(start_time()))
-                },
-                previous_match_id: if previous_match_id().is_empty() {
-                    None
-                } else {
-                    Some(previous_match_id())
-                },
-                refs: Some(refs_vec),
-                team1: if team1().is_empty() { None } else { Some(team1()) },
-                team2: if team2().is_empty() { None } else { Some(team2()) },
-                set_type: Some(set_type()),
-                nsets: Some(nsets()),
-                stones_per_set: Some(stones_per_set()),
-                ribbon: Some(ribbon()),
-                skip_condition: Some(skip_condition()),
-            };
-            match api::create_match(&tournament_url, &req).await {
-                Ok(_) => {
-                    saving.set(false);
-                    on_save.call(());
+                    Some(length())
+                };
+                let req = CreateMatchRequest {
+                    name: name(),
+                    field: if field().is_empty() {
+                        None
+                    } else {
+                        Some(field())
+                    },
+                    schedule_type: Some(schedule_type()),
+                    length: len,
+                    start_time: if start_time().is_empty() {
+                        None
+                    } else {
+                        local_datetime_to_utc_iso(&start_time()).or_else(|| Some(start_time()))
+                    },
+                    previous_match_id: if previous_match_id().is_empty() {
+                        None
+                    } else {
+                        Some(previous_match_id())
+                    },
+                    refs: Some(refs_vec),
+                    team1: if team1().is_empty() {
+                        None
+                    } else {
+                        Some(team1())
+                    },
+                    team2: if team2().is_empty() {
+                        None
+                    } else {
+                        Some(team2())
+                    },
+                    set_type: Some(set_type()),
+                    nsets: Some(nsets()),
+                    stones_per_set: Some(stones_per_set()),
+                    ribbon: Some(ribbon()),
+                    skip_condition: Some(skip_condition()),
+                };
+                match api::create_match(&tournament_url, &req).await {
+                    Ok(_) => {
+                        saving.set(false);
+                        on_save.call(());
+                    }
+                    Err(e) => {
+                        error.set(Some(e));
+                        saving.set(false);
+                    }
                 }
-                Err(e) => {
-                    error.set(Some(e));
-                    saving.set(false);
-                }
-            }
-        });
-    })));
+            });
+        })));
     let submit_create_rc2 = submit_create_rc.clone();
     let form_keydown = move |ev: Event<KeyboardData>| {
         let key = ev.key().to_string();
@@ -1159,7 +1191,8 @@ fn FieldsModal(
     let mut recording_modal_error = use_signal(|| None::<String>);
     let mut preview_modal_field = use_signal(|| None::<u32>);
     let mut preview_modal_field_name = use_signal(|| None::<String>);
-    let mut preview_modal_closed = use_signal(|| None::<std::sync::Arc<std::sync::atomic::AtomicBool>>);
+    let mut preview_modal_closed =
+        use_signal(|| None::<std::sync::Arc<std::sync::atomic::AtomicBool>>);
     let mut preview_cameras = use_signal(|| vec![] as Vec<String>);
     let mut preview_selected_camera = use_signal(|| String::new());
     let preview_cache_bust = use_signal(|| "0".to_string());
@@ -1195,19 +1228,19 @@ fn FieldsModal(
             let u2 = u.clone();
             let field_name2 = field_name.clone();
             spawn(async move {
-            use std::sync::atomic::Ordering;
-            while !closed.load(Ordering::SeqCst) {
-                if let Ok(list) = api::list_preview_cameras(&u, &field_name).await {
-                    cameras_sig.set(list);
-                }
-                for _ in 0..3 {
-                    if closed.load(Ordering::SeqCst) {
-                        return;
+                use std::sync::atomic::Ordering;
+                while !closed.load(Ordering::SeqCst) {
+                    if let Ok(list) = api::list_preview_cameras(&u, &field_name).await {
+                        cameras_sig.set(list);
                     }
-                    gloo_timers::future::TimeoutFuture::new(1000).await;
+                    for _ in 0..3 {
+                        if closed.load(Ordering::SeqCst) {
+                            return;
+                        }
+                        gloo_timers::future::TimeoutFuture::new(1000).await;
+                    }
                 }
-            }
-        });
+            });
             // Fetch preview frame with credentials and set img via object URL (Safari compatibility).
             let mut image_url_sig = preview_image_object_url_eff.clone();
             let cam_sig = preview_selected_camera_eff.clone();
@@ -1219,7 +1252,9 @@ fn FieldsModal(
                     let camera = cam_sig();
                     if !camera.is_empty() {
                         let cache_bust = format!("{}", js_sys::Date::now());
-                        match api::fetch_preview_frame(&u2, &field_name2, &camera, &cache_bust).await {
+                        match api::fetch_preview_frame(&u2, &field_name2, &camera, &cache_bust)
+                            .await
+                        {
                             Ok(Some(bytes)) => {
                                 let arr = js_sys::Uint8Array::from(&bytes[..]);
                                 let blob = web_sys::Blob::new_with_u8_array_sequence_and_options(
@@ -1238,7 +1273,9 @@ fn FieldsModal(
                             Err(_) => {}
                         }
                         #[cfg(target_arch = "wasm32")]
-                        if let Ok(Some(meta)) = api::fetch_preview_metadata(&u2, &field_name2, &camera).await {
+                        if let Ok(Some(meta)) =
+                            api::fetch_preview_metadata(&u2, &field_name2, &camera).await
+                        {
                             meta_sig.set(Some(meta));
                         }
                     }
@@ -1936,18 +1973,30 @@ fn TableView(
 ) -> Element {
     let tz_offset = schedule_tz_offset_minutes();
     // ... existing filter logic ...
-    let matches: Vec<&MatchSetupData> = data.matches.iter().filter(|m| {
-        if m.status == "SKIPPED" { return false; }
-        if selected_field != "all" {
-             if let Some(f_name) = &m.field {
-                 let field_id = data.fields.iter().find(|f| &f.name == f_name).map(|f| f.id.to_string());
-                 if field_id.as_deref() != Some(selected_field.as_str()) { return false; }
-             } else {
-                 return false;
-             }
-        }
-        true
-    }).collect();
+    let matches: Vec<&MatchSetupData> = data
+        .matches
+        .iter()
+        .filter(|m| {
+            if m.status == "SKIPPED" {
+                return false;
+            }
+            if selected_field != "all" {
+                if let Some(f_name) = &m.field {
+                    let field_id = data
+                        .fields
+                        .iter()
+                        .find(|f| &f.name == f_name)
+                        .map(|f| f.id.to_string());
+                    if field_id.as_deref() != Some(selected_field.as_str()) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect();
 
     let base_url = api::base_url();
     rsx! {
@@ -2183,7 +2232,6 @@ struct JoinGroup {
     field_matches: Vec<(u32, String)>,
 }
 
-
 #[component]
 fn ScheduleTimeline(
     data: ScheduleSetupResponse,
@@ -2195,8 +2243,8 @@ fn ScheduleTimeline(
     key_nav: Signal<Option<String>>,
     on_key_nav_consumed: EventHandler<()>,
 ) -> Element {
-    use chrono::Timelike;
     use chrono::NaiveDateTime;
+    use chrono::Timelike;
     let navigator = use_navigator();
 
     // Get browser timezone offset in minutes (local = utc + offset). Only used on wasm.
@@ -2237,7 +2285,9 @@ fn ScheduleTimeline(
 
     // All match dates in local time (unique, sorted) for prev/next navigation
     let dates_with_matches: Vec<chrono::NaiveDate> = {
-        let mut dates: Vec<chrono::NaiveDate> = data.matches.iter()
+        let mut dates: Vec<chrono::NaiveDate> = data
+            .matches
+            .iter()
             .filter(|m| m.status != "SKIPPED")
             .filter_map(|m| effective_start_str(m))
             .filter_map(|s| parse_schedule_time_to_local(s, tz_offset_minutes))
@@ -2249,7 +2299,8 @@ fn ScheduleTimeline(
     };
 
     // Today in local time
-    let today_local = (chrono::Utc::now() + chrono::Duration::minutes(tz_offset_minutes)).date_naive();
+    let today_local =
+        (chrono::Utc::now() + chrono::Duration::minutes(tz_offset_minutes)).date_naive();
 
     // Default visible date: today if it has matches, else first day with matches
     let mut visible_date_signal = use_signal(|| {
@@ -2276,7 +2327,11 @@ fn ScheduleTimeline(
                     }
                 }
                 "prev" => {
-                    if let Some(idx) = dates.iter().position(|&d| d == current).and_then(|i| i.checked_sub(1)) {
+                    if let Some(idx) = dates
+                        .iter()
+                        .position(|&d| d == current)
+                        .and_then(|i| i.checked_sub(1))
+                    {
                         if let Some(&prev_date) = dates.get(idx) {
                             visible_date_signal.set(prev_date);
                         }
@@ -2299,7 +2354,8 @@ fn ScheduleTimeline(
     let visible_fields: Vec<&FieldSetupData> = if selected_field == "all" {
         data.fields.iter().collect()
     } else {
-        data.fields.iter()
+        data.fields
+            .iter()
             .filter(|f| f.id.to_string() == selected_field)
             .collect()
     };
@@ -2314,13 +2370,15 @@ fn ScheduleTimeline(
     const FIRST_HOUR: u32 = 0;
     const LAST_HOUR: u32 = 24;
     let slots_per_day = ((LAST_HOUR - FIRST_HOUR) * 60 / SLOT_MINUTES as u32) as usize;
-    
+
     // Get current visible date value (reactive - will update when signal changes)
     let current_visible_date = visible_date_signal();
 
     // Build timeline events (non-join matches)
     // Use confirmed_start_time/completed_time when set; else nominal_start_time and start + nominal_length
-    let mut timeline_events: Vec<TimelineEvent> = data.matches.iter()
+    let mut timeline_events: Vec<TimelineEvent> = data
+        .matches
+        .iter()
         .filter(|m| m.status != "SKIPPED")
         .filter(|m| m.schedule_type.as_deref() != Some("JOIN"))
         .filter_map(|m| {
@@ -2336,53 +2394,94 @@ fn ScheduleTimeline(
             };
             let field_name = m.field.as_ref()?;
             let field = data.fields.iter().find(|f| &f.name == field_name)?;
-            
+
             // Check if field is visible
             if selected_field != "all" && field.id.to_string() != selected_field {
                 return None;
             }
-            
+
             // Don't filter by date here - we'll filter when rendering based on current_visible_date
             // This allows date navigation to work properly
-            
+
             // Display pseudonyms (from registration): prefer team_options pseudonym when team ID is set.
             // We keep both a "raw" (full pseudonym) and a "label" (shortname/truncated) form:
             // - label is what gets rendered in the timeline (limited horizontal space).
             // - raw is what the highlight filter substring-matches against, so a user typing
             //   the full team name still matches teams whose label was abbreviated.
-            let opt1 = m.team1.as_ref().and_then(|id| data.team_options.iter().find(|o| &o.id == id));
-            let t1_raw = opt1.and_then(|o| o.pseudonym.as_deref()).map(String::from)
+            let opt1 = m
+                .team1
+                .as_ref()
+                .and_then(|id| data.team_options.iter().find(|o| &o.id == id));
+            let t1_raw = opt1
+                .and_then(|o| o.pseudonym.as_deref())
+                .map(String::from)
                 .unwrap_or_else(|| m.team1_initial.as_deref().unwrap_or("").to_string());
-            let t1 = opt1.map(|o| short_or_truncate(o.pseudonym.as_deref().unwrap_or(o.id.as_str()), o.shortname.as_deref()))
+            let t1 = opt1
+                .map(|o| {
+                    short_or_truncate(
+                        o.pseudonym.as_deref().unwrap_or(o.id.as_str()),
+                        o.shortname.as_deref(),
+                    )
+                })
                 .unwrap_or_else(|| m.team1_initial.as_deref().unwrap_or("").to_string());
-            let opt2 = m.team2.as_ref().and_then(|id| data.team_options.iter().find(|o| &o.id == id));
-            let t2_raw = opt2.and_then(|o| o.pseudonym.as_deref()).map(String::from)
+            let opt2 = m
+                .team2
+                .as_ref()
+                .and_then(|id| data.team_options.iter().find(|o| &o.id == id));
+            let t2_raw = opt2
+                .and_then(|o| o.pseudonym.as_deref())
+                .map(String::from)
                 .unwrap_or_else(|| m.team2_initial.as_deref().unwrap_or("").to_string());
-            let t2 = opt2.map(|o| short_or_truncate(o.pseudonym.as_deref().unwrap_or(o.id.as_str()), o.shortname.as_deref()))
+            let t2 = opt2
+                .map(|o| {
+                    short_or_truncate(
+                        o.pseudonym.as_deref().unwrap_or(o.id.as_str()),
+                        o.shortname.as_deref(),
+                    )
+                })
                 .unwrap_or_else(|| m.team2_initial.as_deref().unwrap_or("").to_string());
 
             // Team profile photos
             let team1_photo = opt1.and_then(|o| o.profile_photo.clone());
             let team2_photo = opt2.and_then(|o| o.profile_photo.clone());
             // Refs as list of (display_name, profile_photo). Keep a raw form for filter matching.
-            let refs_tokens: Vec<&str> = m.refs.as_deref().or(m.refs_initial.as_deref()).unwrap_or("")
+            let refs_tokens: Vec<&str> = m
+                .refs
+                .as_deref()
+                .or(m.refs_initial.as_deref())
+                .unwrap_or("")
                 .split(',')
                 .map(|s| s.trim())
                 .filter(|s| !s.is_empty())
                 .collect();
-            let refs_list: Vec<(String, Option<String>)> = refs_tokens.iter()
+            let refs_list: Vec<(String, Option<String>)> = refs_tokens
+                .iter()
                 .map(|token| {
                     let opt = data.team_options.iter().find(|o| &o.id == token);
-                    let display = opt.map(|o| short_or_truncate(o.pseudonym.as_deref().unwrap_or(o.id.as_str()), o.shortname.as_deref())).unwrap_or_else(|| token.to_string());
+                    let display = opt
+                        .map(|o| {
+                            short_or_truncate(
+                                o.pseudonym.as_deref().unwrap_or(o.id.as_str()),
+                                o.shortname.as_deref(),
+                            )
+                        })
+                        .unwrap_or_else(|| token.to_string());
                     let photo = opt.and_then(|o| o.profile_photo.clone());
                     (display, photo)
                 })
                 .collect();
-            let refs_display = refs_list.iter().map(|(d, _)| d.as_str()).collect::<Vec<_>>().join(", ");
-            let refs_display_raw = refs_tokens.iter()
+            let refs_display = refs_list
+                .iter()
+                .map(|(d, _)| d.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let refs_display_raw = refs_tokens
+                .iter()
                 .map(|token| {
                     let opt = data.team_options.iter().find(|o| &o.id == token);
-                    opt.and_then(|o| o.pseudonym.as_deref()).map(String::from).unwrap_or_else(|| token.to_string())
+                    opt.and_then(|o| o.pseudonym.as_deref())
+                        .map(String::from)
+                        .unwrap_or_else(|| token.to_string())
                 })
                 .collect::<Vec<_>>()
                 .join(", ");
@@ -2396,11 +2495,12 @@ fn ScheduleTimeline(
                 (false, false)
             } else {
                 let ht = highlight_team.to_lowercase();
-                let playing = t1_raw.to_lowercase().contains(&ht) || t2_raw.to_lowercase().contains(&ht);
+                let playing =
+                    t1_raw.to_lowercase().contains(&ht) || t2_raw.to_lowercase().contains(&ht);
                 let reffing = !playing && refs_display_raw.to_lowercase().contains(&ht);
                 (playing, reffing)
             };
-            
+
             Some(TimelineEvent {
                 id: m.uuid.clone(),
                 name: m.name.clone(),
@@ -2467,7 +2567,8 @@ fn ScheduleTimeline(
 
     // Compute lanes using exact time overlap (not slot-based), so only actually overlapping events share width
     for field in &visible_fields {
-        let field_event_indices: Vec<usize> = timeline_events.iter()
+        let field_event_indices: Vec<usize> = timeline_events
+            .iter()
             .enumerate()
             .filter(|(_, e)| {
                 e.field_id == field.id
@@ -2488,7 +2589,8 @@ fn ScheduleTimeline(
         // Assign lane: first lane L such that no already-placed event that overlaps this one (in time) uses L
         for (k, &idx) in sorted_indices.iter().enumerate() {
             let event = &timeline_events[idx];
-            let occupied_lanes: std::collections::HashSet<usize> = sorted_indices[..k].iter()
+            let occupied_lanes: std::collections::HashSet<usize> = sorted_indices[..k]
+                .iter()
                 .filter(|&&i| events_overlap(event, &timeline_events[i]))
                 .map(|&i| timeline_events[i].lane_index)
                 .collect();
@@ -2502,7 +2604,8 @@ fn ScheduleTimeline(
         // num_lanes per event = 1 + max lane among all events that overlap this one (in time)
         for &idx in &field_event_indices {
             let event = &timeline_events[idx];
-            let max_lane = field_event_indices.iter()
+            let max_lane = field_event_indices
+                .iter()
                 .filter(|&&i| events_overlap(event, &timeline_events[i]))
                 .map(|&i| timeline_events[i].lane_index)
                 .max()
@@ -2515,46 +2618,58 @@ fn ScheduleTimeline(
     let join_groups: Vec<JoinGroup> = {
         use std::collections::HashMap;
         let mut groups: HashMap<String, Vec<&MatchSetupData>> = HashMap::new();
-        
+
         for m in &data.matches {
             if m.status == "SKIPPED" {
                 continue;
             }
             if m.schedule_type.as_deref() == Some("JOIN") {
-                groups.entry(m.name.clone()).or_insert_with(Vec::new).push(m);
+                groups
+                    .entry(m.name.clone())
+                    .or_insert_with(Vec::new)
+                    .push(m);
             }
         }
-        
-        groups.into_iter().filter_map(|(name, matches)| {
-            if matches.is_empty() {
-                return None;
-            }
-            
-            // Get time from first match (effective start in local time)
-            let time_str = effective_start_str(matches[0])?;
-            let time_dt = parse_schedule_time_to_local(time_str, tz_offset_minutes)?;
-            
-            // Build per-field join matches (field_id -> match_uuid)
-            let field_matches: Vec<(u32, String)> = matches
-                .iter()
-                .filter_map(|m| {
-                    let field_name = m.field.as_ref()?;
-                    let field_id = data.fields.iter().find(|f| &f.name == field_name).map(|f| f.id)?;
-                    Some((field_id, m.uuid.clone()))
-                })
-                .filter(|(field_id, _)| selected_field == "all" || field_id.to_string() == selected_field)
-                .collect();
 
-            if field_matches.is_empty() {
-                return None;
-            }
-            
-            Some(JoinGroup {
-                name: name.clone(),
-                time: time_dt,
-                field_matches,
+        groups
+            .into_iter()
+            .filter_map(|(name, matches)| {
+                if matches.is_empty() {
+                    return None;
+                }
+
+                // Get time from first match (effective start in local time)
+                let time_str = effective_start_str(matches[0])?;
+                let time_dt = parse_schedule_time_to_local(time_str, tz_offset_minutes)?;
+
+                // Build per-field join matches (field_id -> match_uuid)
+                let field_matches: Vec<(u32, String)> = matches
+                    .iter()
+                    .filter_map(|m| {
+                        let field_name = m.field.as_ref()?;
+                        let field_id = data
+                            .fields
+                            .iter()
+                            .find(|f| &f.name == field_name)
+                            .map(|f| f.id)?;
+                        Some((field_id, m.uuid.clone()))
+                    })
+                    .filter(|(field_id, _)| {
+                        selected_field == "all" || field_id.to_string() == selected_field
+                    })
+                    .collect();
+
+                if field_matches.is_empty() {
+                    return None;
+                }
+
+                Some(JoinGroup {
+                    name: name.clone(),
+                    time: time_dt,
+                    field_matches,
+                })
             })
-        }).collect()
+            .collect()
     };
 
     // Pre-compute slot time strings
@@ -2566,7 +2681,7 @@ fn ScheduleTimeline(
             format!("{:02}:{:02}", hour, minute)
         })
         .collect();
-    
+
     // Pre-compute join line data with slots and exact top offset within slot (to-the-minute)
     #[allow(dead_code)]
     struct JoinLineData {
@@ -2581,7 +2696,8 @@ fn ScheduleTimeline(
         field_items: Vec<(usize, String)>,
     }
 
-    let join_lines_data: Vec<JoinLineData> = join_groups.iter()
+    let join_lines_data: Vec<JoinLineData> = join_groups
+        .iter()
         .filter_map(|join| {
             let date = join.time.date();
             if date != current_visible_date {
@@ -2630,7 +2746,8 @@ fn ScheduleTimeline(
 
     // Target row for auto-scroll: first match of the day, or current time if viewing today
     let first_match_slot = {
-        let event_slots = timeline_events.iter()
+        let event_slots = timeline_events
+            .iter()
             .filter(|e| e.start_time.date() == current_visible_date)
             .map(|e| {
                 let h = e.start_time.hour();
@@ -2684,7 +2801,7 @@ fn ScheduleTimeline(
 
     const TIME_COL_WIDTH_PX: u32 = 80;
     let base_url = api::base_url();
-    
+
     rsx! {
         div { class: "schedule-timeline-wrapper", id: "schedule-timeline-wrapper",
             div { class: "schedule-timeline-nav",
@@ -2786,7 +2903,7 @@ fn ScheduleTimeline(
                                                 event_slot == slot
                                             })
                                             .collect();
-                                        
+
                                         // Pre-compute event rendering data: exact-to-the-minute top and height (fraction of slot)
                                         let event_render_data_opt = if !events_in_slot.is_empty() {
                                             let max_lanes = events_in_slot.first().map(|e| e.num_lanes).unwrap_or(1);
@@ -2803,7 +2920,7 @@ fn ScheduleTimeline(
                                         } else {
                                             None
                                         };
-                                        
+
                                         // Join at this (slot, col_idx): horizontal line in cell; label in edit mode (positioned to-the-minute)
                                         let join_in_cell = join_lines_data.iter().find_map(|jl| {
                                             if jl.slot != slot { return None; }
@@ -2811,7 +2928,7 @@ fn ScheduleTimeline(
                                                 .find(|(c, _)| *c == col_idx)
                                                 .map(|(_, mid)| (jl.join.name.clone(), mid.clone(), jl.top_fraction))
                                         });
-                                        
+
                                         rsx! {
                                             if let Some(event_render_data) = event_render_data_opt {
                                                 div {
@@ -2959,39 +3076,54 @@ fn ScheduleTimeline(
 
 #[component]
 fn EditMatchModal(
-    tournament_url: String, 
-    match_id: String, 
+    tournament_url: String,
+    match_id: String,
     data: ScheduleSetupResponse,
-    on_close: EventHandler<()>, 
-    on_save: EventHandler<()>
+    on_close: EventHandler<()>,
+    on_save: EventHandler<()>,
 ) -> Element {
     let match_data = data.matches.iter().find(|m| m.uuid == match_id).cloned();
-    
+
     if match_data.is_none() {
         return rsx! { div { "Match not found" } };
     }
-    
+
     let m = match_data.unwrap();
-    
+
     // Original schedule type for edit: only allow transitions STATIC→SAFE/FAST, SAFE→FAST
     let original_schedule_type = m.schedule_type.as_deref().unwrap_or("STATIC");
-    
+
     let name = use_signal(|| m.name.clone());
     let mut field = use_signal(|| m.field.clone().unwrap_or_default());
     let schedule_type = use_signal(|| m.schedule_type.clone().unwrap_or("STATIC".to_string()));
     let mut length = use_signal(|| m.nominal_length.unwrap_or(60));
-    
+
     let start_time_init = if let Some(t) = &m.nominal_start_time {
         utc_iso_to_local_datetime_input(t).unwrap_or_else(|| t.chars().take(16).collect::<String>())
     } else {
         "".to_string()
     };
-    
+
     let start_time = use_signal(|| start_time_init);
     let mut previous_match_id = use_signal(|| m.previous_match.clone().unwrap_or_default());
-    let mut refs = use_signal(|| m.refs_initial.clone().or(m.refs.clone()).unwrap_or_default());
-    let mut team1 = use_signal(|| m.team1_initial.clone().or(m.team1.clone()).unwrap_or_default());
-    let mut team2 = use_signal(|| m.team2_initial.clone().or(m.team2.clone()).unwrap_or_default());
+    let mut refs = use_signal(|| {
+        m.refs_initial
+            .clone()
+            .or(m.refs.clone())
+            .unwrap_or_default()
+    });
+    let mut team1 = use_signal(|| {
+        m.team1_initial
+            .clone()
+            .or(m.team1.clone())
+            .unwrap_or_default()
+    });
+    let mut team2 = use_signal(|| {
+        m.team2_initial
+            .clone()
+            .or(m.team2.clone())
+            .unwrap_or_default()
+    });
     let mut set_type = use_signal(|| m.set_type.clone().unwrap_or("SETS".to_string()));
     let mut nsets = use_signal(|| m.nsets.unwrap_or(3));
     let mut stones_per_set = use_signal(|| m.stones_per_set.unwrap_or(100));
@@ -3008,7 +3140,11 @@ fn EditMatchModal(
     let match_id_effect = match_id.clone();
     let data_effect = data.clone();
     use_effect(move || {
-        if let Some(m) = data_effect.matches.iter().find(|x| x.uuid == match_id_effect) {
+        if let Some(m) = data_effect
+            .matches
+            .iter()
+            .find(|x| x.uuid == match_id_effect)
+        {
             field.set(m.field.clone().unwrap_or_default());
             previous_match_id.set(m.previous_match.clone().unwrap_or_default());
         }
@@ -3023,7 +3159,11 @@ fn EditMatchModal(
         field.set(new_field.clone());
         previous_match_id.set("".to_string());
         if !new_field.is_empty() {
-            let list = matches_on_field_sorted(&data_field_edit.matches, &new_field, Some(&match_id_for_field));
+            let list = matches_on_field_sorted(
+                &data_field_edit.matches,
+                &new_field,
+                Some(&match_id_for_field),
+            );
             if let Some(prev) = list.first() {
                 length.set(prev.nominal_length.unwrap_or(60));
                 set_type.set(prev.set_type.clone().unwrap_or_else(|| "SETS".to_string()));
@@ -3042,13 +3182,18 @@ fn EditMatchModal(
         if st == "BREAK" || st == "JOIN" || st == "FAST" || st == "SAFE" {
             let prev_id = previous_match_id().trim().to_string();
             if prev_id.is_empty() {
-                error.set(Some("Previous match is required for Break, Join, Fast, and Safe matches.".to_string()));
+                error.set(Some(
+                    "Previous match is required for Break, Join, Fast, and Safe matches."
+                        .to_string(),
+                ));
                 return;
             }
             let current_field = field();
             if let Some(prev_m) = data_save.matches.iter().find(|x| x.uuid == prev_id) {
                 if prev_m.field.as_deref() != Some(current_field.as_str()) {
-                    error.set(Some("Previous match must be on the same field.".to_string()));
+                    error.set(Some(
+                        "Previous match must be on the same field.".to_string(),
+                    ));
                     return;
                 }
             }
@@ -3059,7 +3204,9 @@ fn EditMatchModal(
         saving.set(true);
         error.set(None);
         spawn(async move {
-            if (schedule_type() == "SAFE" || schedule_type() == "FAST") && !skip_condition().trim().is_empty() {
+            if (schedule_type() == "SAFE" || schedule_type() == "FAST")
+                && !skip_condition().trim().is_empty()
+            {
                 if let Some(Err(msg)) = skip_condition_validity() {
                     error.set(Some(format!("Skip condition: {msg}")));
                     saving.set(false);
@@ -3068,13 +3215,22 @@ fn EditMatchModal(
                 match api::validate_dsl(&tournament_url, &skip_condition()).await {
                     Ok(res) => {
                         if !res.valid {
-                            error.set(Some(format!("Skip condition: {}", res.error.unwrap_or_else(|| "invalid".to_string()))));
+                            error.set(Some(format!(
+                                "Skip condition: {}",
+                                res.error.unwrap_or_else(|| "invalid".to_string())
+                            )));
                             saving.set(false);
                             return;
                         }
                         if !res.result_type.iter().any(|t| t == "BOOL") {
-                            let got = if res.result_type.is_empty() { "unknown".to_string() } else { res.result_type.join(" | ") };
-                            error.set(Some(format!("Skip condition must evaluate to BOOL, got {got}.")));
+                            let got = if res.result_type.is_empty() {
+                                "unknown".to_string()
+                            } else {
+                                res.result_type.join(" | ")
+                            };
+                            error.set(Some(format!(
+                                "Skip condition must evaluate to BOOL, got {got}."
+                            )));
                             saving.set(false);
                             return;
                         }
@@ -3086,7 +3242,11 @@ fn EditMatchModal(
                     }
                 }
             }
-            let refs_vec: Vec<String> = refs().split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+            let refs_vec: Vec<String> = refs()
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
             let len = if schedule_type() == "JOIN" {
                 Some(0u32)
             } else {
@@ -3117,8 +3277,14 @@ fn EditMatchModal(
                 skip_condition: Some(skip_condition()),
             };
             match api::update_match(&tournament_url, &match_id, &req).await {
-                Ok(_) => { saving.set(false); on_save.call(()); }
-                Err(e) => { error.set(Some(e)); saving.set(false); }
+                Ok(_) => {
+                    saving.set(false);
+                    on_save.call(());
+                }
+                Err(e) => {
+                    error.set(Some(e));
+                    saving.set(false);
+                }
             }
         });
     })));
@@ -3171,7 +3337,7 @@ fn EditMatchModal(
                         form {
                             onsubmit: onsubmit,
                             onkeydown: form_keydown,
-                            
+
                             div { class: "row",
                                 div { class: "col-md-6",
                                     div { class: "mb-3",
@@ -3194,7 +3360,7 @@ fn EditMatchModal(
                                     }
                                 }
                             }
-                            
+
                             div { class: "row",
                                 div { class: "col-md-6",
                                     div { class: "mb-3",
@@ -3226,7 +3392,7 @@ fn EditMatchModal(
                                     }
                                 }
                             }
-                            
+
                             if schedule_type() == "STATIC" {
                                 div { class: "mb-3",
                                     label { class: "form-label", "Start Time" }
@@ -3243,7 +3409,7 @@ fn EditMatchModal(
                                     }
                                 }
                             }
-                            
+
                             if schedule_type() == "STATIC" || schedule_type() == "SAFE" || schedule_type() == "FAST" {
                                 div { class: "row",
                                     div { class: "col-md-6",
@@ -3345,10 +3511,10 @@ fn EditMatchModal(
                                     }
                                 }
                             }
-                            
+
                             div { class: "modal-footer",
                                 button { class: "btn btn-secondary", "type": "button", onclick: move |_| on_close.call(()), "Cancel (Esc)" }
-                                button { class: "btn btn-danger", "type": "button", 
+                                button { class: "btn btn-danger", "type": "button",
                                     onclick: move |_| {
                                         // Delete match
                                         let u = url_sig();
@@ -3360,11 +3526,11 @@ fn EditMatchModal(
                                             }
                                         }
                                     },
-                                    "Delete" 
+                                    "Delete"
                                 }
                                 button { class: "btn btn-primary", "type": "submit", disabled: "{saving}",
                                     if saving() { span { class: "spinner-border spinner-border-sm me-2" } }
-                                    "Save (⇧↵)" 
+                                    "Save (⇧↵)"
                                 }
                             }
                         }
@@ -3413,7 +3579,12 @@ fn team_ref_display(raw: &str) -> (u8, String) {
     } else if raw.ends_with("::loser") {
         let name = raw.strip_suffix("::loser").unwrap_or(raw).trim();
         (2, format!("{} loser", name))
-    } else if raw.len() >= 5 && raw.get(..5).map(|s| s.eq_ignore_ascii_case("tag::")).unwrap_or(false) {
+    } else if raw.len() >= 5
+        && raw
+            .get(..5)
+            .map(|s| s.eq_ignore_ascii_case("tag::"))
+            .unwrap_or(false)
+    {
         (1, raw.get(5..).unwrap_or("").trim().to_string())
     } else {
         (0, raw.to_string())

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -606,7 +606,7 @@ fn SkipConditionHelpModal(on_close: EventHandler<()>) -> Element {
                         ul {
                             li { code { "(if CONDITION IF_TRUE IF_FALSE)" } " - If condition is true, return IF_TRUE, otherwise return IF_FALSE" }
                             li { code { "(lambda (*args) (output))" } " - Define a lambda function" }
-                            li { code { "(cons *_)" } " - Create a list from the arguments" }
+                            li { code { "(quote EXPR)" } " or " code { "'EXPR" } " - Literal expression, unevaluated (use " code { "'(1 2 3)" } " to build a list)" }
                             li { code { "(car LIST)" } " - Get the first element of a list" }
                             li { code { "(cdr LIST)" } " - Get the rest of a list" }
                             li { code { "(get INDEX LIST)" } " - Get the element at index" }

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -11,6 +11,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use super::TeamSelectionField;
+use crate::components::AssEntry;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsCast as _;
 
@@ -535,30 +536,6 @@ pub fn Schedule(url: String) -> Element {
 // ... EditMatchModal ...
 
 /// Matches on the given field, sorted by nominal_start_time descending (most recent first).
-/// DSL function names and signatures for skip-condition docs popup (from app/utils/parser.py).
-const DSL_FUNCTIONS: &[(&str, &str)] = &[
-    ("wins", "(wins TEAM) -> INT"),
-    ("losses", "(losses TEAM) -> INT"),
-    ("winner", "(winner MATCH) -> TEAM"),
-    ("loser", "(loser MATCH) -> TEAM"),
-    ("points-won", "(points-won TEAM MATCH) -> INT"),
-    ("points-lost", "(points-lost TEAM MATCH) -> INT"),
-    ("is-skipped", "(is-skipped MATCH) -> BOOL"),
-    ("+", "(+ INT INT) -> INT"),
-    ("-", "(- INT INT) -> INT"),
-    ("*", "(* INT INT) -> INT"),
-    ("/", "(/ INT INT) -> INT"),
-    (">", "(> INT INT) -> BOOL"),
-    ("<", "(< INT INT) -> BOOL"),
-    (">=", "(>= INT INT) -> BOOL"),
-    ("<=", "(<= INT INT) -> BOOL"),
-    ("==", "(== ANY ANY) -> BOOL"),
-    ("or", "(or BOOL BOOL) -> BOOL"),
-    ("and", "(and BOOL BOOL) -> BOOL"),
-    ("not", "(not BOOL) -> BOOL"),
-    ("if", "(if COND IF_TRUE IF_FALSE)"),
-];
-
 fn matches_on_field_sorted<'a>(
     matches: &'a [MatchSetupData],
     field_name: &str,
@@ -571,119 +548,6 @@ fn matches_on_field_sorted<'a>(
         .collect();
     v.sort_by(|a, b| b.nominal_start_time.as_deref().cmp(&a.nominal_start_time.as_deref()));
     v
-}
-
-/// Index in `new` (byte offset) where the single added character is, when new.len() == old.len() + 1.
-fn skip_condition_new_char_index(old: &str, new: &str) -> Option<usize> {
-    if new.len() != old.len() + 1 {
-        return None;
-    }
-    let mut new_chars = new.char_indices();
-    let mut old_chars = old.char_indices();
-    loop {
-        match (new_chars.next(), old_chars.next()) {
-            (Some((i, c_new)), Some((_, c_old))) => {
-                if c_new != c_old {
-                    return Some(i);
-                }
-            }
-            (Some((i, _)), None) => return Some(i),
-            (None, _) => return None,
-        }
-    }
-}
-
-/// Find matching close bracket from open_pos (byte index of open char). Returns byte index of close char.
-fn skip_condition_find_matching_close(s: &str, open_byte_pos: usize, open_c: char, close_c: char) -> Option<usize> {
-    let rest = s.get(open_byte_pos..)?;
-    let mut depth = 1u32;
-    for (i, c) in rest.char_indices() {
-        if c == open_c {
-            depth += 1;
-        } else if c == close_c {
-            depth = depth.saturating_sub(1);
-            if depth == 0 {
-                return Some(open_byte_pos + i);
-            }
-        }
-    }
-    None
-}
-
-/// Innermost unclosed bracket: (content_start_byte, content_end_byte). content_end_byte = position of close or s.len().
-#[allow(dead_code)]
-fn skip_condition_innermost_unclosed(s: &str, open_c: char, close_c: char) -> Option<(usize, usize)> {
-    let open_len = open_c.len_utf8();
-    let mut search_end = s.len();
-    loop {
-        let Some(open_pos) = s[..search_end].rfind(open_c) else {
-            break;
-        };
-        let close_pos = skip_condition_find_matching_close(s, open_pos, open_c, close_c);
-        match close_pos {
-            None => return Some((open_pos + open_len, s.len())),
-            Some(_end) => search_end = open_pos,
-        }
-    }
-    None
-}
-
-/// Cursor position in character index (e.g. from selection_start).
-fn skip_condition_cursor_byte(s: &str, cursor_char: usize) -> usize {
-    s.char_indices()
-        .nth(cursor_char)
-        .map(|(i, _)| i)
-        .unwrap_or(s.len())
-}
-
-/// Innermost bracket that contains the cursor. Uses largest content_start (most recent open before cursor).
-#[derive(Clone, Copy)]
-enum InnermostBracket {
-    Paren(usize, usize), // content_start_byte, content_end_byte
-    Square(usize, usize),
-    Curly(usize, usize),
-}
-
-fn skip_condition_innermost_around_cursor(s: &str, cursor_char: usize) -> Option<InnermostBracket> {
-    let cursor_byte = skip_condition_cursor_byte(s, cursor_char);
-    let mut best: Option<(usize, InnermostBracket)> = None; // (content_start, bracket)
-    if let Some(open_pos) = s[..cursor_byte].rfind('(') {
-        let close_pos = skip_condition_find_matching_close(s, open_pos, '(', ')');
-        let content_end = close_pos.unwrap_or(s.len());
-        if close_pos.is_none() || content_end >= cursor_byte {
-            let content_start = open_pos + 1;
-            if content_start <= cursor_byte {
-                if best.map_or(true, |(cs, _)| content_start > cs) {
-                    best = Some((content_start, InnermostBracket::Paren(content_start, content_end)));
-                }
-            }
-        }
-    }
-    if let Some(open_pos) = s[..cursor_byte].rfind('[') {
-        let close_pos = skip_condition_find_matching_close(s, open_pos, '[', ']');
-        let content_end = close_pos.unwrap_or(s.len());
-        if close_pos.is_none() || content_end >= cursor_byte {
-            let content_start = open_pos + 1;
-            if content_start <= cursor_byte {
-                if best.map_or(true, |(cs, _)| content_start > cs) {
-                    best = Some((content_start, InnermostBracket::Square(content_start, content_end)));
-                }
-            }
-        }
-    }
-    if let Some(open_pos) = s[..cursor_byte].rfind('{') {
-        let close_pos = skip_condition_find_matching_close(s, open_pos, '{', '}');
-        let content_end = close_pos.unwrap_or(s.len());
-        if close_pos.is_none() || content_end >= cursor_byte {
-            let content_start = open_pos + 1;
-            if content_start <= cursor_byte {
-                if best.map_or(true, |(cs, _)| content_start > cs) {
-                    best = Some((content_start, InnermostBracket::Curly(content_start, content_end)));
-                }
-            }
-        }
-    }
-    best.map(|(_, b)| b)
 }
 
 /// Skip condition help modal (same content as Flask #dslHelpModal).
@@ -797,14 +661,6 @@ fn CreateMatchModal(
     let mut stones_per_set = use_signal(|| 100u32);
     let ribbon = use_signal(|| false);
     let mut skip_condition = use_signal(|| "".to_string());
-    let mut skip_condition_error = use_signal(|| None::<String>);
-    let mut skip_condition_simplified = use_signal(|| None::<String>);
-    let mut skip_condition_cursor = use_signal(|| None::<usize>);
-    let mut skip_condition_cursor_pos = use_signal(|| None::<usize>);
-    let mut skip_docs_visible = use_signal(|| false);
-    let mut skip_bracket_ac_visible = use_signal(|| false);
-    let mut skip_bracket_ac_team = use_signal(|| true);
-    let mut skip_bracket_ac_index = use_signal(|| 0usize);
     let mut skip_condition_help_open = use_signal(|| false);
 
     let mut error = use_signal(|| None::<String>);
@@ -820,56 +676,6 @@ fn CreateMatchModal(
                         if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
                             let _ = input.focus();
                         }
-                    }
-                }
-            }
-        });
-    });
-
-    #[cfg(target_arch = "wasm32")]
-    use_effect(move || {
-        let pos = skip_condition_cursor();
-        if let Some(p) = pos {
-            skip_condition_cursor.set(None);
-            let id = "skip-condition-input-create".to_string();
-            spawn(async move {
-                gloo_timers::future::TimeoutFuture::new(0).await;
-                if let Some(window) = web_sys::window() {
-                    if let Some(doc) = window.document() {
-                        if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                            if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                let _ = input.set_selection_range(p as u32, p as u32);
-                                let _ = input.focus();
-                            }
-                        }
-                    }
-                }
-            });
-        }
-    });
-
-    let tournament_url_val = tournament_url.clone();
-    use_effect(move || {
-        let expr = skip_condition();
-        let _ = expr.clone();
-        if expr.trim().is_empty() {
-            return;
-        }
-        let expr_captured = expr.clone();
-        let url = tournament_url_val.clone();
-        #[cfg(target_arch = "wasm32")]
-        spawn(async move {
-            gloo_timers::future::TimeoutFuture::new(3000).await;
-            let current = skip_condition();
-            if current == expr_captured {
-                match api::validate_dsl(&url, &expr_captured).await {
-                    Ok(res) => {
-                        skip_condition_error.set(if res.valid { None } else { res.error.clone() });
-                        skip_condition_simplified.set(if res.valid { res.simplified } else { None });
-                    }
-                    Err(e) => {
-                        skip_condition_error.set(Some(e));
-                        skip_condition_simplified.set(None);
                     }
                 }
             }
@@ -954,16 +760,13 @@ fn CreateMatchModal(
                 match api::validate_dsl(&tournament_url, &skip_condition()).await {
                     Ok(res) => {
                         if !res.valid {
-                            skip_condition_error.set(res.error);
-                            skip_condition_simplified.set(None);
+                            error.set(Some(format!("Skip condition: {}", res.error.unwrap_or_else(|| "invalid".to_string()))));
                             saving.set(false);
                             return;
                         }
-                        skip_condition_simplified.set(res.simplified);
                     }
                     Err(e) => {
-                        skip_condition_error.set(Some(e));
-                        skip_condition_simplified.set(None);
+                        error.set(Some(format!("Skip condition: {}", e)));
                         saving.set(false);
                         return;
                     }
@@ -1028,12 +831,10 @@ fn CreateMatchModal(
             if (schedule_type() == "SAFE" || schedule_type() == "FAST") && !skip_condition().trim().is_empty() {
                 if let Ok(res) = api::validate_dsl(&tournament_url, &skip_condition()).await {
                     if !res.valid {
-                        skip_condition_error.set(res.error);
-                        skip_condition_simplified.set(None);
+                        error.set(Some(format!("Skip condition: {}", res.error.unwrap_or_else(|| "invalid".to_string()))));
                         saving.set(false);
                         return;
                     }
-                    skip_condition_simplified.set(res.simplified);
                 }
             }
             let refs_vec: Vec<String> = refs()
@@ -1105,192 +906,6 @@ fn CreateMatchModal(
             ev.stop_propagation();
             submit_create_rc2.borrow_mut()();
         }
-    };
-
-    let sc_val = skip_condition();
-    let cursor_char = skip_condition_cursor_pos();
-    let innermost = cursor_char.and_then(|c| skip_condition_innermost_around_cursor(&sc_val, c));
-    let cursor_byte = cursor_char.map(|c| skip_condition_cursor_byte(&sc_val, c)).unwrap_or(0);
-    let show_skip_docs = matches!(innermost, Some(InnermostBracket::Paren(_, _)));
-    let docs_prefix = match &innermost {
-        Some(InnermostBracket::Paren(cs, ce)) => {
-            sc_val[*cs..*ce].trim().split_whitespace().next().unwrap_or("").to_lowercase()
-        }
-        _ => String::new(),
-    };
-    let docs_filtered: Vec<_> = if show_skip_docs {
-        DSL_FUNCTIONS
-            .iter()
-            .filter(|(n, _)| n.to_lowercase().starts_with(docs_prefix.as_str()))
-            .take(12)
-            .collect()
-    } else {
-        vec![]
-    };
-    let (bracket_is_team, bracket_query) = match &innermost {
-        Some(InnermostBracket::Square(cs, ce)) => {
-            let end = (*ce).min(cursor_byte).max(*cs);
-            (true, sc_val[*cs..end].trim().to_lowercase())
-        }
-        Some(InnermostBracket::Curly(cs, ce)) => {
-            let end = (*ce).min(cursor_byte).max(*cs);
-            (false, sc_val[*cs..end].trim().to_lowercase())
-        }
-        _ => (true, String::new()),
-    };
-    let show_bracket_ac = matches!(innermost, Some(InnermostBracket::Square(_, _)) | Some(InnermostBracket::Curly(_, _)));
-    let bracket_ac_idx_raw = skip_bracket_ac_index();
-    // (insert_value, display_value, profile_photo for teams). Teams: insert id; matches: insert name.
-    // Team bracket also includes MatchName::winner and MatchName::loser.
-    let bracket_options: Vec<(String, String, Option<String>)> = if show_bracket_ac && bracket_is_team {
-        let team_opts: Vec<_> = data
-            .team_options
-            .iter()
-            .filter(|t| {
-                let disp = t.pseudonym.as_deref().unwrap_or(t.id.as_str());
-                disp.to_lowercase().contains(bracket_query.as_str())
-                    || t.id.to_lowercase().contains(bracket_query.as_str())
-            })
-            .map(|t| {
-                (
-                    t.id.clone(),
-                    t.pseudonym.clone().unwrap_or_else(|| t.id.clone()),
-                    t.profile_photo.clone(),
-                )
-            })
-            .take(15)
-            .collect();
-        let match_qual_opts: Vec<_> = data
-            .matches
-            .iter()
-            .flat_map(|m| {
-                let w = (format!("{}::winner", m.name), format!("{}::winner", m.name), None);
-                let l = (format!("{}::loser", m.name), format!("{}::loser", m.name), None);
-                [w, l]
-            })
-            .filter(|(s, _, _)| s.to_lowercase().contains(bracket_query.as_str()))
-            .take(15)
-            .collect();
-        let tag_opts: Vec<_> = data
-            .tags
-            .iter()
-            .filter(|t| t.name.to_lowercase().contains(bracket_query.as_str()))
-            .map(|t| (format!("tag::{}", t.name), t.name.clone(), None))
-            .take(15)
-            .collect();
-        team_opts
-            .into_iter()
-            .chain(match_qual_opts)
-            .chain(tag_opts)
-            .take(20)
-            .collect()
-    } else if show_bracket_ac {
-        data.matches
-            .iter()
-            .filter(|m| m.name.to_lowercase().contains(bracket_query.as_str()))
-            .map(|m| (m.name.clone(), m.name.clone(), None))
-            .take(15)
-            .collect()
-    } else {
-        vec![]
-    };
-    let bracket_ac_idx = bracket_ac_idx_raw.min(bracket_options.len().saturating_sub(1));
-    let docs_items: Vec<_> = if show_skip_docs && !docs_filtered.is_empty() {
-        docs_filtered
-            .iter()
-            .map(|(dn, ds)| {
-                let fname = dn.to_string();
-                rsx! {
-                    li {
-                        class: "py-1 px-2 rounded",
-                        onclick: move |_| {
-                            let v = skip_condition();
-                            if let Some(i) = v.rfind('(') {
-                                skip_condition.set(format!("{}{}", &v[..=i], fname));
-                            }
-                            skip_docs_visible.set(false);
-                        },
-                        span { class: "fw-medium text-primary", "{dn}" }
-                        span { class: "text-muted ms-1", " {ds}" }
-                    }
-                }
-            })
-            .collect()
-    } else {
-        vec![]
-    };
-    let base_url_create = api::base_url();
-    let bracket_option_items: Vec<_> = if show_bracket_ac && !bracket_options.is_empty() {
-        bracket_options
-            .iter()
-            .enumerate()
-            .map(|(idx, (insert_val, display_val, photo))| {
-                let opt_insert = insert_val.clone();
-                let opt_display = display_val.clone();
-                let opt_photo = photo.clone();
-                let is_team = bracket_is_team;
-                let is_cur = bracket_ac_idx == idx;
-                let li_class = if is_cur {
-                    "py-1 px-2 rounded bg-primary text-white"
-                } else {
-                    "py-1 px-2 rounded"
-                };
-                let avatar_node = if is_team {
-                    if opt_insert.ends_with("::winner") || opt_insert.ends_with("::loser") {
-                        rsx! {
-                            img { class: "icon-primary-svg me-1", src: "{base_url_create}/static/reference.svg", alt: "Reference", style: "width: 1.25em; height: 1.25em;" }
-                        }
-                    } else if opt_insert.starts_with("tag::") {
-                        rsx! {
-                            img { class: "icon-primary-svg me-1", src: "{base_url_create}/static/tag.svg", alt: "Tag", style: "width: 1.25em; height: 1.25em;" }
-                        }
-                    } else if let Some(photo) = &opt_photo {
-                        rsx! {
-                            img {
-                                src: "{base_url_create}/static/{photo}",
-                                alt: "{opt_display}",
-                                class: "team-token-avatar small me-1 rounded-circle",
-                                style: "width: 1.5em; height: 1.5em; object-fit: cover;"
-                            }
-                        }
-                    } else {
-                        rsx! {
-                            span { class: "team-token-avatar small me-1", "{opt_display.chars().next().unwrap_or('?')}" }
-                        }
-                    }
-                } else {
-                    rsx! { }
-                };
-                rsx! {
-                    li {
-                        class: "{li_class}",
-                        onclick: move |_| {
-                            let v = skip_condition();
-                            let cursor_char = skip_condition_cursor_pos().unwrap_or(0);
-                            let cursor_byte = skip_condition_cursor_byte(&v, cursor_char);
-                            let inn = skip_condition_innermost_around_cursor(&v, cursor_char);
-                            let Some(cs) = inn.and_then(|b| match b {
-                                InnermostBracket::Square(cs, _) | InnermostBracket::Curly(cs, _) => Some(cs),
-                                _ => None,
-                            }) else {
-                                skip_bracket_ac_visible.set(false);
-                                return;
-                            };
-                            let new_v = format!("{}{}{}", &v[..cs], opt_insert, &v[cursor_byte..]);
-                            skip_condition.set(new_v.clone());
-                            let cs_chars = v[..cs].chars().count();
-                            let new_cursor_char = cs_chars + opt_insert.chars().count();
-                            skip_condition_cursor.set(Some(new_cursor_char));
-                            skip_bracket_ac_visible.set(false);
-                        },
-                        {avatar_node}
-                        span { "{display_val}" }
-                    }
-                }
-            })
-            .collect()
-    } else {
-        vec![]
     };
 
     rsx! {
@@ -1455,7 +1070,7 @@ fn CreateMatchModal(
                                     }
                                 }
                                 if schedule_type() == "SAFE" || schedule_type() == "FAST" {
-                                    div { class: "mb-3 position-relative",
+                                    div { class: "mb-3",
                                         label { class: "form-label", "Skip condition" }
                                         div { class: "form-text mb-1",
                                             "Optional expression that evaluates to a boolean. If true, this match will be skipped. "
@@ -1469,209 +1084,15 @@ fn CreateMatchModal(
                                                 "(skip condition help)"
                                             }
                                         }
-                                        input {
-                                            id: "skip-condition-input-create",
-                                            class: "form-control font-monospace",
-                                            "type": "text",
-                                            placeholder: "e.g. (== 0 (losses [Team]))",
-                                            value: "{skip_condition}",
-                                            oninput: move |e| {
-                                                let new_val = e.value();
-                                                let old = skip_condition();
-                                                let (out, cursor_after_open) = if let Some(byte_i) = skip_condition_new_char_index(&old, &new_val) {
-                                                    let open_c = new_val[byte_i..].chars().next().unwrap_or('\0');
-                                                    let closing = match open_c {
-                                                        '(' => ")",
-                                                        '[' => {
-                                                            skip_bracket_ac_visible.set(true);
-                                                            skip_bracket_ac_team.set(true);
-                                                            skip_bracket_ac_index.set(0);
-                                                            "]"
-                                                        }
-                                                        '{' => {
-                                                            skip_bracket_ac_visible.set(true);
-                                                            skip_bracket_ac_team.set(false);
-                                                            skip_bracket_ac_index.set(0);
-                                                            "}"
-                                                        }
-                                                        _ => "",
-                                                    };
-                                                    if closing.is_empty() {
-                                                        (new_val, None)
-                                                    } else {
-                                                        let char_end = byte_i + new_val[byte_i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
-                                                        let out_str = format!("{}{}{}", &new_val[..char_end], closing, &new_val[char_end..]);
-                                                        (out_str, Some(char_end))
-                                                    }
-                                                } else {
-                                                    (new_val, None)
-                                                };
-                                                skip_condition.set(out.clone());
-                                                if let Some(pos) = cursor_after_open {
-                                                    skip_condition_cursor.set(Some(pos));
-                                                }
-                                                skip_condition_error.set(None);
-                                                if out.contains('(') {
-                                                    skip_docs_visible.set(true);
-                                                }
-                                                let id = "skip-condition-input-create".to_string();
-                                                spawn(async move {
-                                                    gloo_timers::future::TimeoutFuture::new(0).await;
-                                                    #[cfg(target_arch = "wasm32")]
-                                                    if let Some(window) = web_sys::window() {
-                                                        if let Some(doc) = window.document() {
-                                                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                                                    if let Ok(Some(sel)) = input.selection_start() {
-                                                                        skip_condition_cursor_pos.set(Some(sel as usize));
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            onfocus: move |_| {
-                                                let id = "skip-condition-input-create".to_string();
-                                                spawn(async move {
-                                                    gloo_timers::future::TimeoutFuture::new(0).await;
-                                                    #[cfg(target_arch = "wasm32")]
-                                                    if let Some(window) = web_sys::window() {
-                                                        if let Some(doc) = window.document() {
-                                                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                                                    if let Ok(Some(sel)) = input.selection_start() {
-                                                                        skip_condition_cursor_pos.set(Some(sel as usize));
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            onkeydown: move |ev: Event<KeyboardData>| {
-                                                let key = ev.key().to_string();
-                                                let n = bracket_options.len();
-                                                if show_bracket_ac && n > 0 {
-                                                    if key == "ArrowDown" {
-                                                        ev.prevent_default();
-                                                        skip_bracket_ac_index.set((bracket_ac_idx + 1) % n);
-                                                        return;
-                                                    }
-                                                    if key == "ArrowUp" {
-                                                        ev.prevent_default();
-                                                        skip_bracket_ac_index.set((bracket_ac_idx + n - 1) % n);
-                                                        return;
-                                                    }
-                                                    if key == "Enter" {
-                                                        ev.prevent_default();
-                                                        if let Some((opt_insert, _, _)) = bracket_options.get(bracket_ac_idx) {
-                                                            let v = skip_condition();
-                                                            let cursor_char = skip_condition_cursor_pos().unwrap_or(0);
-                                                            let cursor_byte = skip_condition_cursor_byte(&v, cursor_char);
-                                                            let inn = skip_condition_innermost_around_cursor(&v, cursor_char);
-                                                            if let Some(cs) = inn.and_then(|b| match b {
-                                                                InnermostBracket::Square(cs, _) | InnermostBracket::Curly(cs, _) => Some(cs),
-                                                                _ => None,
-                                                            }) {
-                                                                let new_v = format!("{}{}{}", &v[..cs], opt_insert, &v[cursor_byte..]);
-                                                                skip_condition.set(new_v);
-                                                                let cs_chars = v[..cs].chars().count();
-                                                                let new_cursor_char = cs_chars + opt_insert.chars().count();
-                                                                skip_condition_cursor.set(Some(new_cursor_char));
-                                                                skip_bracket_ac_visible.set(false);
-                                                            }
-                                                        }
-                                                        return;
-                                                    }
-                                                }
-                                                if key == "Enter" && !ev.modifiers().contains(Modifiers::SHIFT) {
-                                                    ev.prevent_default();
-                                                }
-                                            },
-                                            onkeyup: move |_| {
-                                                let id = "skip-condition-input-create".to_string();
-                                                spawn(async move {
-                                                    gloo_timers::future::TimeoutFuture::new(0).await;
-                                                    #[cfg(target_arch = "wasm32")]
-                                                    if let Some(window) = web_sys::window() {
-                                                        if let Some(doc) = window.document() {
-                                                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                                                    if let Ok(Some(sel)) = input.selection_start() {
-                                                                        let sel_i = sel as usize;
-                                                                        skip_condition_cursor_pos.set(Some(sel_i));
-                                                                        let val = input.value();
-                                                                        let inside = skip_condition_innermost_around_cursor(&val, sel_i)
-                                                                            .map(|b| matches!(b, InnermostBracket::Square(_, _) | InnermostBracket::Curly(_, _)))
-                                                                            .unwrap_or(false);
-                                                                        if !inside {
-                                                                            skip_bracket_ac_visible.set(false);
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            onblur: move |_| {
-                                                skip_docs_visible.set(false);
-                                                skip_bracket_ac_visible.set(false);
-                                                let expr = skip_condition();
-                                                if expr.trim().is_empty() {
-                                                    skip_condition_error.set(None);
-                                                    return;
-                                                }
-                                                let url = tournament_url.clone();
-                                                spawn(async move {
-                                                    match api::validate_dsl(&url, &expr).await {
-                                                        Ok(res) => {
-                                                            skip_condition_error.set(if res.valid {
-                                                                None
-                                                            } else {
-                                                                res.error.clone()
-                                                            });
-                                                            skip_condition_simplified.set(if res.valid {
-                                                                res.simplified
-                                                            } else {
-                                                                None
-                                                            });
-                                                        }
-                                                        Err(e) => {
-                                                            skip_condition_error.set(Some(e));
-                                                            skip_condition_simplified.set(None);
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                        }
-                                        if show_skip_docs && !docs_filtered.is_empty() {
-                                            div { class: "position-absolute start-0 mt-1 p-2 bg-light border rounded shadow-sm z-3",
-                                                style: "min-width: 280px; max-height: 240px; overflow-y: auto;",
-                                                ul { class: "list-unstyled mb-0 small",
-                                                    for item in docs_items.iter() {
-                                                        {item.clone()}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        if show_bracket_ac && !bracket_option_items.is_empty() {
-                                            div { class: "position-absolute start-0 mt-1 p-2 bg-light border rounded shadow-sm z-3",
-                                                style: "min-width: 200px; max-height: 200px; overflow-y: auto;",
-                                                ul { class: "list-unstyled mb-0 small",
-                                                    for bracket_item in bracket_option_items.iter() {
-                                                        {bracket_item.clone()}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        if let Some(err) = skip_condition_error() {
-                                            div { class: "form-text text-danger", "✗ {err}" }
-                                        } else if let Some(simp) = skip_condition_simplified() {
-                                            div { class: "form-text text-success", "✓ Valid (simplified: {simp})" }
-                                        } else if !skip_condition().trim().is_empty() {
-                                            div { class: "form-text text-success", "✓ Valid" }
+                                        AssEntry {
+                                            id_suffix: "create".to_string(),
+                                            value: skip_condition(),
+                                            on_change: move |v| skip_condition.set(v),
+                                            team_options: data.team_options.clone(),
+                                            tags: data.tags.clone(),
+                                            matches: data.matches.clone(),
+                                            tournament_url: tournament_url.clone(),
+                                            placeholder: "e.g. (== 0 (losses [Team]))".to_string(),
                                         }
                                     }
                                 }
@@ -3551,37 +2972,7 @@ fn EditMatchModal(
     let mut stones_per_set = use_signal(|| m.stones_per_set.unwrap_or(100));
     let ribbon = use_signal(|| m.ribbon);
     let mut skip_condition = use_signal(|| m.skip_condition.clone().unwrap_or_default());
-    let mut skip_condition_error = use_signal(|| None::<String>);
-    let mut skip_condition_simplified = use_signal(|| None::<String>);
-    let mut skip_condition_cursor = use_signal(|| None::<usize>);
-    let mut skip_condition_cursor_pos = use_signal(|| None::<usize>);
-    let mut skip_docs_visible = use_signal(|| false);
-    let mut skip_bracket_ac_visible = use_signal(|| false);
-    let mut skip_bracket_ac_team = use_signal(|| true);
-    let mut skip_bracket_ac_index = use_signal(|| 0usize);
     let mut skip_condition_help_open = use_signal(|| false);
-
-    #[cfg(target_arch = "wasm32")]
-    use_effect(move || {
-        let pos = skip_condition_cursor();
-        if let Some(p) = pos {
-            skip_condition_cursor.set(None);
-            let id = "skip-condition-input-edit".to_string();
-            spawn(async move {
-                gloo_timers::future::TimeoutFuture::new(0).await;
-                if let Some(window) = web_sys::window() {
-                    if let Some(doc) = window.document() {
-                        if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                            if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                let _ = input.set_selection_range(p as u32, p as u32);
-                                let _ = input.focus();
-                            }
-                        }
-                    }
-                }
-            });
-        }
-    });
 
     let mut error = use_signal(|| None::<String>);
     let mut saving = use_signal(|| false);
@@ -3646,16 +3037,13 @@ fn EditMatchModal(
                 match api::validate_dsl(&tournament_url, &skip_condition()).await {
                     Ok(res) => {
                         if !res.valid {
-                            skip_condition_error.set(res.error);
-                            skip_condition_simplified.set(None);
+                            error.set(Some(format!("Skip condition: {}", res.error.unwrap_or_else(|| "invalid".to_string()))));
                             saving.set(false);
                             return;
                         }
-                        skip_condition_simplified.set(res.simplified);
                     }
                     Err(e) => {
-                        skip_condition_error.set(Some(e));
-                        skip_condition_simplified.set(None);
+                        error.set(Some(format!("Skip condition: {}", e)));
                         saving.set(false);
                         return;
                     }
@@ -3726,220 +3114,6 @@ fn EditMatchModal(
             do_save_rc3.borrow_mut()();
         }
     };
-
-    let sc_val_edit = skip_condition();
-    let cursor_char_edit = skip_condition_cursor_pos();
-    let innermost_edit = cursor_char_edit.and_then(|c| skip_condition_innermost_around_cursor(&sc_val_edit, c));
-    let cursor_byte_edit = cursor_char_edit.map(|c| skip_condition_cursor_byte(&sc_val_edit, c)).unwrap_or(0);
-    let show_skip_docs_edit = matches!(innermost_edit, Some(InnermostBracket::Paren(_, _)));
-    let docs_prefix_edit = match &innermost_edit {
-        Some(InnermostBracket::Paren(cs, ce)) => {
-            sc_val_edit[*cs..*ce].trim().split_whitespace().next().unwrap_or("").to_lowercase()
-        }
-        _ => String::new(),
-    };
-    let docs_filtered_edit: Vec<_> = if show_skip_docs_edit {
-        DSL_FUNCTIONS
-            .iter()
-            .filter(|(n, _)| n.to_lowercase().starts_with(docs_prefix_edit.as_str()))
-            .take(12)
-            .collect()
-    } else {
-        vec![]
-    };
-    let (bracket_is_team_edit, bracket_query_edit) = match &innermost_edit {
-        Some(InnermostBracket::Square(cs, ce)) => {
-            let end = (*ce).min(cursor_byte_edit).max(*cs);
-            (true, sc_val_edit[*cs..end].trim().to_lowercase())
-        }
-        Some(InnermostBracket::Curly(cs, ce)) => {
-            let end = (*ce).min(cursor_byte_edit).max(*cs);
-            (false, sc_val_edit[*cs..end].trim().to_lowercase())
-        }
-        _ => (true, String::new()),
-    };
-    let show_bracket_ac_edit = matches!(innermost_edit, Some(InnermostBracket::Square(_, _)) | Some(InnermostBracket::Curly(_, _)));
-    let bracket_ac_idx_edit_raw = skip_bracket_ac_index();
-    let bracket_options_edit: Vec<(String, String, Option<String>)> = if show_bracket_ac_edit && bracket_is_team_edit {
-        let team_opts_edit: Vec<_> = data
-            .team_options
-            .iter()
-            .filter(|t| {
-                let disp = t.pseudonym.as_deref().unwrap_or(t.id.as_str());
-                disp.to_lowercase().contains(bracket_query_edit.as_str())
-                    || t.id.to_lowercase().contains(bracket_query_edit.as_str())
-            })
-            .map(|t| {
-                (
-                    t.id.clone(),
-                    t.pseudonym.clone().unwrap_or_else(|| t.id.clone()),
-                    t.profile_photo.clone(),
-                )
-            })
-            .take(15)
-            .collect();
-        let match_qual_opts_edit: Vec<_> = data
-            .matches
-            .iter()
-            .flat_map(|m| {
-                let w = (format!("{}::winner", m.name), format!("{}::winner", m.name), None);
-                let l = (format!("{}::loser", m.name), format!("{}::loser", m.name), None);
-                [w, l]
-            })
-            .filter(|(s, _, _)| s.to_lowercase().contains(bracket_query_edit.as_str()))
-            .take(15)
-            .collect();
-        let tag_opts_edit: Vec<_> = data
-            .tags
-            .iter()
-            .filter(|t| t.name.to_lowercase().contains(bracket_query_edit.as_str()))
-            .map(|t| (format!("tag::{}", t.name), t.name.clone(), None))
-            .take(15)
-            .collect();
-        team_opts_edit
-            .into_iter()
-            .chain(match_qual_opts_edit)
-            .chain(tag_opts_edit)
-            .take(20)
-            .collect()
-    } else if show_bracket_ac_edit {
-        data.matches
-            .iter()
-            .filter(|m| m.name.to_lowercase().contains(bracket_query_edit.as_str()))
-            .map(|m| (m.name.clone(), m.name.clone(), None))
-            .take(15)
-            .collect()
-    } else {
-        vec![]
-    };
-    let bracket_ac_idx_edit = bracket_ac_idx_edit_raw.min(bracket_options_edit.len().saturating_sub(1));
-    let docs_items_edit: Vec<_> = if show_skip_docs_edit && !docs_filtered_edit.is_empty() {
-        docs_filtered_edit
-            .iter()
-            .map(|(dn, ds)| {
-                let fname = dn.to_string();
-                rsx! {
-                    li {
-                        class: "py-1 px-2 rounded",
-                        onclick: move |_| {
-                            let v = skip_condition();
-                            if let Some(i) = v.rfind('(') {
-                                skip_condition.set(format!("{}{}", &v[..=i], fname));
-                            }
-                            skip_docs_visible.set(false);
-                        },
-                        span { class: "fw-medium text-primary", "{dn}" }
-                        span { class: "text-muted ms-1", " {ds}" }
-                    }
-                }
-            })
-            .collect()
-    } else {
-        vec![]
-    };
-    let base_url_edit = api::base_url();
-    let bracket_option_items_edit: Vec<_> = if show_bracket_ac_edit && !bracket_options_edit.is_empty() {
-        bracket_options_edit
-            .iter()
-            .enumerate()
-            .map(|(idx, (insert_val, display_val, photo))| {
-                let opt_insert = insert_val.clone();
-                let opt_display = display_val.clone();
-                let opt_photo = photo.clone();
-                let is_team = bracket_is_team_edit;
-                let is_cur = bracket_ac_idx_edit == idx;
-                let li_class = if is_cur {
-                    "py-1 px-2 rounded bg-primary text-white"
-                } else {
-                    "py-1 px-2 rounded"
-                };
-                let avatar_node_edit = if is_team {
-                    if opt_insert.ends_with("::winner") || opt_insert.ends_with("::loser") {
-                        rsx! {
-                            img { class: "icon-primary-svg me-1", src: "{base_url_edit}/static/reference.svg", alt: "Reference", style: "width: 1.25em; height: 1.25em;" }
-                        }
-                    } else if opt_insert.starts_with("tag::") {
-                        rsx! {
-                            img { class: "icon-primary-svg me-1", src: "{base_url_edit}/static/tag.svg", alt: "Tag", style: "width: 1.25em; height: 1.25em;" }
-                        }
-                    } else if let Some(photo) = &opt_photo {
-                        rsx! {
-                            img {
-                                src: "{base_url_edit}/static/{photo}",
-                                alt: "{opt_display}",
-                                class: "team-token-avatar small me-1 rounded-circle",
-                                style: "width: 1.5em; height: 1.5em; object-fit: cover;"
-                            }
-                        }
-                    } else {
-                        rsx! {
-                            span { class: "team-token-avatar small me-1", "{opt_display.chars().next().unwrap_or('?')}" }
-                        }
-                    }
-                } else {
-                    rsx! { }
-                };
-                rsx! {
-                    li {
-                        class: "{li_class}",
-                        onclick: move |_| {
-                            let v = skip_condition();
-                            let cursor_char = skip_condition_cursor_pos().unwrap_or(0);
-                            let cursor_byte = skip_condition_cursor_byte(&v, cursor_char);
-                            let inn = skip_condition_innermost_around_cursor(&v, cursor_char);
-                            let Some(cs) = inn.and_then(|b| match b {
-                                InnermostBracket::Square(cs, _) | InnermostBracket::Curly(cs, _) => Some(cs),
-                                _ => None,
-                            }) else {
-                                skip_bracket_ac_visible.set(false);
-                                return;
-                            };
-                            let new_v = format!("{}{}{}", &v[..cs], opt_insert, &v[cursor_byte..]);
-                            skip_condition.set(new_v.clone());
-                            let cs_chars = v[..cs].chars().count();
-                            let new_cursor_char = cs_chars + opt_insert.chars().count();
-                            skip_condition_cursor.set(Some(new_cursor_char));
-                            skip_bracket_ac_visible.set(false);
-                        },
-                        {avatar_node_edit}
-                        span { "{display_val}" }
-                    }
-                }
-            })
-            .collect()
-    } else {
-        vec![]
-    };
-
-    let tournament_url_val_edit = tournament_url.clone();
-    use_effect(move || {
-        let expr = skip_condition();
-        let _ = expr.clone();
-        if expr.trim().is_empty() {
-            return;
-        }
-        let expr_captured = expr.clone();
-        let url = tournament_url_val_edit.clone();
-        #[cfg(target_arch = "wasm32")]
-        spawn(async move {
-            gloo_timers::future::TimeoutFuture::new(3000).await;
-            let current = skip_condition();
-            if current == expr_captured {
-                match api::validate_dsl(&url, &expr_captured).await {
-                    Ok(res) => {
-                        skip_condition_error.set(if res.valid { None } else { res.error.clone() });
-                        skip_condition_simplified.set(if res.valid { res.simplified } else { None });
-                    }
-                    Err(e) => {
-                        skip_condition_error.set(Some(e));
-                        skip_condition_simplified.set(None);
-                    }
-                }
-            }
-        });
-        #[cfg(not(target_arch = "wasm32"))]
-        let _ = (expr_captured, url);
-    });
 
     rsx! {
         div {
@@ -4105,7 +3279,7 @@ fn EditMatchModal(
                                     }
                                 }
                                 if schedule_type() == "SAFE" || schedule_type() == "FAST" {
-                                    div { class: "mb-3 position-relative",
+                                    div { class: "mb-3",
                                         label { class: "form-label", "Skip condition" }
                                         div { class: "form-text mb-1",
                                             "Optional expression that evaluates to a boolean. If true, this match will be skipped. "
@@ -4119,209 +3293,15 @@ fn EditMatchModal(
                                                 "(skip condition help)"
                                             }
                                         }
-                                        input {
-                                            id: "skip-condition-input-edit",
-                                            class: "form-control font-monospace",
-                                            "type": "text",
-                                            placeholder: "e.g. (== 0 (losses [Team]))",
-                                            value: "{skip_condition}",
-                                            oninput: move |e| {
-                                                let new_val = e.value();
-                                                let old = skip_condition();
-                                                let (out, cursor_after_open) = if let Some(byte_i) = skip_condition_new_char_index(&old, &new_val) {
-                                                    let open_c = new_val[byte_i..].chars().next().unwrap_or('\0');
-                                                    let closing = match open_c {
-                                                        '(' => ")",
-                                                        '[' => {
-                                                            skip_bracket_ac_visible.set(true);
-                                                            skip_bracket_ac_team.set(true);
-                                                            skip_bracket_ac_index.set(0);
-                                                            "]"
-                                                        }
-                                                        '{' => {
-                                                            skip_bracket_ac_visible.set(true);
-                                                            skip_bracket_ac_team.set(false);
-                                                            skip_bracket_ac_index.set(0);
-                                                            "}"
-                                                        }
-                                                        _ => "",
-                                                    };
-                                                    if closing.is_empty() {
-                                                        (new_val, None)
-                                                    } else {
-                                                        let char_end = byte_i + new_val[byte_i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
-                                                        let out_str = format!("{}{}{}", &new_val[..char_end], closing, &new_val[char_end..]);
-                                                        (out_str, Some(char_end))
-                                                    }
-                                                } else {
-                                                    (new_val, None)
-                                                };
-                                                skip_condition.set(out.clone());
-                                                if let Some(pos) = cursor_after_open {
-                                                    skip_condition_cursor.set(Some(pos));
-                                                }
-                                                skip_condition_error.set(None);
-                                                if out.contains('(') {
-                                                    skip_docs_visible.set(true);
-                                                }
-                                                let id = "skip-condition-input-edit".to_string();
-                                                spawn(async move {
-                                                    gloo_timers::future::TimeoutFuture::new(0).await;
-                                                    #[cfg(target_arch = "wasm32")]
-                                                    if let Some(window) = web_sys::window() {
-                                                        if let Some(doc) = window.document() {
-                                                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                                                    if let Ok(Some(sel)) = input.selection_start() {
-                                                                        skip_condition_cursor_pos.set(Some(sel as usize));
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            onfocus: move |_| {
-                                                let id = "skip-condition-input-edit".to_string();
-                                                spawn(async move {
-                                                    gloo_timers::future::TimeoutFuture::new(0).await;
-                                                    #[cfg(target_arch = "wasm32")]
-                                                    if let Some(window) = web_sys::window() {
-                                                        if let Some(doc) = window.document() {
-                                                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                                                    if let Ok(Some(sel)) = input.selection_start() {
-                                                                        skip_condition_cursor_pos.set(Some(sel as usize));
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            onkeydown: move |ev: Event<KeyboardData>| {
-                                                let key = ev.key().to_string();
-                                                let n_edit = bracket_options_edit.len();
-                                                if show_bracket_ac_edit && n_edit > 0 {
-                                                    if key == "ArrowDown" {
-                                                        ev.prevent_default();
-                                                        skip_bracket_ac_index.set((bracket_ac_idx_edit + 1) % n_edit);
-                                                        return;
-                                                    }
-                                                    if key == "ArrowUp" {
-                                                        ev.prevent_default();
-                                                        skip_bracket_ac_index.set((bracket_ac_idx_edit + n_edit - 1) % n_edit);
-                                                        return;
-                                                    }
-                                                    if key == "Enter" {
-                                                        ev.prevent_default();
-                                                        if let Some((opt_insert, _, _)) = bracket_options_edit.get(bracket_ac_idx_edit) {
-                                                            let v = skip_condition();
-                                                            let cursor_char = skip_condition_cursor_pos().unwrap_or(0);
-                                                            let cursor_byte = skip_condition_cursor_byte(&v, cursor_char);
-                                                            let inn = skip_condition_innermost_around_cursor(&v, cursor_char);
-                                                            if let Some(cs) = inn.and_then(|b| match b {
-                                                                InnermostBracket::Square(cs, _) | InnermostBracket::Curly(cs, _) => Some(cs),
-                                                                _ => None,
-                                                            }) {
-                                                                let new_v = format!("{}{}{}", &v[..cs], opt_insert, &v[cursor_byte..]);
-                                                                skip_condition.set(new_v);
-                                                                let cs_chars = v[..cs].chars().count();
-                                                                let new_cursor_char = cs_chars + opt_insert.chars().count();
-                                                                skip_condition_cursor.set(Some(new_cursor_char));
-                                                                skip_bracket_ac_visible.set(false);
-                                                            }
-                                                        }
-                                                        return;
-                                                    }
-                                                }
-                                                if key == "Enter" && !ev.modifiers().contains(Modifiers::SHIFT) {
-                                                    ev.prevent_default();
-                                                }
-                                            },
-                                            onkeyup: move |_| {
-                                                let id = "skip-condition-input-edit".to_string();
-                                                spawn(async move {
-                                                    gloo_timers::future::TimeoutFuture::new(0).await;
-                                                    #[cfg(target_arch = "wasm32")]
-                                                    if let Some(window) = web_sys::window() {
-                                                        if let Some(doc) = window.document() {
-                                                            if let Ok(Some(el)) = doc.query_selector(&format!("#{}", id)) {
-                                                                if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
-                                                                    if let Ok(Some(sel)) = input.selection_start() {
-                                                                        let sel_i = sel as usize;
-                                                                        skip_condition_cursor_pos.set(Some(sel_i));
-                                                                        let val = input.value();
-                                                                        let inside = skip_condition_innermost_around_cursor(&val, sel_i)
-                                                                            .map(|b| matches!(b, InnermostBracket::Square(_, _) | InnermostBracket::Curly(_, _)))
-                                                                            .unwrap_or(false);
-                                                                        if !inside {
-                                                                            skip_bracket_ac_visible.set(false);
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                            onblur: move |_| {
-                                                skip_docs_visible.set(false);
-                                                skip_bracket_ac_visible.set(false);
-                                                let expr = skip_condition();
-                                                if expr.trim().is_empty() {
-                                                    skip_condition_error.set(None);
-                                                    return;
-                                                }
-                                                let url = tournament_url.clone();
-                                                spawn(async move {
-                                                    match api::validate_dsl(&url, &expr).await {
-                                                        Ok(res) => {
-                                                            skip_condition_error.set(if res.valid {
-                                                                None
-                                                            } else {
-                                                                res.error
-                                                            });
-                                                            skip_condition_simplified.set(if res.valid {
-                                                                res.simplified
-                                                            } else {
-                                                                None
-                                                            });
-                                                        }
-                                                        Err(e) => {
-                                                            skip_condition_error.set(Some(e));
-                                                            skip_condition_simplified.set(None);
-                                                        }
-                                                    }
-                                                });
-                                            },
-                                        }
-                                        if show_skip_docs_edit && !docs_filtered_edit.is_empty() {
-                                            div { class: "position-absolute start-0 mt-1 p-2 bg-light border rounded shadow-sm z-3",
-                                                style: "min-width: 280px; max-height: 240px; overflow-y: auto;",
-                                                ul { class: "list-unstyled mb-0 small",
-                                                    for item in docs_items_edit.iter() {
-                                                        {item.clone()}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        if show_bracket_ac_edit && !bracket_options_edit.is_empty() {
-                                            div { class: "position-absolute start-0 mt-1 p-2 bg-light border rounded shadow-sm z-3",
-                                                style: "min-width: 200px; max-height: 240px; overflow-y: auto;",
-                                                ul { class: "list-unstyled mb-0 small",
-                                                    for item in bracket_option_items_edit.iter() {
-                                                        {item.clone()}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        if let Some(err) = skip_condition_error() {
-                                            div { class: "form-text text-danger", "✗ {err}" }
-                                        } else if let Some(simp) = skip_condition_simplified() {
-                                            div { class: "form-text text-success", "✓ Valid (simplified: {simp})" }
-                                        } else if !skip_condition().trim().is_empty() {
-                                            div { class: "form-text text-success", "✓ Valid" }
+                                        AssEntry {
+                                            id_suffix: "edit".to_string(),
+                                            value: skip_condition(),
+                                            on_change: move |v| skip_condition.set(v),
+                                            team_options: data.team_options.clone(),
+                                            tags: data.tags.clone(),
+                                            matches: data.matches.clone(),
+                                            tournament_url: tournament_url.clone(),
+                                            placeholder: "e.g. (== 0 (losses [Team]))".to_string(),
                                         }
                                     }
                                 }

--- a/frontend/src/pages/schedule_timeline.css
+++ b/frontend/src/pages/schedule_timeline.css
@@ -487,6 +487,104 @@
     padding: 0.05rem 0.25rem;
 }
 
+/* ASS (Arctos Schedule Script) entry component */
+.ass-entry {
+    /* container holds input + dropdown + preview + status */
+}
+
+.ass-entry-input {
+    /* monospaced input from form-control font-monospace */
+}
+
+.ass-entry-ac {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1050;
+    min-width: 280px;
+    max-width: 480px;
+    max-height: 280px;
+    overflow-y: auto;
+    margin-top: 2px;
+    padding: 0.25rem 0;
+    background: white;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+    list-style: none;
+}
+
+.ass-entry-ac-item {
+    padding: 0.3rem 0.6rem;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.ass-entry-ac-item-active {
+    background: #0d6efd;
+    color: white;
+}
+
+.ass-entry-ac-item-active .text-muted,
+.ass-entry-ac-item-active .ass-entry-ac-fn-desc {
+    color: rgba(255, 255, 255, 0.85) !important;
+}
+
+.ass-entry-ac-fn-name {
+    font-weight: 600;
+    font-family: var(--bs-font-monospace, monospace);
+}
+
+.ass-entry-ac-fn-sig {
+    font-family: var(--bs-font-monospace, monospace);
+    font-size: 0.85em;
+}
+
+.ass-entry-ac-fn-desc {
+    font-size: 0.8em;
+    line-height: 1.3;
+}
+
+.ass-entry-preview {
+    margin-top: 0.3rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    align-items: center;
+    padding: 0.25rem 0.4rem;
+    background: #f8f9fa;
+    border-radius: 4px;
+    border: 1px dashed #ced4da;
+}
+
+.ass-entry-preview-text {
+    font-family: var(--bs-font-monospace, monospace);
+    color: #495057;
+    white-space: pre;
+}
+
+.ass-entry-preview-bracket {
+    font-family: var(--bs-font-monospace, monospace);
+    font-weight: 600;
+}
+
+.team-token-chip-match {
+    background: #fff3cd;
+    border-color: #ffe69c;
+}
+
+.ass-entry-preview-unknown {
+    background: #f8d7da;
+    border-color: #f5c2c7;
+}
+
+.ass-entry-error {
+    white-space: pre-wrap;
+    font-family: var(--bs-font-monospace, monospace);
+}
+
 /* Schedule table view: keep cells as table-cell so Team 1 / Team 2 / Refs columns layout correctly */
 .schedule-table-view table {
     table-layout: auto;

--- a/frontend/src/pages/schedule_timeline.css
+++ b/frontend/src/pages/schedule_timeline.css
@@ -585,6 +585,130 @@
     font-family: var(--bs-font-monospace, monospace);
 }
 
+.ass-entry-simplified {
+    margin-top: 0.25rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    align-items: center;
+    padding: 0.25rem 0.4rem;
+    background: rgba(25, 135, 84, 0.06);
+    border-radius: 4px;
+    border: 1px dashed rgba(25, 135, 84, 0.35);
+}
+
+.ass-entry-simplified-label {
+    font-style: italic;
+}
+
+/* Compact atom rendering used inside the match autocomplete and ASS preview */
+.ass-atom {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    background: rgba(13, 110, 253, 0.07);
+    border: 1px solid rgba(13, 110, 253, 0.18);
+    font-size: 0.85em;
+    line-height: 1.2;
+    margin-right: 0.15rem;
+}
+
+.ass-atom-unknown {
+    background: rgba(220, 53, 69, 0.07);
+    border-color: rgba(220, 53, 69, 0.25);
+    color: #842029;
+}
+
+.ass-atom-avatar {
+    display: inline-flex;
+    width: 1.1em;
+    height: 1.1em;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: #6c757d;
+    color: white;
+    font-size: 0.7em;
+    font-weight: 600;
+    object-fit: cover;
+}
+
+.ass-atom-avatar-text {
+    line-height: 1;
+}
+
+.ass-atom-icon {
+    width: 1em;
+    height: 1em;
+}
+
+.ass-atom-label {
+    font-size: 0.95em;
+}
+
+.ass-atom-badge {
+    font-size: 0.65em;
+    font-weight: 700;
+    padding: 0 0.25rem;
+    border-radius: 2px;
+    color: white;
+}
+
+.ass-entry-ac-item .ass-atom {
+    background: rgba(0, 0, 0, 0.04);
+    border-color: rgba(0, 0, 0, 0.1);
+}
+
+.ass-entry-ac-item-active .ass-atom {
+    background: rgba(255, 255, 255, 0.18);
+    border-color: rgba(255, 255, 255, 0.3);
+    color: white;
+}
+
+.ass-entry-ac-item-active .ass-atom-unknown {
+    background: rgba(255, 255, 255, 0.18);
+    border-color: rgba(255, 200, 200, 0.4);
+    color: #ffd9d9;
+}
+
+.ass-entry-ac-match-head {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.ass-entry-ac-match-name {
+    font-weight: 600;
+}
+
+.ass-entry-ac-match-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.15rem;
+    margin-top: 0.15rem;
+}
+
+.ass-entry-ac-vs {
+    font-style: italic;
+}
+
+.ass-entry-ac-refs {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.15rem;
+}
+
+.ass-entry-ac-resolved {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    font-size: 0.85em;
+}
+
 /* Schedule table view: keep cells as table-cell so Team 1 / Team 2 / Refs columns layout correctly */
 .schedule-table-view table {
     table-layout: auto;

--- a/frontend/src/pages/schedule_timeline.css
+++ b/frontend/src/pages/schedule_timeline.css
@@ -500,26 +500,36 @@
     position: absolute;
     top: 100%;
     left: 0;
-    z-index: 1050;
-    min-width: 280px;
-    max-width: 480px;
+    /* Width follows the input — the textarea above sets the column width.
+       Allow growing wider when there's room (e.g. for long match descriptors). */
+    width: 100%;
+    min-width: 0;
+    max-width: min(520px, 95vw);
     max-height: 280px;
     overflow-y: auto;
     margin-top: 2px;
-    padding: 0.25rem 0;
+    padding: 0.15rem 0;
     background: white;
     border: 1px solid #dee2e6;
     border-radius: 4px;
     box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
     list-style: none;
+    font-size: 0.85em;
 }
 
 .ass-entry-ac-item {
-    padding: 0.3rem 0.6rem;
+    padding: 0.2rem 0.4rem;
     cursor: pointer;
     display: flex;
     flex-direction: column;
     gap: 0;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.ass-entry-ac-item > span,
+.ass-entry-ac-item > div {
+    min-width: 0;
 }
 
 .ass-entry-ac-item-active {
@@ -540,11 +550,17 @@
 .ass-entry-ac-fn-sig {
     font-family: var(--bs-font-monospace, monospace);
     font-size: 0.85em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .ass-entry-ac-fn-desc {
     font-size: 0.8em;
-    line-height: 1.3;
+    line-height: 1.25;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .ass-entry-preview {
@@ -570,6 +586,13 @@
     font-weight: 600;
 }
 
+/* Forces the next chip onto a new flex row — drop-in replacement for `\n` in the input. */
+.ass-entry-preview-break {
+    flex-basis: 100%;
+    width: 100%;
+    height: 0;
+}
+
 .team-token-chip-match {
     background: #fff3cd;
     border-color: #ffe69c;
@@ -583,6 +606,13 @@
 .ass-entry-error {
     white-space: pre-wrap;
     font-family: var(--bs-font-monospace, monospace);
+}
+
+.ass-entry-input {
+    resize: none;
+    min-height: calc(1.5em + 0.75rem + 2px);
+    overflow-y: hidden;
+    line-height: 1.5;
 }
 
 .ass-entry-simplified {
@@ -605,14 +635,18 @@
 .ass-atom {
     display: inline-flex;
     align-items: center;
-    gap: 0.2rem;
-    padding: 0.05rem 0.3rem;
+    gap: 0.15rem;
+    padding: 0 0.2rem;
     border-radius: 3px;
     background: rgba(13, 110, 253, 0.07);
     border: 1px solid rgba(13, 110, 253, 0.18);
-    font-size: 0.85em;
-    line-height: 1.2;
-    margin-right: 0.15rem;
+    font-size: 0.78em;
+    line-height: 1.3;
+    margin-right: 0.1rem;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .ass-atom-unknown {
@@ -677,10 +711,18 @@
     display: flex;
     align-items: center;
     gap: 0.25rem;
+    flex-wrap: wrap;
+    min-width: 0;
 }
 
 .ass-entry-ac-match-name {
     font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.ass-entry-ac-match-field {
+    font-size: 0.85em;
 }
 
 .ass-entry-ac-match-meta {
@@ -688,11 +730,13 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 0.15rem;
-    margin-top: 0.15rem;
+    margin-top: 0.1rem;
+    min-width: 0;
 }
 
 .ass-entry-ac-vs {
     font-style: italic;
+    font-size: 0.8em;
 }
 
 .ass-entry-ac-refs {
@@ -700,13 +744,18 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 0.15rem;
+    min-width: 0;
 }
 
 .ass-entry-ac-resolved {
     display: inline-flex;
     align-items: center;
-    gap: 0.2rem;
-    font-size: 0.85em;
+    gap: 0.15rem;
+    font-size: 0.8em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
 }
 
 /* Schedule table view: keep cells as table-cell so Team 1 / Team 2 / Refs columns layout correctly */

--- a/frontend/src/types.rs
+++ b/frontend/src/types.rs
@@ -1283,6 +1283,9 @@ pub struct ValidateDslResponse {
     #[serde(default)]
     pub simplified: Option<String>,
     pub error: Option<String>,
+    /// Possible types of the simplified result, e.g. ["BOOL"], ["TEAM"], ["UNKNOWN"].
+    #[serde(default)]
+    pub result_type: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/tests/test_dsl_parser.py
+++ b/tests/test_dsl_parser.py
@@ -6,7 +6,7 @@ team/match operations, lambdas, and list operations.
 
 import pytest
 
-from app.utils.parser import get_parser, DSLValidationError
+from app.utils.parser import get_parser, DSLValidationError, _infer_types
 from app.domain.enums import MatchStatus, WinnerSide
 from models import Match, Team, Point, Tag, db
 
@@ -777,3 +777,110 @@ class TestEdgeCases:
             assert parser.parse(f"(== (winner {{{match1_name}}}) [team1])") is True
             # Different team must be False
             assert parser.parse(f"(== [{match1_name}::winner] [team2])") is False
+
+
+class TestInferTypes:
+    """Type inference for the validate-dsl response.
+
+    Concrete values map directly; preserved expressions look up their head
+    function's declared return type and recurse where it depends on args
+    (`if`, `or-default`).
+    """
+
+    @pytest.mark.unit
+    def test_concrete_atoms(self, app, tournament_with_data):
+        with app.app_context():
+            parser = get_parser(tournament_with_data["tournament_url"])
+            assert _infer_types(parser.parse("true")) == frozenset({"BOOL"})
+            assert _infer_types(parser.parse("false")) == frozenset({"BOOL"})
+            assert _infer_types(parser.parse("42")) == frozenset({"INT"})
+            assert _infer_types(parser.parse("nil")) == frozenset({"NIL"})
+            assert _infer_types(parser.parse("[team1]")) == frozenset({"TEAM"})
+
+    @pytest.mark.unit
+    def test_arithmetic_returns_int(self, app, tournament_with_data):
+        with app.app_context():
+            parser = get_parser(tournament_with_data["tournament_url"])
+            assert _infer_types(parser.parse("(+ 1 2)")) == frozenset({"INT"})
+
+    @pytest.mark.unit
+    def test_comparison_and_logic_return_bool(self, app, tournament):
+        with app.app_context():
+            parser = get_parser(tournament.url)
+            assert _infer_types(parser.parse("(> 3 2)")) == frozenset({"BOOL"})
+            assert _infer_types(parser.parse("(and true false)")) == frozenset({"BOOL"})
+            assert _infer_types(parser.parse("(not true)")) == frozenset({"BOOL"})
+
+    @pytest.mark.unit
+    def test_winner_loser_return_team(self, app, tournament_with_data):
+        with app.app_context():
+            parser = get_parser(tournament_with_data["tournament_url"])
+            match3_name = tournament_with_data["match3_name"]
+            # match3 hasn't started, so winner stays preserved.
+            assert _infer_types(parser.parse(f"(winner {{{match3_name}}})")) == frozenset({"TEAM"})
+
+    @pytest.mark.unit
+    def test_preserved_unresolved_team(self, app, tournament_with_data):
+        """Expressions over a SymbolicTeam stay as preserved-list expressions whose
+        head's return type still pins down the resulting type."""
+        with app.app_context():
+            tournament_url = tournament_with_data["tournament_url"]
+            db.session.add(Tag(event=tournament_url, name="UnsetTagInfer", team=None))
+            db.session.commit()
+            parser = get_parser(tournament_url)
+            assert _infer_types(parser.parse("(losses [tag::UnsetTagInfer])")) == frozenset({"INT"})
+            assert _infer_types(parser.parse("(== 0 (losses [tag::UnsetTagInfer]))")) == frozenset({"BOOL"})
+
+    @pytest.mark.unit
+    def test_if_unions_branches(self, app, tournament_with_data):
+        with app.app_context():
+            tournament_url = tournament_with_data["tournament_url"]
+            db.session.add(Tag(event=tournament_url, name="UnsetTagIf", team=None))
+            db.session.commit()
+            parser = get_parser(tournament_url)
+            # condition is symbolic so the if stays preserved; both branches return INT.
+            assert _infer_types(parser.parse("(if (== 0 (losses [tag::UnsetTagIf])) 1 2)")) == frozenset({"INT"})
+            # mixed branches → union.
+            assert _infer_types(parser.parse("(if (== 0 (losses [tag::UnsetTagIf])) true 0)")) == frozenset(
+                {"BOOL", "INT"}
+            )
+
+    @pytest.mark.unit
+    def test_or_default_unions_non_nil(self, app, tournament_with_data):
+        """(or-default val default) — type is val's possible types minus NIL, plus default's types."""
+        with app.app_context():
+            parser = get_parser(tournament_with_data["tournament_url"])
+            assert _infer_types(parser.parse("(or-default nil 5)")) == frozenset({"INT"})
+            assert _infer_types(parser.parse("(or-default 5 7)")) == frozenset({"INT"})
+
+    @pytest.mark.unit
+    def test_lambda_returns_func(self, app, tournament):
+        with app.app_context():
+            parser = get_parser(tournament.url)
+            assert _infer_types(parser.parse("(lambda (x) (+ x 1))")) == frozenset({"FUNC"})
+
+    @pytest.mark.unit
+    def test_cons_returns_list(self, app, tournament):
+        with app.app_context():
+            parser = get_parser(tournament.url)
+            assert _infer_types(parser.parse("(cons 1 2 3)")) == frozenset({"LIST"})
+
+    @pytest.mark.unit
+    def test_get_infers_element_types_from_cons(self, app, tournament_with_data):
+        """(get index (cons ...)) — when get stays preserved (symbolic index), the
+        cons element types are still recoverable so or-default can drop the NIL."""
+        with app.app_context():
+            tournament_url = tournament_with_data["tournament_url"]
+            db.session.add(Tag(event=tournament_url, name="UnsetTagGet", team=None))
+            db.session.commit()
+            parser = get_parser(tournament_url)
+            # The original failing example from the bug report — `(wins [tag::UnsetTagGet])`
+            # is symbolic so `get` stays preserved; element-type inference makes or-default
+            # collapse to {BOOL} instead of {BOOL, UNKNOWN}.
+            assert _infer_types(
+                parser.parse("(or-default (get (wins [tag::UnsetTagGet]) (cons true false true)) false)")
+            ) == frozenset({"BOOL"})
+            # Without or-default, the preserved get exposes element-types ∪ NIL.
+            assert _infer_types(parser.parse("(get (wins [tag::UnsetTagGet]) (cons true false 1))")) == frozenset(
+                {"BOOL", "INT", "NIL"}
+            )

--- a/tests/test_dsl_parser.py
+++ b/tests/test_dsl_parser.py
@@ -577,7 +577,7 @@ class TestErrorHandling:
         with app.app_context():
             parser = get_parser(tournament.url)
 
-            with pytest.raises(DSLValidationError, match="No symbol named"):
+            with pytest.raises(DSLValidationError, match="Unknown function"):
                 parser.parse("(undefined_function 1 2)")
 
     @pytest.mark.unit

--- a/tests/test_dsl_parser.py
+++ b/tests/test_dsl_parser.py
@@ -538,13 +538,22 @@ class TestSymbolicExpressions:
     @pytest.mark.unit
     def test_preserved_expression_with_unresolved_team(self, app, tournament_with_data):
         with app.app_context():
-            parser = get_parser(tournament_with_data["tournament_url"])
+            tournament_url = tournament_with_data["tournament_url"]
+            # Create a tag without a team — its team is unknown, so the expression should preserve.
+            db.session.add(Tag(event=tournament_url, name="UnsetTagPreserve", team=None))
+            db.session.commit()
 
-            # Tag that doesn't exist or isn't set should preserve expression
-            result = parser.parse("(== 0 (losses [tag::NonExistent]))")
-            # Should be a preserved expression (list)
+            parser = get_parser(tournament_url)
+            result = parser.parse("(== 0 (losses [tag::UnsetTagPreserve]))")
             assert isinstance(result, list)
             assert result[0] == "=="
+
+    @pytest.mark.unit
+    def test_unknown_tag_errors(self, app, tournament_with_data):
+        with app.app_context():
+            parser = get_parser(tournament_with_data["tournament_url"])
+            with pytest.raises(DSLValidationError, match="Tag .* does not exist"):
+                parser.parse("[tag::NonExistent]")
 
     @pytest.mark.unit
     def test_preserved_expression_with_unresolved_match(self, app, tournament_with_data):
@@ -560,13 +569,16 @@ class TestSymbolicExpressions:
     @pytest.mark.unit
     def test_preserved_expression_nested(self, app, tournament_with_data):
         with app.app_context():
-            parser = get_parser(tournament_with_data["tournament_url"])
+            tournament_url = tournament_with_data["tournament_url"]
+            # The tag exists but has no team — preserve, don't error.
+            db.session.add(Tag(event=tournament_url, name="UnsetTagNested", team=None))
+            db.session.commit()
 
-            # Complex expression with unresolved values should preserve
-            result = parser.parse("(== 0 (losses [tag::UnsetTag]))")
+            parser = get_parser(tournament_url)
+            result = parser.parse("(== 0 (losses [tag::UnsetTagNested]))")
             assert isinstance(result, list)
-            # The inner expression should also be preserved
-            assert isinstance(result[2], list)  # (losses [tag::UnsetTag])
+            # The inner expression should also be preserved.
+            assert isinstance(result[2], list)
 
 
 class TestErrorHandling:

--- a/tests/test_dsl_parser.py
+++ b/tests/test_dsl_parser.py
@@ -6,7 +6,7 @@ team/match operations, lambdas, and list operations.
 
 import pytest
 
-from app.utils.parser import get_parser, DSLValidationError, _infer_types
+from app.utils.parser import get_parser, DSLValidationError, Nil, _infer_types
 from app.domain.enums import MatchStatus, WinnerSide
 from models import Match, Team, Point, Tag, db
 
@@ -153,7 +153,7 @@ class TestBasicOperations:
         with app.app_context():
             parser = get_parser(tournament.url)
 
-            assert parser.parse("nil") is None
+            assert parser.parse("nil") == Nil()
 
 
 class TestConditionalExpressions:
@@ -295,26 +295,26 @@ class TestListOperations:
     """Test list manipulation operations."""
 
     @pytest.mark.unit
-    def test_cons(self, app, tournament):
+    def test_quote(self, app, tournament):
         with app.app_context():
             parser = get_parser(tournament.url)
 
-            result = parser.parse("(cons 1 2 3)")
-            assert result == [1, 2, 3]
+            assert parser.parse("'(1 2 3)") == [1, 2, 3]
+            assert parser.parse("(quote (1 2 3))") == [1, 2, 3]
 
     @pytest.mark.unit
     def test_car(self, app, tournament):
         with app.app_context():
             parser = get_parser(tournament.url)
 
-            assert parser.parse("(car (cons 1 2 3))") == 1
+            assert parser.parse("(car '(1 2 3))") == 1
 
     @pytest.mark.unit
     def test_cdr(self, app, tournament):
         with app.app_context():
             parser = get_parser(tournament.url)
 
-            result = parser.parse("(cdr (cons 1 2 3))")
+            result = parser.parse("(cdr '(1 2 3))")
             assert result == [2, 3]
 
     @pytest.mark.unit
@@ -322,19 +322,19 @@ class TestListOperations:
         with app.app_context():
             parser = get_parser(tournament.url)
 
-            assert parser.parse("(get 0 (cons 10 20 30))") == 10
-            assert parser.parse("(get 1 (cons 10 20 30))") == 20
-            assert parser.parse("(get 2 (cons 10 20 30))") == 30
+            assert parser.parse("(get 0 '(10 20 30))") == 10
+            assert parser.parse("(get 1 '(10 20 30))") == 20
+            assert parser.parse("(get 2 '(10 20 30))") == 30
             # Out of bounds returns nil
-            assert parser.parse("(get 5 (cons 10 20 30))") is None
+            assert parser.parse("(get 5 '(10 20 30))") == Nil()
 
     @pytest.mark.unit
     def test_len(self, app, tournament):
         with app.app_context():
             parser = get_parser(tournament.url)
 
-            assert parser.parse("(len (cons 1 2 3))") == 3
-            assert parser.parse("(len (cons))") == 0
+            assert parser.parse("(len '(1 2 3))") == 3
+            assert parser.parse("(len '())") == 0
 
     @pytest.mark.unit
     def test_or_default(self, app, tournament):
@@ -349,14 +349,14 @@ class TestListOperations:
         with app.app_context():
             parser = get_parser(tournament.url)
 
-            assert parser.parse("(max (cons 1 5 3 2))") == 5
+            assert parser.parse("(max '(1 5 3 2))") == 5
 
     @pytest.mark.unit
     def test_min(self, app, tournament):
         with app.app_context():
             parser = get_parser(tournament.url)
 
-            assert parser.parse("(min (cons 5 1 3 2))") == 1
+            assert parser.parse("(min '(5 1 3 2))") == 1
 
 
 class TestLambdaFunctions:
@@ -395,7 +395,7 @@ class TestLambdaFunctions:
             parser = get_parser(tournament.url)
 
             # Map add 1 to each element
-            result = parser.parse("(map (cons 1 2 3) (lambda (x) (+ x 1)))")
+            result = parser.parse("(map '(1 2 3) (lambda (x) (+ x 1)))")
             assert result == [2, 3, 4]
 
     @pytest.mark.unit
@@ -404,7 +404,7 @@ class TestLambdaFunctions:
             parser = get_parser(tournament.url)
 
             # Sum a list
-            result = parser.parse("(reduce (cons 1 2 3 4) (lambda (acc x) (+ acc x)))")
+            result = parser.parse("(reduce '(1 2 3 4) (lambda (acc x) (+ acc x)))")
             assert result == 10
 
     @pytest.mark.unit
@@ -413,7 +413,7 @@ class TestLambdaFunctions:
             parser = get_parser(tournament.url)
 
             # Find element with maximum value when doubled
-            result = parser.parse("(max-by (cons 1 3 2) (lambda (x) (* x 2)))")
+            result = parser.parse("(max-by '(1 3 2) (lambda (x) (* x 2)))")
             assert result == 3  # 3*2=6 is the max
 
     @pytest.mark.unit
@@ -422,7 +422,7 @@ class TestLambdaFunctions:
             parser = get_parser(tournament.url)
 
             # Find element with minimum value when doubled
-            result = parser.parse("(min-by (cons 3 1 2) (lambda (x) (* x 2)))")
+            result = parser.parse("(min-by '(3 1 2) (lambda (x) (* x 2)))")
             assert result == 1  # 1*2=2 is the min
 
 
@@ -607,7 +607,7 @@ class TestErrorHandling:
 
             # This should preserve the expression if it contains unresolved identifiers
             # But if we try to add a boolean to an int, it should error
-            with pytest.raises(DSLValidationError, match="must be an INT"):
+            with pytest.raises(DSLValidationError, match="must be INT"):
                 parser.parse("(+ true 5)")
 
     @pytest.mark.unit
@@ -616,10 +616,10 @@ class TestErrorHandling:
             parser = get_parser(tournament.url)
 
             with pytest.raises(DSLValidationError, match="empty list"):
-                parser.parse("(car (cons))")
+                parser.parse("(car '())")
 
             with pytest.raises(DSLValidationError, match="empty list"):
-                parser.parse("(cdr (cons))")
+                parser.parse("(cdr '())")
 
     @pytest.mark.unit
     def test_lambda_wrong_arg_count(self, app, tournament):
@@ -709,7 +709,7 @@ class TestLambdaAdvanced:
             parser = get_parser(tournament.url)
 
             # Double each element
-            result = parser.parse("(map (cons 1 2 3) (lambda (x) (* x 2)))")
+            result = parser.parse("(map '(1 2 3) (lambda (x) (* x 2)))")
             assert result == [2, 4, 6]
 
     @pytest.mark.unit
@@ -720,7 +720,7 @@ class TestLambdaAdvanced:
             # Find elements greater than 2 (using map and filtering concept)
             # Note: We don't have filter, but we can use map with conditional
             # This is a simplified example
-            result = parser.parse("(map (cons 1 2 3 4) (lambda (x) (if (> x 2) x 0)))")
+            result = parser.parse("(map '(1 2 3 4) (lambda (x) (if (> x 2) x 0)))")
             assert result == [0, 0, 3, 4]
 
 
@@ -742,7 +742,7 @@ class TestEdgeCases:
             parser = get_parser(tournament.url)
 
             # Single element (not a function call, just a list)
-            result = parser.parse("(cons 42)")
+            result = parser.parse("'(42)")
             assert result == [42]
 
     @pytest.mark.unit
@@ -860,15 +860,15 @@ class TestInferTypes:
             assert _infer_types(parser.parse("(lambda (x) (+ x 1))")) == frozenset({"FUNC"})
 
     @pytest.mark.unit
-    def test_cons_returns_list(self, app, tournament):
+    def test_quote_returns_list(self, app, tournament):
         with app.app_context():
             parser = get_parser(tournament.url)
-            assert _infer_types(parser.parse("(cons 1 2 3)")) == frozenset({"LIST"})
+            assert _infer_types(parser.parse("'(1 2 3)")) == frozenset({"LIST"})
 
     @pytest.mark.unit
-    def test_get_infers_element_types_from_cons(self, app, tournament_with_data):
-        """(get index (cons ...)) — when get stays preserved (symbolic index), the
-        cons element types are still recoverable so or-default can drop the NIL."""
+    def test_get_infers_element_types_from_quoted_list(self, app, tournament_with_data):
+        """(get index '(...)) — when get stays preserved (symbolic index), the
+        quoted-list element types are still recoverable so or-default can drop the NIL."""
         with app.app_context():
             tournament_url = tournament_with_data["tournament_url"]
             db.session.add(Tag(event=tournament_url, name="UnsetTagGet", team=None))
@@ -878,9 +878,9 @@ class TestInferTypes:
             # is symbolic so `get` stays preserved; element-type inference makes or-default
             # collapse to {BOOL} instead of {BOOL, UNKNOWN}.
             assert _infer_types(
-                parser.parse("(or-default (get (wins [tag::UnsetTagGet]) (cons true false true)) false)")
+                parser.parse("(or-default (get (wins [tag::UnsetTagGet]) '(true false true)) false)")
             ) == frozenset({"BOOL"})
             # Without or-default, the preserved get exposes element-types ∪ NIL.
-            assert _infer_types(parser.parse("(get (wins [tag::UnsetTagGet]) (cons true false 1))")) == frozenset(
+            assert _infer_types(parser.parse("(get (wins [tag::UnsetTagGet]) '(true false 1))")) == frozenset(
                 {"BOOL", "INT", "NIL"}
             )


### PR DESCRIPTION
## Summary

adds a component for ASS entry with suggestions, completion, and validation that actually make sense.  
also helps split up the massive Thing that is `schedule.rs`

i know nobody uses this feature!! i promise its relevant to do this issue first; its so that we can migrate the team1/team2/refs entry boxes to ASS as a part of the editing refactor. this autocomplete should make it easier not to fuck up when entering data.

## What changed

- returns errors/warnings that actually make sense (ie, `unexpected '(', line 1, col 32`)
- checks that braces are balanced
- difflib fuzzy search for suggestions
- distinguish between nonexistant tags and unset tags 🫪
- check for invalid references
- display more match info (teams, field) in the autocomplete when in curly brackets
- updated DSL_FUNCTIONS const
- make the ass-related frontend stuff into a component and move it into a separate file in the components directory

still todo: 
- [x] ensure it can work with different box sizes
- [x] make it a bit more compact for use in team and ref entries
- [x] make it actually check the expression when i stop typing for long enough (rn its just when i focus away from the box)
- [ ] ~~get rid of those awful chains of four `if let`s~~ nope my rust-analyzer is cooked and gives errors about the current year being before 2024 when this was stable and i dont care enough to fix it

## Migration impact

none! the migration will come when we actually start using this for team1/team2/refs.

## Test plan


- [x] `make test` passes locally
- [x] Manual verification - tested expressions with:
  - tags (that exist, don't exist, or exist but are not set)
  - team literals which do or dont exist
  - team literals in the `matchname::winner` format
  - match literals which do or do not exist
  - conditionals
  - lambdas, cons, cat, cdr, and map (over numbers)

## Linked issues

Closes #200 

## Screenshots / repro

turns out that putting tokens inline with editable text is rlly hard and you need to use a canvas or something and do all of the ui custom. im not about that, so this will be good enough

<img width="817" height="438" alt="image" src="https://github.com/user-attachments/assets/6c9a4666-916b-4aea-824f-968c5230e003" />
<img width="817" height="438" alt="image" src="https://github.com/user-attachments/assets/e4843f77-d2b7-4d52-b6c7-0f9e84e84b03" />
<img width="817" height="412" alt="image" src="https://github.com/user-attachments/assets/bad4d4b6-22f1-47f2-b76a-369dbfba29e0" />


---

### Pre-review checklist

<!-- Strike through (~~item~~) anything that doesn't apply, rather than
     deleting, so reviewers can see you thought about it. -->

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [x] Targeting `dev`, not `main` (unless this is a release PR).
- [x] `make lint` and `make format` are clean.
- [x] Tests added or updated for the new behavior.
- [ ] ~~If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated (per `CLAUDE.md`).~~
- [x] If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.
- [x] No merge conflicts with the base branch.
