### PR TITLE
[Refactor] Extract auth and account-lifecycle routes into the auth blueprint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -211,7 +211,7 @@ def create_app(config: dict | None = None) -> Flask:
 
     # Initialize login manager
     login_manager.init_app(app)
-    login_manager.login_view = "_api.login_redirect"
+    login_manager.login_view = "auth.login_redirect"
 
     @login_manager.unauthorized_handler
     def unauthorized():

--- a/app/routes/_api.py
+++ b/app/routes/_api.py
@@ -6,11 +6,11 @@ CRUD, schedule queries, rosters, head-ref permissions, photos, profile
 updates, search, ...).
 """
 
-from flask import Blueprint, g, request, jsonify, session, redirect, current_app
+from flask import Blueprint, g, request, jsonify, current_app
 from datetime import datetime, timezone
 import collections
 import os
-from flask_login import current_user, login_user, logout_user, login_required
+from flask_login import current_user, login_required
 from sqlalchemy import or_, and_, func
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.attributes import flag_modified
@@ -19,7 +19,6 @@ from app.services.permission_service import PermissionService
 from app.services.tournament_service import TournamentService
 from app.utils.decorators import require_json_body
 from app.utils.helpers import (
-    is_valid_url_username,
     check_tournament_access,
     can_head_ref_match,
     resolve_team_name_to_id,
@@ -86,12 +85,6 @@ import json
 bp = Blueprint("_api", __name__, url_prefix="/_api")
 
 
-@bp.route("/")
-def login_redirect():
-    """Redirect to SPA root (used as login_view when unauthenticated)."""
-    return redirect("/")
-
-
 def _dt_iso(dt) -> str | None:
     """Serialise a datetime-like value to an ISO-8601 string.
 
@@ -138,266 +131,6 @@ def _player_reg_waiver_api(reg, cfg):
         "waiver_signature_valid": signature_valid,
         "waiver_legal_name_signature": legal,
     }
-
-
-def _user_json() -> dict | None:
-    """Serialise the current user to a minimal JSON-safe dictionary.
-
-    Returns:
-        A dict with keys ``id``, ``name``, ``type`` (``"player"`` or
-        ``"team"``), and ``has_password``; or ``None`` when no user is
-        authenticated.
-    """
-    if not current_user.is_authenticated:
-        return None
-    t = current_user_type()
-    has_password = bool(getattr(current_user, "pw_hash", None))
-    return {
-        "id": current_user.id,
-        "name": current_user.name,
-        "type": t,
-        "has_password": has_password,
-    }
-
-
-@bp.route("/me", methods=["GET"])
-def me():
-    """Return current user or 401."""
-    u = _user_json()
-    if u is None:
-        return jsonify({"error": "Not authenticated"}), 401
-    return jsonify(u)
-
-
-@bp.route("/login", methods=["POST"])
-@require_json_body()
-def login():
-    """JSON body: { username, password }. Sets session cookie on success."""
-    data = g.json_body
-    username = data.get("username")
-    password = data.get("password")
-    if not username or not password:
-        return jsonify({"error": "username and password required"}), 400
-    user = Player.query.filter_by(id=username).first()
-    if not user:
-        user = Team.query.filter_by(id=username).first()
-    if not user or not user.check_password(password):
-        return jsonify({"error": "Invalid username or password"}), 401
-    login_user(user)
-    return jsonify(_user_json())
-
-
-@bp.route("/logout", methods=["POST"])
-@login_required
-def logout():
-    """Clear session."""
-    logout_user()
-    return jsonify({"ok": True})
-
-
-@bp.route("/change-password", methods=["POST"])
-@login_required
-@require_json_body()
-def change_password():
-    """JSON body: { current_password, new_password }. Change authenticated user's password."""
-    data = g.json_body
-    current_password = data.get("current_password")
-    new_password = data.get("new_password")
-    if not current_password or not new_password:
-        return jsonify({"error": "current_password and new_password required"}), 400
-    user = current_user
-    if not user.pw_hash:
-        return (
-            jsonify(
-                {
-                    "error": "This account uses Google sign-in. Password cannot be changed here.",
-                }
-            ),
-            400,
-        )
-    if not user.check_password(current_password):
-        return jsonify({"error": "Current password is incorrect"}), 401
-    user.set_password(new_password)
-    db.session.commit()
-    return jsonify({"ok": True})
-
-
-@bp.route("/register", methods=["POST"])
-@require_json_body()
-def register():
-    """JSON body: { username, password, name, user_type?: "player"|"team" }. Creates user and logs in."""
-    data = g.json_body
-    username = data.get("username")
-    password = data.get("password")
-    name = data.get("name")
-    user_type = data.get("user_type", "player")
-    if not username or not password or not name:
-        return jsonify({"error": "username, password, and name required"}), 400
-    if user_type not in ("player", "team"):
-        return jsonify({"error": "user_type must be player or team"}), 400
-    if not is_valid_url_username(username):
-        return (
-            jsonify(
-                {
-                    "error": "Username must be URL-safe: letters, numbers, hyphens, underscores. Cannot start or end with hyphen or underscore.",
-                }
-            ),
-            400,
-        )
-    if Player.query.filter_by(id=username).first() or Team.query.filter_by(id=username).first():
-        return jsonify({"error": "Username already exists"}), 409
-    if user_type == "player":
-        user = Player(id=username, name=name)
-    else:
-        user = Team(id=username, name=name)
-    user.set_password(password)
-    db.session.add(user)
-    db.session.commit()
-    login_user(user)
-    return jsonify(_user_json())
-
-
-@bp.route("/check-username", methods=["GET"])
-def check_username():
-    """Query param: username. Returns { available: bool, message: str }."""
-    username = request.args.get("username", "").strip()
-    if not username:
-        return jsonify({"available": False, "message": "Username is required"})
-    if not is_valid_url_username(username):
-        return jsonify(
-            {
-                "available": False,
-                "message": "Username must be URL-safe: letters, numbers, hyphens, underscores. Cannot start or end with hyphen or underscore.",
-            }
-        )
-    if Player.query.filter_by(id=username).first() or Team.query.filter_by(id=username).first():
-        return jsonify({"available": False, "message": "Username already exists"})
-    return jsonify({"available": True, "message": "Username is available"})
-
-
-@bp.route("/google/choose-account-type", methods=["GET", "POST"])
-def google_choose_account_type_api():
-    """Select account type (player / team) after Google OAuth.
-
-    ``GET  /_api/google/choose-account-type`` — Returns the email stored in the
-    session so the frontend can pre-fill the form.
-
-    ``POST /_api/google/choose-account-type`` — Stores the chosen
-    ``user_type`` in the session and returns ``{"ok": true}``.
-
-    Request JSON (POST):
-        user_type (str): ``"player"`` or ``"team"``.
-
-    Returns:
-        JSON object or error with HTTP 400/401.
-    """
-    oauth_data = session.get("google_oauth_data")
-    if not oauth_data:
-        return jsonify({"error": "Session expired"}), 401
-
-    if request.method == "POST":
-        if not request.is_json:
-            return jsonify({"error": "Content-Type must be application/json"}), 415
-        data = request.get_json()
-        if not data:
-            return jsonify({"error": "Invalid JSON"}), 400
-        user_type = data.get("user_type")
-        if user_type not in ["player", "team"]:
-            return jsonify({"error": "Please select an account type"}), 400
-        oauth_data["user_type"] = user_type
-        session["google_oauth_data"] = oauth_data
-        session.modified = True
-        return jsonify({"ok": True})
-
-    return jsonify({"email": oauth_data.get("email", "")})
-
-
-@bp.route("/google/complete-profile", methods=["GET", "POST"])
-def google_complete_profile_api():
-    """Complete account creation for a new Google OAuth user.
-
-    ``GET  /_api/google/complete-profile`` — Returns the email, account type,
-    and a suggested display name derived from the session-stored OAuth data.
-
-    ``POST /_api/google/complete-profile`` — Validates the chosen username and
-    display name, creates the :class:`~app.models.user.Player` or
-    :class:`~app.models.user.Team` record, clears the OAuth session data, and
-    logs the user in.
-
-    Request JSON (POST):
-        username (str): Desired URL-safe username.
-        display_name (str): Public display name.
-
-    Returns:
-        JSON object with ``ok`` key on success, or error with HTTP 400/401/409.
-    """
-    oauth_data = session.get("google_oauth_data")
-    if not oauth_data:
-        return jsonify({"error": "Session expired"}), 401
-
-    user_type = oauth_data.get("user_type")
-    if not user_type:
-        return jsonify({"error": "Account type not selected"}), 400
-
-    email = oauth_data.get("email", "")
-    suggested_name = oauth_data.get("name", email.split("@")[0] if email else "User")
-
-    if request.method == "POST":
-        if not request.is_json:
-            return jsonify({"error": "Content-Type must be application/json"}), 415
-        data = request.get_json()
-        if not data:
-            return jsonify({"error": "Invalid JSON"}), 400
-        username = (data.get("username") or "").strip()
-        display_name = (data.get("display_name") or "").strip()
-
-        if not username:
-            return jsonify({"error": "Username is required"}), 400
-        if not is_valid_url_username(username):
-            return (
-                jsonify(
-                    {
-                        "error": "Username must be URL-safe: only letters, numbers, hyphens, and underscores. Cannot start or end with hyphen or underscore.",
-                    }
-                ),
-                400,
-            )
-        existing_player = Player.query.filter_by(id=username).first()
-        existing_team = Team.query.filter_by(id=username).first()
-        if existing_player or existing_team:
-            return jsonify({"error": "Username already exists"}), 409
-        if not display_name:
-            return jsonify({"error": "Display name is required"}), 400
-
-        if user_type == "player":
-            user = Player(
-                id=username,
-                name=display_name,
-                google_id=oauth_data["google_id"],
-                email=email,
-                profile_photo=(None if username.lower() not in ("jeb", "jebediah") else "jeb.png"),
-            )
-        else:
-            user = Team(
-                id=username,
-                name=display_name,
-                google_id=oauth_data["google_id"],
-                email=email,
-                profile_photo=(None if username.lower() not in ("jeb", "jebediah") else "jeb.png"),
-            )
-        db.session.add(user)
-        db.session.commit()
-        session.pop("google_oauth_data", None)
-        login_user(user)
-        return jsonify({"ok": True})
-
-    return jsonify(
-        {
-            "email": email,
-            "user_type": user_type,
-            "suggested_name": suggested_name,
-        }
-    )
 
 
 def _tournament_to_dict(t) -> dict:

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -12,9 +12,12 @@ from flask import (
     session,
     current_app,
     url_for,
+    g,
 )
-from flask_login import login_user, logout_user, login_required
-from models import Player, Team
+from flask_login import current_user, login_user, logout_user, login_required
+from models import Player, Team, db
+from app.serializers.user_serializer import user_json
+from app.utils.decorators import require_json_body
 from app.utils.helpers import is_valid_url_username
 from authlib.integrations.flask_client import OAuth
 
@@ -199,3 +202,231 @@ def google_callback():
     except Exception as e:
         flash(f"Error during Google authentication: {str(e)}", "error")
         return _redirect_to_frontend("/")
+
+
+@bp.route("/")
+def login_redirect():
+    """Redirect to SPA root (used as login_view when unauthenticated)."""
+    return redirect("/")
+
+
+@bp.route("/me", methods=["GET"])
+def me():
+    """Return current user or 401."""
+    u = user_json()
+    if u is None:
+        return jsonify({"error": "Not authenticated"}), 401
+    return jsonify(u)
+
+
+@bp.route("/login", methods=["POST"])
+@require_json_body()
+def login():
+    """JSON body: { username, password }. Sets session cookie on success."""
+    data = g.json_body
+    username = data.get("username")
+    password = data.get("password")
+    if not username or not password:
+        return jsonify({"error": "username and password required"}), 400
+    user = Player.query.filter_by(id=username).first()
+    if not user:
+        user = Team.query.filter_by(id=username).first()
+    if not user or not user.check_password(password):
+        return jsonify({"error": "Invalid username or password"}), 401
+    login_user(user)
+    return jsonify(user_json())
+
+
+@bp.route("/logout", methods=["POST"])
+@login_required
+def logout_post():
+    """Clear session (JSON API for the SPA)."""
+    logout_user()
+    return jsonify({"ok": True})
+
+
+@bp.route("/change-password", methods=["POST"])
+@login_required
+@require_json_body()
+def change_password():
+    """JSON body: { current_password, new_password }. Change authenticated user's password."""
+    data = g.json_body
+    current_password = data.get("current_password")
+    new_password = data.get("new_password")
+    if not current_password or not new_password:
+        return jsonify({"error": "current_password and new_password required"}), 400
+    user = current_user
+    if not user.pw_hash:
+        return (
+            jsonify(
+                {
+                    "error": "This account uses Google sign-in. Password cannot be changed here.",
+                }
+            ),
+            400,
+        )
+    if not user.check_password(current_password):
+        return jsonify({"error": "Current password is incorrect"}), 401
+    user.set_password(new_password)
+    db.session.commit()
+    return jsonify({"ok": True})
+
+
+@bp.route("/register", methods=["POST"])
+@require_json_body()
+def register():
+    """JSON body: { username, password, name, user_type?: "player"|"team" }. Creates user and logs in."""
+    data = g.json_body
+    username = data.get("username")
+    password = data.get("password")
+    name = data.get("name")
+    user_type = data.get("user_type", "player")
+    if not username or not password or not name:
+        return jsonify({"error": "username, password, and name required"}), 400
+    if user_type not in ("player", "team"):
+        return jsonify({"error": "user_type must be player or team"}), 400
+    if not is_valid_url_username(username):
+        return (
+            jsonify(
+                {
+                    "error": "Username must be URL-safe: letters, numbers, hyphens, underscores. Cannot start or end with hyphen or underscore.",
+                }
+            ),
+            400,
+        )
+    if Player.query.filter_by(id=username).first() or Team.query.filter_by(id=username).first():
+        return jsonify({"error": "Username already exists"}), 409
+    if user_type == "player":
+        user = Player(id=username, name=name)
+    else:
+        user = Team(id=username, name=name)
+    user.set_password(password)
+    db.session.add(user)
+    db.session.commit()
+    login_user(user)
+    return jsonify(user_json())
+
+
+@bp.route("/google/choose-account-type", methods=["GET", "POST"])
+def google_choose_account_type_api():
+    """Select account type (player / team) after Google OAuth.
+
+    ``GET  /_api/google/choose-account-type`` — Returns the email stored in the
+    session so the frontend can pre-fill the form.
+
+    ``POST /_api/google/choose-account-type`` — Stores the chosen
+    ``user_type`` in the session and returns ``{"ok": true}``.
+
+    Request JSON (POST):
+        user_type (str): ``"player"`` or ``"team"``.
+
+    Returns:
+        JSON object or error with HTTP 400/401.
+    """
+    oauth_data = session.get("google_oauth_data")
+    if not oauth_data:
+        return jsonify({"error": "Session expired"}), 401
+
+    if request.method == "POST":
+        if not request.is_json:
+            return jsonify({"error": "Content-Type must be application/json"}), 415
+        data = request.get_json()
+        if not data:
+            return jsonify({"error": "Invalid JSON"}), 400
+        user_type = data.get("user_type")
+        if user_type not in ["player", "team"]:
+            return jsonify({"error": "Please select an account type"}), 400
+        oauth_data["user_type"] = user_type
+        session["google_oauth_data"] = oauth_data
+        session.modified = True
+        return jsonify({"ok": True})
+
+    return jsonify({"email": oauth_data.get("email", "")})
+
+
+@bp.route("/google/complete-profile", methods=["GET", "POST"])
+def google_complete_profile_api():
+    """Complete account creation for a new Google OAuth user.
+
+    ``GET  /_api/google/complete-profile`` — Returns the email, account type,
+    and a suggested display name derived from the session-stored OAuth data.
+
+    ``POST /_api/google/complete-profile`` — Validates the chosen username and
+    display name, creates the :class:`~app.models.user.Player` or
+    :class:`~app.models.user.Team` record, clears the OAuth session data, and
+    logs the user in.
+
+    Request JSON (POST):
+        username (str): Desired URL-safe username.
+        display_name (str): Public display name.
+
+    Returns:
+        JSON object with ``ok`` key on success, or error with HTTP 400/401/409.
+    """
+    oauth_data = session.get("google_oauth_data")
+    if not oauth_data:
+        return jsonify({"error": "Session expired"}), 401
+
+    user_type = oauth_data.get("user_type")
+    if not user_type:
+        return jsonify({"error": "Account type not selected"}), 400
+
+    email = oauth_data.get("email", "")
+    suggested_name = oauth_data.get("name", email.split("@")[0] if email else "User")
+
+    if request.method == "POST":
+        if not request.is_json:
+            return jsonify({"error": "Content-Type must be application/json"}), 415
+        data = request.get_json()
+        if not data:
+            return jsonify({"error": "Invalid JSON"}), 400
+        username = (data.get("username") or "").strip()
+        display_name = (data.get("display_name") or "").strip()
+
+        if not username:
+            return jsonify({"error": "Username is required"}), 400
+        if not is_valid_url_username(username):
+            return (
+                jsonify(
+                    {
+                        "error": "Username must be URL-safe: only letters, numbers, hyphens, and underscores. Cannot start or end with hyphen or underscore.",
+                    }
+                ),
+                400,
+            )
+        existing_player = Player.query.filter_by(id=username).first()
+        existing_team = Team.query.filter_by(id=username).first()
+        if existing_player or existing_team:
+            return jsonify({"error": "Username already exists"}), 409
+        if not display_name:
+            return jsonify({"error": "Display name is required"}), 400
+
+        if user_type == "player":
+            user = Player(
+                id=username,
+                name=display_name,
+                google_id=oauth_data["google_id"],
+                email=email,
+                profile_photo=(None if username.lower() not in ("jeb", "jebediah") else "jeb.png"),
+            )
+        else:
+            user = Team(
+                id=username,
+                name=display_name,
+                google_id=oauth_data["google_id"],
+                email=email,
+                profile_photo=(None if username.lower() not in ("jeb", "jebediah") else "jeb.png"),
+            )
+        db.session.add(user)
+        db.session.commit()
+        session.pop("google_oauth_data", None)
+        login_user(user)
+        return jsonify({"ok": True})
+
+    return jsonify(
+        {
+            "email": email,
+            "user_type": user_type,
+            "suggested_name": suggested_name,
+        }
+    )

--- a/app/serializers/user_serializer.py
+++ b/app/serializers/user_serializer.py
@@ -12,15 +12,30 @@ endpoints. The dict shape is part of the API contract:
     }
 
 When the current user is not authenticated, returns ``None``.
-
-This module is currently a facade re-exporting the implementation from
-``app.routes._api``. The auth-refactor PR replaces the re-export with
-the real implementation; consumers can import the public name now and
-never have to change once the refactor lands.
 """
 
 from __future__ import annotations
 
-from app.routes._api import _user_json as user_json
+from flask_login import current_user
 
-__all__ = ["user_json"]
+from app.services._common import current_user_type
+
+
+def user_json() -> dict | None:
+    """Serialise the current user to a minimal JSON-safe dictionary.
+
+    Returns:
+        A dict with keys ``id``, ``name``, ``type`` (``"player"`` or
+        ``"team"``), and ``has_password``; or ``None`` when no user is
+        authenticated.
+    """
+    if not current_user.is_authenticated:
+        return None
+    t = current_user_type()
+    has_password = bool(getattr(current_user, "pw_hash", None))
+    return {
+        "id": current_user.id,
+        "name": current_user.name,
+        "type": t,
+        "has_password": has_password,
+    }

--- a/tests/fixtures/url_surface.txt
+++ b/tests/fixtures/url_surface.txt
@@ -28,7 +28,6 @@ GET /_api/auth/google/callback
 GET /_api/auth/google/login
 GET /_api/camera-url
 GET /_api/check-username
-GET /_api/check-username
 GET /_api/leagues
 GET /_api/leagues/<league_url>
 GET /_api/leagues/<league_url>/invitations


### PR DESCRIPTION
## Summary

Pulls the auth and account-lifecycle routes out of the `_api.py` monolith into the existing `auth` blueprint, and gives `user_serializer.py` its real implementation. This is the fourth PR in the `_api.py` refactor stack, landing on top of the penalty-types extraction (#204) that's already on `dev`.

## What changed

Backend:
- Moves seven handlers from `_api.py` into `app/routes/auth.py`: `/login`, `/register`, `/change-password`, `/me`, the `/logout` POST, the two Google OAuth completion endpoints, and the root `login_redirect`. Bodies moved verbatim.
- Points `login_manager.login_view` at the new home (`auth.login_redirect`).
- `app/serializers/user_serializer.py` graduates from a facade re-export into the real `user_json` implementation, now that the auth routes that share it live next door.
- Removes the dead `/check-username` duplicate from `_api.py`. Both `_api.py` and `auth.py` registered the same `(path, methods)` rule; Flask served `auth.py`'s body (last registration wins), so the `_api.py` copy was shipped code that never ran. User-visible behavior is unchanged.
- Narrows `_api.py`'s `flask_login` import to what it still uses (`current_user`, `login_required`) now that `login_user`/`logout_user` left with the auth routes.

Tests:
- Regenerates `tests/fixtures/url_surface.txt`. The only delta versus `dev` is one fewer `GET /_api/check-username` line - the duplicate rule going away. No live URL changes.

## Test plan

- [x] `just unit` passes locally - 232 passed
- [x] `just integration` passes locally - 60 passed
- [x] `tests/test_url_surface.py` passes - surface is identical to `dev` except the dropped `/check-username` duplicate
- [x] `just format` clean on the touched files; `just lint` clean on the touched files

No new tests - the routes moved verbatim, and the existing auth integration tests plus the URL-surface gate cover the behavior.

Note: `just lint` reports one pre-existing F401 in `app/models/validators.py` (`URL_SLUG_LEN` imported but unused). It's already present on `dev` and unrelated to this PR, so I left it alone rather than fold an unrelated fix into a refactor PR.

## Linked issues

Refs #174

## Screenshots / repro

No UI or API-shape change. Same URLs, same methods, same payloads (minus a duplicate registration that never served traffic) - verified by the URL-surface snapshot test.

---

### Pre-review checklist

- [x] Title prefixed with `[Refactor]`.
- [x] Branch name follows `category/name` (`feature/refactor-auth`).
- [x] Targeting `dev`, not `main`.
- [x] `just format` clean; `just lint` clean on touched files (one unrelated pre-existing warning noted above).
- [x] ~~Tests added or updated~~ - verbatim relocation; URL-surface gate + existing auth tests cover it.
- [x] ~~New module README/rst~~ - no new module; `user_serializer.py` already existed as a facade, and no route file carries an `app.routes.*.rst` entry.
- [x] ~~Developer workflow docs~~ - unchanged.
- [x] No merge conflicts with the base branch (rebased onto current `dev`).
