### PR TITLE
[Refactor] Extract registration routes into the registration blueprint

### DIFF
--- a/app/routes/_api.py
+++ b/app/routes/_api.py
@@ -43,6 +43,7 @@ from app.services.dual_write import (
     set_match_referees_from_csv,
 )
 from app.serializers.match_note_serializer import MatchNoteSerializer
+from app.serializers.registration_serializer import player_reg_waiver_api, serialize_manage
 from app.routes.tournaments import update_match_previous_link
 from app.utils.scheduling import (
     recompute_all_match_times,
@@ -99,37 +100,6 @@ def _dt_iso(dt) -> str | None:
     if hasattr(dt, "isoformat"):
         return dt.isoformat()
     return str(dt)
-
-
-def _player_reg_waiver_api(reg, cfg):
-    """Waiver fields for API given a PlayerRegistration and RegistrableConfig (or None)."""
-    waiver_required = bool(getattr(cfg, "waiver_filepath", None)) if cfg else False
-    fp = getattr(cfg, "waiver_filepath", None) if cfg else None
-    sha = getattr(cfg, "waiver_sha256", None) if cfg else None
-    stored = getattr(reg, "waiver_legal_name_signature_sha256", None) if reg else None
-    legal = getattr(reg, "waiver_legal_name_signature", None) if reg else None
-
-    if not waiver_required:
-        waiver_status = None
-        signature_valid = True
-    elif not stored:
-        waiver_status = "NOT_SIGNED"
-        signature_valid = False
-    elif sha is not None and stored == sha:
-        waiver_status = "VALID"
-        signature_valid = True
-    else:
-        waiver_status = "OUT_OF_DATE"
-        signature_valid = False
-
-    return {
-        "waiver_required": waiver_required,
-        "waiver_filepath": fp,
-        "waiver_sha256": sha,
-        "waiver_status": waiver_status,
-        "waiver_signature_valid": signature_valid,
-        "waiver_legal_name_signature": legal,
-    }
 
 
 def _tournament_to_dict(t) -> dict:
@@ -314,7 +284,7 @@ def leagues_list():
                 reg = PlayerRegistration.query.filter_by(league_id=l.url, player=current_user.id).first()
                 if reg:
                     rc = l.registrable_config
-                    w = _player_reg_waiver_api(reg, rc)
+                    w = player_reg_waiver_api(reg, rc)
                     user_reg_status[l.url] = {
                         "type": "player",
                         "status": (reg.status.value if hasattr(reg.status, "value") else str(reg.status or "")),
@@ -579,7 +549,6 @@ def league_results_team_matches(league_url, team_id):
     return jsonify({"matches": match_list})
 
 
-@bp.route("/leagues/<league_url>/register-team", methods=["POST"])
 @login_required
 def league_register_team(league_url):
     """Register a team for a league.
@@ -610,7 +579,6 @@ def league_register_team(league_url):
     )
 
 
-@bp.route("/leagues/<league_url>/register-player", methods=["POST"])
 @login_required
 def league_register_player(league_url):
     """Register a player for a league."""
@@ -643,7 +611,6 @@ def league_register_player(league_url):
     )
 
 
-@bp.route("/leagues/<league_url>/deregister-team", methods=["POST"])
 @login_required
 def league_deregister_team(league_url):
     """Deregister a team from a league."""
@@ -871,7 +838,6 @@ def delete_league(league_url):
     )
 
 
-@bp.route("/leagues/<league_url>/deregister-player", methods=["POST"])
 @login_required
 def league_deregister_player(league_url):
     """Deregister a player from a league."""
@@ -891,7 +857,6 @@ def league_deregister_player(league_url):
     )
 
 
-@bp.route("/leagues/<league_url>/registrations/player/me", methods=["GET"])
 @login_required
 def get_my_player_registration_league(league_url):
     """Get current player's registration for this league."""
@@ -929,7 +894,7 @@ def get_my_player_registration_league(league_url):
             }
 
     rc = league.registrable_config
-    w = _player_reg_waiver_api(reg, rc)
+    w = player_reg_waiver_api(reg, rc)
     return jsonify(
         {
             "registration": {
@@ -949,7 +914,6 @@ def get_my_player_registration_league(league_url):
     )
 
 
-@bp.route("/leagues/<league_url>/registrations/player/me", methods=["PUT"])
 @login_required
 def update_my_player_registration_league(league_url):
     """Update current player's registration for this league."""
@@ -1009,7 +973,6 @@ def update_my_player_registration_league(league_url):
     return jsonify({"success": True})
 
 
-@bp.route("/leagues/<league_url>/registrations/team/me", methods=["GET"])
 @login_required
 def get_my_team_registration_league(league_url):
     """Get current team's registration for this league."""
@@ -1045,7 +1008,6 @@ def get_my_team_registration_league(league_url):
     )
 
 
-@bp.route("/leagues/<league_url>/registrations/team/me", methods=["PUT"])
 @login_required
 def update_my_team_registration_league(league_url):
     """Update current team's registration for this league."""
@@ -1096,165 +1058,6 @@ def update_my_team_registration_league(league_url):
     return jsonify({"success": True})
 
 
-def _serialize_manage(scope, search_query: str, search_type: str, cfg) -> dict:
-    """Build the manage-API payload for *scope*.
-
-    Handles search filtering, registration loading, and the team/player
-    summary construction shared between tournament_manage_api and
-    league_manage_api.
-
-    Args:
-        scope: :class:`~app.services._common.Scope` identifying event vs league.
-        search_query: Search string from request query args.
-        search_type: ``"team"`` / ``"player"`` / ``"both"``.
-        cfg: registrable_config object (shared between scopes).
-
-    Returns:
-        The manage payload dict ready to be jsonified.
-    """
-    from app.services.registration_resolver import (
-        team_registrations_for_scope,
-        player_registrations_for_scope,
-    )
-
-    team_registrations = team_registrations_for_scope(scope, exclude_cancelled=True)
-    teams_with_registrations = []
-    for team_reg in team_registrations:
-        team = Team.query.get(team_reg.team)
-        if team:
-            teams_with_registrations.append({"registration": team_reg, "team": team})
-
-    player_registrations = player_registrations_for_scope(
-        scope,
-        statuses=[
-            RegistrationStatus.PENDING_TEAM_APPROVAL,
-            RegistrationStatus.CONFIRMED,
-            RegistrationStatus.REJECTED,
-        ],
-    )
-    players_with_registrations = []
-    for player_reg in player_registrations:
-        player = Player.query.get(player_reg.player)
-        team = Team.query.get(player_reg.team) if player_reg.team else None
-        if player:
-            players_with_registrations.append({"registration": player_reg, "player": player, "team": team})
-
-    if search_query:
-        q = search_query.lower()
-        if search_type in ("both", "teams"):
-            teams_with_registrations = [
-                t
-                for t in teams_with_registrations
-                if (
-                    (t["team"].name or "").lower().find(q) != -1
-                    or (t["registration"].pseudonym or "").lower().find(q) != -1
-                )
-            ]
-        else:
-            teams_with_registrations = []
-
-        if search_type in ("both", "players"):
-            players_with_registrations = [
-                p
-                for p in players_with_registrations
-                if (
-                    (p["player"].name or "").lower().find(q) != -1
-                    or (p["registration"].jersey_name or "").lower().find(q) != -1
-                )
-            ]
-        else:
-            players_with_registrations = []
-
-    if scope.is_league:
-        league = League.query.get(scope.league_url)
-        wf = getattr(cfg, "waiver_filepath", None) if cfg else None
-        tournament_dict = {
-            "url": league.url,
-            "name": league.name,
-            "start_date": "",
-            "end_date": None,
-            "location": None,
-            "published": league.published,
-            "league": {"league_url": league.url, "name": league.name},
-            "waiver_required": bool(wf),
-            "waiver_filepath": wf,
-            "waiver_sha256": getattr(cfg, "waiver_sha256", None) if cfg else None,
-        }
-    else:
-        tournament = Tournament.query.filter_by(url=scope.event_url).first()
-        tournament_dict = _tournament_to_dict(tournament)
-
-    player_rows = []
-    for pr in players_with_registrations:
-        w = _player_reg_waiver_api(pr["registration"], cfg)
-        player_rows.append(
-            {
-                "registration": {
-                    "id": pr["registration"].id,
-                    "player": pr["registration"].player,
-                    "team": pr["registration"].team,
-                    "jersey_name": pr["registration"].jersey_name,
-                    "jersey_number": pr["registration"].jersey_number,
-                    "status": (
-                        pr["registration"].status.value
-                        if hasattr(pr["registration"].status, "value")
-                        else str(pr["registration"].status)
-                    ),
-                    "paid": bool(pr["registration"].paid),
-                    "amount_paid": pr["registration"].amount_paid or 0.0,
-                    "registered_at": _dt_iso(pr["registration"].registered_at),
-                    "paid_at": _dt_iso(pr["registration"].paid_at),
-                    "waiver_required": w["waiver_required"],
-                    "waiver_status": w["waiver_status"],
-                    "waiver_legal_name_signature": w["waiver_legal_name_signature"],
-                },
-                "player": {
-                    "id": pr["player"].id,
-                    "name": pr["player"].name,
-                },
-                "team": (
-                    {
-                        "id": pr["team"].id,
-                        "name": pr["team"].name,
-                    }
-                    if pr["team"]
-                    else None
-                ),
-            }
-        )
-
-    return {
-        "tournament": tournament_dict,
-        "search_query": search_query,
-        "search_type": search_type,
-        "team_registrations": [
-            {
-                "registration": {
-                    "id": tr["registration"].id,
-                    "team": tr["registration"].team,
-                    "pseudonym": tr["registration"].pseudonym,
-                    "shortname": tr["registration"].shortname,
-                    "status": (
-                        tr["registration"].status.value
-                        if hasattr(tr["registration"].status, "value")
-                        else str(tr["registration"].status)
-                    ),
-                    "paid": bool(tr["registration"].paid),
-                    "amount_paid": tr["registration"].amount_paid or 0.0,
-                    "registered_at": _dt_iso(tr["registration"].registered_at),
-                    "paid_at": _dt_iso(tr["registration"].paid_at),
-                },
-                "team": {
-                    "id": tr["team"].id,
-                    "name": tr["team"].name,
-                },
-            }
-            for tr in teams_with_registrations
-        ],
-        "player_registrations": player_rows,
-    }
-
-
 @bp.route("/leagues/<league_url>/manage", methods=["GET"])
 @login_required
 def league_manage_api(league_url):
@@ -1267,7 +1070,7 @@ def league_manage_api(league_url):
 
     search_query = (request.args.get("search") or "").strip()
     search_type = (request.args.get("type") or "both").lower()
-    return jsonify(_serialize_manage(Scope.league(league_url), search_query, search_type, league.registrable_config))
+    return jsonify(serialize_manage(Scope.league(league_url), search_query, search_type, league.registrable_config))
 
 
 @bp.route("/leagues/<league_url>/invitations", methods=["GET"])
@@ -1371,7 +1174,6 @@ def league_invitations_api(league_url):
     )
 
 
-@bp.route("/leagues/<league_url>/mark-team-paid", methods=["POST"])
 @login_required
 def league_mark_team_paid(league_url):
     """Mark team payment status (league TO only)."""
@@ -1407,7 +1209,6 @@ def league_mark_team_paid(league_url):
     return jsonify({"success": True, "message": "Team payment updated"}), 200
 
 
-@bp.route("/leagues/<league_url>/mark-player-paid", methods=["POST"])
 @login_required
 def league_mark_player_paid(league_url):
     """Mark player payment status (league TO only)."""
@@ -1443,7 +1244,6 @@ def league_mark_player_paid(league_url):
     return jsonify({"success": True, "message": "Player payment updated"}), 200
 
 
-@bp.route("/leagues/<league_url>/deregister-any-team", methods=["POST"])
 @login_required
 def league_deregister_any_team(league_url):
     """Deregister any team (league TO only)."""
@@ -1485,7 +1285,6 @@ def league_deregister_any_team(league_url):
     )
 
 
-@bp.route("/leagues/<league_url>/deregister-any-player", methods=["POST"])
 @login_required
 def league_deregister_any_player(league_url):
     """Deregister any player (league TO only)."""
@@ -1526,7 +1325,6 @@ def league_deregister_any_player(league_url):
     )
 
 
-@bp.route("/leagues/<league_url>/invitation/<int:invitation_id>/accept", methods=["POST"])
 @login_required
 def league_accept_invitation(league_url, invitation_id):
     """Accept a pending player registration (league roster)."""
@@ -1551,7 +1349,6 @@ def league_accept_invitation(league_url, invitation_id):
     )
 
 
-@bp.route("/leagues/<league_url>/invitation/<int:invitation_id>/decline", methods=["POST"])
 @login_required
 def league_decline_invitation(league_url, invitation_id):
     """Decline a pending player registration (league roster)."""
@@ -1729,7 +1526,7 @@ def tournament_manage_api(tournament_url):
     search_query = (request.args.get("search") or "").strip()
     search_type = (request.args.get("type") or "both").lower()
     cfg = get_registrable_config(tournament)
-    return jsonify(_serialize_manage(Scope.event(tournament_url), search_query, search_type, cfg))
+    return jsonify(serialize_manage(Scope.event(tournament_url), search_query, search_type, cfg))
 
 
 @bp.route("/tournaments/<tournament_url>/invitations", methods=["GET"])
@@ -4147,7 +3944,6 @@ def list_tags(tournament_url):
     return jsonify({"tags": [{"id": t.id, "name": t.name, "team": t.team} for t in tags]})
 
 
-@bp.route("/tournaments/<tournament_url>/registrations/player/me", methods=["GET"])
 @login_required
 def get_my_player_registration(tournament_url):
     """Get current player's registration for this tournament."""
@@ -4177,7 +3973,7 @@ def get_my_player_registration(tournament_url):
             }
 
     cfg = get_registrable_config(tournament)
-    w = _player_reg_waiver_api(reg, cfg)
+    w = player_reg_waiver_api(reg, cfg)
     return jsonify(
         {
             "registration": {
@@ -4197,7 +3993,6 @@ def get_my_player_registration(tournament_url):
     )
 
 
-@bp.route("/tournaments/<tournament_url>/registrations/player/me", methods=["PUT"])
 @login_required
 def update_my_player_registration(tournament_url):
     """Update current player's registration."""
@@ -4251,7 +4046,6 @@ def update_my_player_registration(tournament_url):
     return jsonify({"success": True})
 
 
-@bp.route("/tournaments/<tournament_url>/registrations/team/me", methods=["GET"])
 @login_required
 def get_my_team_registration(tournament_url):
     """Get current team's registration for this tournament."""
@@ -4278,7 +4072,6 @@ def get_my_team_registration(tournament_url):
     )
 
 
-@bp.route("/tournaments/<tournament_url>/registrations/team/me", methods=["PUT"])
 @login_required
 def update_my_team_registration(tournament_url):
     """Update current team's registration."""

--- a/app/routes/registration.py
+++ b/app/routes/registration.py
@@ -21,8 +21,13 @@ from models import (
 )
 from app.domain.enums import RegistrationStatus
 from app.services._common import current_user_type, Scope
+from app.services.permission_service import PermissionService
 from app.services.registration_service import RegistrationService
+from app.serializers.league_serializer import require_league
+from app.serializers.registration_serializer import player_reg_waiver_api
 from app.utils.decorators import require_json_body, require_tournament_organizer
+from app.utils.helpers import get_registrable_config
+from app.utils.name_validation import team_pseudonym_char_error
 from app.utils.user_helpers import is_player, is_team
 from app.utils.result_helpers import json_from_result
 from app.utils.datetime_helpers import now_utc_naive
@@ -577,3 +582,689 @@ def register_team_as_to(tournament_url: str):
         }
 
     return json_from_result(res, ok_to_payload=_checkin_team_payload)
+
+
+@bp.route("/leagues/<league_url>/register-team", methods=["POST"])
+@login_required
+def league_register_team(league_url):
+    """Register a team for a league.
+
+    Form Data:
+        pseudonym (str): Team display name for this league.
+        shortname (str, optional): Short alias (<= 12 chars) used in
+            space-constrained UI. Blank/missing stores ``NULL``.
+    """
+    from app.services.registration_service import RegistrationService
+    from app.utils.result_helpers import json_from_result
+
+    if not is_team(current_user):
+        return jsonify({"success": False, "error": "Only teams can register"}), 403
+    league, err = require_league(league_url)
+    if err:
+        return jsonify({"error": "Not found" if err == 404 else "Forbidden"}), err
+    res = RegistrationService.register_team(
+        Scope.league(league.url),
+        current_user.id,
+        request.form.get("pseudonym", ""),
+        shortname=request.form.get("shortname", "") or None,
+    )
+    return json_from_result(
+        res,
+        ok_to_payload=lambda _: {"message": "Team registration successful!"},
+        err_status_code=400,
+    )
+
+
+@bp.route("/leagues/<league_url>/register-player", methods=["POST"])
+@login_required
+def league_register_player(league_url):
+    """Register a player for a league."""
+    from app.services.registration_service import RegistrationService
+    from app.utils.result_helpers import json_from_result
+
+    if not is_player(current_user):
+        return jsonify({"success": False, "error": "Only players can register"}), 403
+    league, err = require_league(league_url)
+    if err:
+        return jsonify({"error": "Not found" if err == 404 else "Forbidden"}), err
+    team_id = request.form.get("team", "") or None
+    msg = (
+        "Registration submitted! The team will need to approve your request."
+        if team_id
+        else "Player registration successful!"
+    )
+    res = RegistrationService.register_player(
+        Scope.league(league.url),
+        current_user.id,
+        team_id,
+        jersey_number=request.form.get("jersey_number", ""),
+        jersey_name=request.form.get("jersey_name", ""),
+        waiver_legal_name_signature=request.form.get("waiver_legal_name_signature", ""),
+    )
+    return json_from_result(
+        res,
+        ok_to_payload=lambda _: {"message": msg},
+        err_status_code=400,
+    )
+
+
+@bp.route("/leagues/<league_url>/deregister-team", methods=["POST"])
+@login_required
+def league_deregister_team(league_url):
+    """Deregister a team from a league."""
+    from app.services.registration_service import RegistrationService
+    from app.utils.result_helpers import json_from_result
+
+    if not is_team(current_user):
+        return jsonify({"success": False, "error": "Only teams can deregister"}), 403
+    league, err = require_league(league_url)
+    if err:
+        return jsonify({"error": "Not found" if err == 404 else "Forbidden"}), err
+    res = RegistrationService.deregister_team(Scope.league(league.url), current_user.id)
+    return json_from_result(
+        res,
+        ok_to_payload=lambda _: {"message": "Team deregistered"},
+        err_status_code=400,
+    )
+
+
+@bp.route("/leagues/<league_url>/deregister-player", methods=["POST"])
+@login_required
+def league_deregister_player(league_url):
+    """Deregister a player from a league."""
+    from app.services.registration_service import RegistrationService
+    from app.utils.result_helpers import json_from_result
+
+    if not is_player(current_user):
+        return jsonify({"success": False, "error": "Only players can deregister"}), 403
+    league, err = require_league(league_url)
+    if err:
+        return jsonify({"error": "Not found" if err == 404 else "Forbidden"}), err
+    res = RegistrationService.deregister_player(Scope.league(league.url), current_user.id)
+    return json_from_result(
+        res,
+        ok_to_payload=lambda _: {"message": "Player deregistered"},
+        err_status_code=400,
+    )
+
+
+@bp.route("/leagues/<league_url>/registrations/player/me", methods=["GET"])
+@login_required
+def get_my_player_registration_league(league_url):
+    """Get current player's registration for this league."""
+    if not is_player(current_user):
+        return jsonify({"error": "Only players have player registrations"}), 400
+
+    from app.services.registration_resolver import (
+        player_registration_for_tournament,
+        team_registration_for_tournament,
+    )
+
+    league, err = require_league(league_url)
+    if err:
+        return jsonify({"error": "Not found" if err == 404 else "Forbidden"}), err
+
+    class LeagueContext:
+        def __init__(self, league):
+            self.league_id = league.url
+            self.url = None
+
+    ctx = LeagueContext(league)
+    reg = player_registration_for_tournament(ctx, current_user.id)
+
+    if not reg:
+        return jsonify({"error": "Not registered"}), 404
+
+    current_team = None
+    if reg.team:
+        team_reg = team_registration_for_tournament(ctx, reg.team)
+        if team_reg:
+            current_team = {
+                "id": reg.team,
+                "pseudonym": team_reg.pseudonym,
+                "shortname": team_reg.shortname,
+            }
+
+    rc = league.registrable_config
+    w = player_reg_waiver_api(reg, rc)
+    return jsonify(
+        {
+            "registration": {
+                "id": reg.id,
+                "jersey_name": reg.jersey_name,
+                "jersey_number": reg.jersey_number,
+                "team": reg.team,
+                "status": (reg.status.value if hasattr(reg.status, "value") else str(reg.status)),
+            },
+            "current_team": current_team,
+            "waiver_required": w["waiver_required"],
+            "waiver_filepath": w["waiver_filepath"],
+            "waiver_sha256": w["waiver_sha256"],
+            "waiver_signature_valid": w["waiver_signature_valid"],
+            "waiver_legal_name_signature": w["waiver_legal_name_signature"],
+        }
+    )
+
+
+@bp.route("/leagues/<league_url>/registrations/player/me", methods=["PUT"])
+@login_required
+def update_my_player_registration_league(league_url):
+    """Update current player's registration for this league."""
+    from app.services.registration_resolver import player_registration_for_tournament
+
+    if not is_player(current_user):
+        return jsonify({"error": "Only players can edit their registration"}), 400
+
+    league, err = require_league(league_url)
+    if err:
+        return jsonify({"error": "Not found" if err == 404 else "Forbidden"}), err
+
+    if not league.registrable_config or not league.registrable_config.player_registration_open:
+        return jsonify({"error": "Registration changes are locked"}), 403
+
+    class LeagueContext:
+        def __init__(self, league):
+            self.league_id = league.url
+            self.url = None
+
+    ctx = LeagueContext(league)
+    reg = player_registration_for_tournament(ctx, current_user.id)
+
+    if not reg:
+        return jsonify({"error": "Not registered"}), 404
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid JSON"}), 400
+
+    if "jersey_name" in data:
+        reg.jersey_name = data["jersey_name"]
+    if "jersey_number" in data:
+        reg.jersey_number = data["jersey_number"]
+
+    if "team" in data:
+        new_team_id = data["team"] or None
+        if reg.team != new_team_id:
+            reg.team = new_team_id
+            if new_team_id:
+                reg.status = RegistrationStatus.PENDING_TEAM_APPROVAL
+            else:
+                reg.status = RegistrationStatus.CONFIRMED
+
+    if "waiver_legal_name_signature" in data and data["waiver_legal_name_signature"]:
+        rc = league.registrable_config
+        sig = (data.get("waiver_legal_name_signature") or "").strip()
+        if rc and getattr(rc, "waiver_filepath", None) and sig:
+            sha_cur = getattr(rc, "waiver_sha256", None)
+            if sha_cur:
+                now = now_utc_naive()
+                reg.waiver_legal_name_signature = sig
+                reg.waiver_legal_name_signature_sha256 = sha_cur
+                reg.waiver_signature_submitted_at = now
+
+    db.session.commit()
+    return jsonify({"success": True})
+
+
+@bp.route("/leagues/<league_url>/registrations/team/me", methods=["GET"])
+@login_required
+def get_my_team_registration_league(league_url):
+    """Get current team's registration for this league."""
+    from app.services.registration_resolver import team_registration_for_tournament
+
+    if not is_team(current_user):
+        return jsonify({"error": "Only teams have team registrations"}), 400
+
+    league, err = require_league(league_url)
+    if err:
+        return jsonify({"error": "Not found" if err == 404 else "Forbidden"}), err
+
+    class LeagueContext:
+        def __init__(self, league):
+            self.league_id = league.url
+            self.url = None
+
+    ctx = LeagueContext(league)
+    reg = team_registration_for_tournament(ctx, current_user.id)
+
+    if not reg:
+        return jsonify({"error": "Not registered"}), 404
+
+    return jsonify(
+        {
+            "registration": {
+                "id": reg.id,
+                "pseudonym": reg.pseudonym,
+                "shortname": reg.shortname,
+                "status": (reg.status.value if hasattr(reg.status, "value") else str(reg.status)),
+            }
+        }
+    )
+
+
+@bp.route("/leagues/<league_url>/registrations/team/me", methods=["PUT"])
+@login_required
+def update_my_team_registration_league(league_url):
+    """Update current team's registration for this league."""
+    from app.services.registration_resolver import team_registration_for_tournament
+
+    if not is_team(current_user):
+        return jsonify({"error": "Only teams can edit their registration"}), 400
+
+    league, err = require_league(league_url)
+    if err:
+        return jsonify({"error": "Not found" if err == 404 else "Forbidden"}), err
+
+    if not league.registrable_config or not league.registrable_config.team_registration_open:
+        return jsonify({"error": "Registration changes are locked"}), 403
+
+    class LeagueContext:
+        def __init__(self, league):
+            self.league_id = league.url
+            self.url = None
+
+    ctx = LeagueContext(league)
+    reg = team_registration_for_tournament(ctx, current_user.id)
+
+    if not reg:
+        return jsonify({"error": "Not registered"}), 404
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid JSON"}), 400
+
+    if "pseudonym" in data:
+        pseudonym = data["pseudonym"].strip()
+        pn_err = team_pseudonym_char_error(pseudonym)
+        if pn_err:
+            return jsonify({"error": pn_err}), 400
+        if not pseudonym:
+            return jsonify({"error": "Team name is required"}), 400
+        reg.pseudonym = pseudonym
+
+    if "shortname" in data:
+        raw = data.get("shortname")
+        if raw is None or (isinstance(raw, str) and not raw.strip()):
+            reg.shortname = None
+        else:
+            reg.shortname = raw.strip()
+
+    db.session.commit()
+    return jsonify({"success": True})
+
+
+@bp.route("/leagues/<league_url>/mark-team-paid", methods=["POST"])
+@login_required
+def league_mark_team_paid(league_url):
+    """Mark team payment status (league TO only)."""
+    league, err = require_league(league_url)
+    if err:
+        return jsonify({"error": "Not found" if err == 404 else "Forbidden"}), err
+    if not PermissionService.is_league_organizer(league_url, current_user):
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Only league organizers can perform this action",
+                }
+            ),
+            403,
+        )
+
+    reg_id = request.form.get("registration_id")
+    paid = request.form.get("paid") == "on"
+    amount_paid = float(request.form.get("amount_paid") or 0)
+    payment_method = request.form.get("payment_method", "")
+    payment_reference = request.form.get("payment_reference", "")
+    payment_notes = request.form.get("payment_notes", "")
+
+    reg = TeamRegistration.query.filter_by(id=reg_id, league_id=league_url).first_or_404()
+    reg.paid = paid
+    reg.amount_paid = amount_paid
+    reg.payment_method = payment_method
+    reg.payment_reference = payment_reference
+    reg.payment_notes = payment_notes
+    reg.paid_at = now_utc_naive() if paid else None
+    db.session.commit()
+    return jsonify({"success": True, "message": "Team payment updated"}), 200
+
+
+@bp.route("/leagues/<league_url>/mark-player-paid", methods=["POST"])
+@login_required
+def league_mark_player_paid(league_url):
+    """Mark player payment status (league TO only)."""
+    league, err = require_league(league_url)
+    if err:
+        return jsonify({"error": "Not found" if err == 404 else "Forbidden"}), err
+    if not PermissionService.is_league_organizer(league_url, current_user):
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Only league organizers can perform this action",
+                }
+            ),
+            403,
+        )
+
+    reg_id = request.form.get("registration_id")
+    paid = request.form.get("paid") == "on"
+    amount_paid = float(request.form.get("amount_paid") or 0)
+    payment_method = request.form.get("payment_method", "")
+    payment_reference = request.form.get("payment_reference", "")
+    payment_notes = request.form.get("payment_notes", "")
+
+    reg = PlayerRegistration.query.filter_by(id=reg_id, league_id=league_url).first_or_404()
+    reg.paid = paid
+    reg.amount_paid = amount_paid
+    reg.payment_method = payment_method
+    reg.payment_reference = payment_reference
+    reg.payment_notes = payment_notes
+    reg.paid_at = now_utc_naive() if paid else None
+    db.session.commit()
+    return jsonify({"success": True, "message": "Player payment updated"}), 200
+
+
+@bp.route("/leagues/<league_url>/deregister-any-team", methods=["POST"])
+@login_required
+def league_deregister_any_team(league_url):
+    """Deregister any team (league TO only)."""
+    league, err = require_league(league_url)
+    if err:
+        return jsonify({"error": "Not found" if err == 404 else "Forbidden"}), err
+    if not PermissionService.is_league_organizer(league_url, current_user):
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Only league organizers can perform this action",
+                }
+            ),
+            403,
+        )
+
+    team_id = request.form.get("team_id")
+    if not team_id:
+        return jsonify({"success": False, "error": "Team ID is required"}), 400
+
+    team_registration = TeamRegistration.query.filter_by(
+        league_id=league_url, team=team_id, status=RegistrationStatus.CONFIRMED
+    ).first()
+
+    if team_registration:
+        team_registration.status = RegistrationStatus.CANCELLED
+        PlayerRegistration.query.filter_by(league_id=league_url, team=team_id).update(
+            {"status": RegistrationStatus.CANCELLED}
+        )
+        db.session.commit()
+        return (
+            jsonify({"success": True, "message": "Team successfully deregistered"}),
+            200,
+        )
+    return (
+        jsonify({"success": False, "error": "Team not found or already deregistered"}),
+        404,
+    )
+
+
+@bp.route("/leagues/<league_url>/deregister-any-player", methods=["POST"])
+@login_required
+def league_deregister_any_player(league_url):
+    """Deregister any player (league TO only)."""
+    league, err = require_league(league_url)
+    if err:
+        return jsonify({"error": "Not found" if err == 404 else "Forbidden"}), err
+    if not PermissionService.is_league_organizer(league_url, current_user):
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Only league organizers can perform this action",
+                }
+            ),
+            403,
+        )
+
+    player_id = request.form.get("player_id")
+    if not player_id:
+        return jsonify({"success": False, "error": "Player ID is required"}), 400
+
+    player_registration = (
+        PlayerRegistration.query.filter_by(league_id=league_url, player=player_id)
+        .filter(PlayerRegistration.status.in_([RegistrationStatus.PENDING_TEAM_APPROVAL, RegistrationStatus.CONFIRMED]))
+        .first()
+    )
+
+    if player_registration:
+        player_registration.status = RegistrationStatus.CANCELLED
+        db.session.commit()
+        return (
+            jsonify({"success": True, "message": "Player successfully deregistered"}),
+            200,
+        )
+    return (
+        jsonify({"success": False, "error": "Player not found or already deregistered"}),
+        404,
+    )
+
+
+@bp.route("/leagues/<league_url>/invitation/<int:invitation_id>/accept", methods=["POST"])
+@login_required
+def league_accept_invitation(league_url, invitation_id):
+    """Accept a pending player registration (league roster)."""
+    if not is_team(current_user):
+        return (
+            jsonify({"success": False, "error": "Only teams can accept invitations"}),
+            403,
+        )
+
+    player_registration = PlayerRegistration.query.filter_by(
+        id=invitation_id,
+        league_id=league_url,
+        team=current_user.id,
+        status=RegistrationStatus.PENDING_TEAM_APPROVAL,
+    ).first_or_404()
+
+    player_registration.status = RegistrationStatus.CONFIRMED
+    db.session.commit()
+    return (
+        jsonify({"success": True, "message": "Player approved! They are now on your team."}),
+        200,
+    )
+
+
+@bp.route("/leagues/<league_url>/invitation/<int:invitation_id>/decline", methods=["POST"])
+@login_required
+def league_decline_invitation(league_url, invitation_id):
+    """Decline a pending player registration (league roster)."""
+    if not is_team(current_user):
+        return (
+            jsonify({"success": False, "error": "Only teams can decline invitations"}),
+            403,
+        )
+
+    player_registration = PlayerRegistration.query.filter_by(
+        id=invitation_id,
+        league_id=league_url,
+        team=current_user.id,
+        status=RegistrationStatus.PENDING_TEAM_APPROVAL,
+    ).first_or_404()
+
+    player_registration.status = RegistrationStatus.REJECTED
+    db.session.commit()
+    return jsonify({"success": True, "message": "Player request declined"}), 200
+
+
+@bp.route("/tournaments/<tournament_url>/registrations/player/me", methods=["GET"])
+@login_required
+def get_my_player_registration(tournament_url):
+    """Get current player's registration for this tournament."""
+    if not is_player(current_user):
+        return jsonify({"error": "Only players have player registrations"}), 400
+
+    from app.services.registration_resolver import (
+        player_registration_for_tournament,
+        team_registration_for_tournament,
+    )
+
+    tournament = Tournament.query.filter_by(url=tournament_url).first_or_404()
+    reg = player_registration_for_tournament(tournament, current_user.id)
+
+    if not reg:
+        return jsonify({"error": "Not registered"}), 404
+
+    # Get current team info if any
+    current_team = None
+    if reg.team:
+        team_reg = team_registration_for_tournament(tournament, reg.team)
+        if team_reg:
+            current_team = {
+                "id": reg.team,
+                "pseudonym": team_reg.pseudonym,
+                "shortname": team_reg.shortname,
+            }
+
+    cfg = get_registrable_config(tournament)
+    w = player_reg_waiver_api(reg, cfg)
+    return jsonify(
+        {
+            "registration": {
+                "id": reg.id,
+                "jersey_name": reg.jersey_name,
+                "jersey_number": reg.jersey_number,
+                "team": reg.team,
+                "status": (reg.status.value if hasattr(reg.status, "value") else str(reg.status)),
+            },
+            "current_team": current_team,
+            "waiver_required": w["waiver_required"],
+            "waiver_filepath": w["waiver_filepath"],
+            "waiver_sha256": w["waiver_sha256"],
+            "waiver_signature_valid": w["waiver_signature_valid"],
+            "waiver_legal_name_signature": w["waiver_legal_name_signature"],
+        }
+    )
+
+
+@bp.route("/tournaments/<tournament_url>/registrations/player/me", methods=["PUT"])
+@login_required
+def update_my_player_registration(tournament_url):
+    """Update current player's registration."""
+    from app.services.registration_resolver import player_registration_for_tournament
+
+    if not is_player(current_user):
+        return jsonify({"error": "Only players can edit their registration"}), 400
+
+    tournament = Tournament.query.filter_by(url=tournament_url).first_or_404()
+    cfg = get_registrable_config(tournament)
+    reg_open = bool(cfg.player_registration_open) if cfg else False
+    if not reg_open:
+        return jsonify({"error": "Registration changes are locked"}), 403
+
+    reg = player_registration_for_tournament(tournament, current_user.id)
+
+    if not reg:
+        return jsonify({"error": "Not registered"}), 404
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid JSON"}), 400
+
+    if "jersey_name" in data:
+        reg.jersey_name = data["jersey_name"]
+    if "jersey_number" in data:
+        reg.jersey_number = data["jersey_number"]
+
+    # Team change logic
+    if "team" in data:
+        new_team_id = data["team"] or None
+        if reg.team != new_team_id:
+            reg.team = new_team_id
+            if new_team_id:
+                reg.status = RegistrationStatus.PENDING_TEAM_APPROVAL
+            else:
+                reg.status = RegistrationStatus.CONFIRMED
+
+    if "waiver_legal_name_signature" in data and data["waiver_legal_name_signature"]:
+        cfg = get_registrable_config(tournament)
+        sig = (data.get("waiver_legal_name_signature") or "").strip()
+        if cfg and getattr(cfg, "waiver_filepath", None) and sig:
+            sha_cur = getattr(cfg, "waiver_sha256", None)
+            if sha_cur:
+                now = now_utc_naive()
+                reg.waiver_legal_name_signature = sig
+                reg.waiver_legal_name_signature_sha256 = sha_cur
+                reg.waiver_signature_submitted_at = now
+
+    db.session.commit()
+    return jsonify({"success": True})
+
+
+@bp.route("/tournaments/<tournament_url>/registrations/team/me", methods=["GET"])
+@login_required
+def get_my_team_registration(tournament_url):
+    """Get current team's registration for this tournament."""
+    from app.services.registration_resolver import team_registration_for_tournament
+
+    if not is_team(current_user):
+        return jsonify({"error": "Only teams have team registrations"}), 400
+
+    tournament = Tournament.query.filter_by(url=tournament_url).first_or_404()
+    reg = team_registration_for_tournament(tournament, current_user.id)
+
+    if not reg:
+        return jsonify({"error": "Not registered"}), 404
+
+    return jsonify(
+        {
+            "registration": {
+                "id": reg.id,
+                "pseudonym": reg.pseudonym,
+                "shortname": reg.shortname,
+                "status": (reg.status.value if hasattr(reg.status, "value") else str(reg.status)),
+            }
+        }
+    )
+
+
+@bp.route("/tournaments/<tournament_url>/registrations/team/me", methods=["PUT"])
+@login_required
+def update_my_team_registration(tournament_url):
+    """Update current team's registration."""
+    from app.services.registration_resolver import team_registration_for_tournament
+
+    if not is_team(current_user):
+        return jsonify({"error": "Only teams can edit their registration"}), 400
+
+    tournament = Tournament.query.filter_by(url=tournament_url).first_or_404()
+    cfg = get_registrable_config(tournament)
+    reg_open = bool(cfg.team_registration_open) if cfg else False
+    if not reg_open:
+        return jsonify({"error": "Registration changes are locked"}), 403
+
+    reg = team_registration_for_tournament(tournament, current_user.id)
+
+    if not reg:
+        return jsonify({"error": "Not registered"}), 404
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid JSON"}), 400
+
+    if "pseudonym" in data:
+        pseudonym = data["pseudonym"].strip()
+        pn_err = team_pseudonym_char_error(pseudonym)
+        if pn_err:
+            return jsonify({"error": pn_err}), 400
+        if not pseudonym:
+            return jsonify({"error": "Team name is required"}), 400
+        reg.pseudonym = pseudonym
+
+    if "shortname" in data:
+        raw = data.get("shortname")
+        if raw is None or (isinstance(raw, str) and not raw.strip()):
+            reg.shortname = None
+        else:
+            reg.shortname = raw.strip()
+
+    db.session.commit()
+    return jsonify({"success": True})

--- a/app/serializers/registration_serializer.py
+++ b/app/serializers/registration_serializer.py
@@ -7,16 +7,203 @@ Two pure-function builders used by registration routes:
 - ``serialize_manage(scope, search_query, search_type, cfg)`` - builds
   the full registration-management response payload used by league and
   tournament TO views.
-
-This module is currently a facade re-exporting the implementations from
-``app.routes._api``. The registration-refactor PR replaces the
-re-exports with the real implementations; consumers can import the
-public names now and never have to change once the refactor lands.
 """
 
 from __future__ import annotations
 
-from app.routes._api import _player_reg_waiver_api as player_reg_waiver_api
-from app.routes._api import _serialize_manage as serialize_manage
+from app.domain.enums import RegistrationStatus
+from models import League, Player, Team, Tournament
 
-__all__ = ["player_reg_waiver_api", "serialize_manage"]
+
+def player_reg_waiver_api(reg, cfg):
+    """Waiver fields for API given a PlayerRegistration and RegistrableConfig (or None)."""
+    waiver_required = bool(getattr(cfg, "waiver_filepath", None)) if cfg else False
+    fp = getattr(cfg, "waiver_filepath", None) if cfg else None
+    sha = getattr(cfg, "waiver_sha256", None) if cfg else None
+    stored = getattr(reg, "waiver_legal_name_signature_sha256", None) if reg else None
+    legal = getattr(reg, "waiver_legal_name_signature", None) if reg else None
+
+    if not waiver_required:
+        waiver_status = None
+        signature_valid = True
+    elif not stored:
+        waiver_status = "NOT_SIGNED"
+        signature_valid = False
+    elif sha is not None and stored == sha:
+        waiver_status = "VALID"
+        signature_valid = True
+    else:
+        waiver_status = "OUT_OF_DATE"
+        signature_valid = False
+
+    return {
+        "waiver_required": waiver_required,
+        "waiver_filepath": fp,
+        "waiver_sha256": sha,
+        "waiver_status": waiver_status,
+        "waiver_signature_valid": signature_valid,
+        "waiver_legal_name_signature": legal,
+    }
+
+
+def serialize_manage(scope, search_query: str, search_type: str, cfg) -> dict:
+    """Build the manage-API payload for *scope*.
+
+    Handles search filtering, registration loading, and the team/player
+    summary construction shared between tournament_manage_api and
+    league_manage_api.
+
+    Args:
+        scope: :class:`~app.services._common.Scope` identifying event vs league.
+        search_query: Search string from request query args.
+        search_type: ``"team"`` / ``"player"`` / ``"both"``.
+        cfg: registrable_config object (shared between scopes).
+
+    Returns:
+        The manage payload dict ready to be jsonified.
+    """
+    # tournament_to_dict and dt_iso live in _api.py, which imports this
+    # module - so import them lazily here to avoid a circular import.
+    from app.routes._api import _tournament_to_dict, _dt_iso
+
+    from app.services.registration_resolver import (
+        team_registrations_for_scope,
+        player_registrations_for_scope,
+    )
+
+    team_registrations = team_registrations_for_scope(scope, exclude_cancelled=True)
+    teams_with_registrations = []
+    for team_reg in team_registrations:
+        team = Team.query.get(team_reg.team)
+        if team:
+            teams_with_registrations.append({"registration": team_reg, "team": team})
+
+    player_registrations = player_registrations_for_scope(
+        scope,
+        statuses=[
+            RegistrationStatus.PENDING_TEAM_APPROVAL,
+            RegistrationStatus.CONFIRMED,
+            RegistrationStatus.REJECTED,
+        ],
+    )
+    players_with_registrations = []
+    for player_reg in player_registrations:
+        player = Player.query.get(player_reg.player)
+        team = Team.query.get(player_reg.team) if player_reg.team else None
+        if player:
+            players_with_registrations.append({"registration": player_reg, "player": player, "team": team})
+
+    if search_query:
+        q = search_query.lower()
+        if search_type in ("both", "teams"):
+            teams_with_registrations = [
+                t
+                for t in teams_with_registrations
+                if (
+                    (t["team"].name or "").lower().find(q) != -1
+                    or (t["registration"].pseudonym or "").lower().find(q) != -1
+                )
+            ]
+        else:
+            teams_with_registrations = []
+
+        if search_type in ("both", "players"):
+            players_with_registrations = [
+                p
+                for p in players_with_registrations
+                if (
+                    (p["player"].name or "").lower().find(q) != -1
+                    or (p["registration"].jersey_name or "").lower().find(q) != -1
+                )
+            ]
+        else:
+            players_with_registrations = []
+
+    if scope.is_league:
+        league = League.query.get(scope.league_url)
+        wf = getattr(cfg, "waiver_filepath", None) if cfg else None
+        tournament_dict = {
+            "url": league.url,
+            "name": league.name,
+            "start_date": "",
+            "end_date": None,
+            "location": None,
+            "published": league.published,
+            "league": {"league_url": league.url, "name": league.name},
+            "waiver_required": bool(wf),
+            "waiver_filepath": wf,
+            "waiver_sha256": getattr(cfg, "waiver_sha256", None) if cfg else None,
+        }
+    else:
+        tournament = Tournament.query.filter_by(url=scope.event_url).first()
+        tournament_dict = _tournament_to_dict(tournament)
+
+    player_rows = []
+    for pr in players_with_registrations:
+        w = player_reg_waiver_api(pr["registration"], cfg)
+        player_rows.append(
+            {
+                "registration": {
+                    "id": pr["registration"].id,
+                    "player": pr["registration"].player,
+                    "team": pr["registration"].team,
+                    "jersey_name": pr["registration"].jersey_name,
+                    "jersey_number": pr["registration"].jersey_number,
+                    "status": (
+                        pr["registration"].status.value
+                        if hasattr(pr["registration"].status, "value")
+                        else str(pr["registration"].status)
+                    ),
+                    "paid": bool(pr["registration"].paid),
+                    "amount_paid": pr["registration"].amount_paid or 0.0,
+                    "registered_at": _dt_iso(pr["registration"].registered_at),
+                    "paid_at": _dt_iso(pr["registration"].paid_at),
+                    "waiver_required": w["waiver_required"],
+                    "waiver_status": w["waiver_status"],
+                    "waiver_legal_name_signature": w["waiver_legal_name_signature"],
+                },
+                "player": {
+                    "id": pr["player"].id,
+                    "name": pr["player"].name,
+                },
+                "team": (
+                    {
+                        "id": pr["team"].id,
+                        "name": pr["team"].name,
+                    }
+                    if pr["team"]
+                    else None
+                ),
+            }
+        )
+
+    return {
+        "tournament": tournament_dict,
+        "search_query": search_query,
+        "search_type": search_type,
+        "team_registrations": [
+            {
+                "registration": {
+                    "id": tr["registration"].id,
+                    "team": tr["registration"].team,
+                    "pseudonym": tr["registration"].pseudonym,
+                    "shortname": tr["registration"].shortname,
+                    "status": (
+                        tr["registration"].status.value
+                        if hasattr(tr["registration"].status, "value")
+                        else str(tr["registration"].status)
+                    ),
+                    "paid": bool(tr["registration"].paid),
+                    "amount_paid": tr["registration"].amount_paid or 0.0,
+                    "registered_at": _dt_iso(tr["registration"].registered_at),
+                    "paid_at": _dt_iso(tr["registration"].paid_at),
+                },
+                "team": {
+                    "id": tr["team"].id,
+                    "name": tr["team"].name,
+                },
+            }
+            for tr in teams_with_registrations
+        ],
+        "player_registrations": player_rows,
+    }


### PR DESCRIPTION
## Summary

Pulls the remaining registration routes out of `_api.py` into the existing `registration` blueprint, and gives `registration_serializer.py` its real implementation. This is the sixth PR in the `_api.py` refactor stack, landing on top of the player/team extraction (#208) that's already on `dev`.

## What changed

Backend:
- Moves 18 routes from `_api.py` into `app/routes/registration.py`, which already owned the tournament-scoped register/deregister/payment endpoints: the four league register/deregister routes, the per-user `registrations/me` GET+PUT routes (league and tournament, player and team), league mark-paid, league deregister-any, and the league invitation accept/decline routes.
- The `/invitations` LIST routes stay in `_api.py` for now - they are not registration-lifecycle routes and find a home in a later PR.
- `app/serializers/registration_serializer.py` graduates from a facade re-export into the real `player_reg_waiver_api` and `serialize_manage` implementations. The manage views that stay in `_api.py` now import the public names from the serializer.
- `tournament_to_dict` and `dt_iso` are imported lazily inside `serialize_manage`, because `_api.py` imports this module - a top-level import would be circular.

## Test plan

- [x] `just unit` passes locally - 232 passed
- [x] `just integration` passes locally - 60 passed (incl. the `test_team_shortname_routes.py` suite)
- [x] `tests/test_url_surface.py` passes - the URL surface fixture is byte-identical to `dev`; same URLs and methods, just a different blueprint owner
- [x] `just lint` and `just format` clean on the touched files

No new tests - the routes move verbatim from `_api.py`, so the existing registration integration tests plus the URL-surface gate cover the behavior.

Implementation note for reviewers: the long-lived branch had drifted behind `dev` (it predated the team `shortname` feature), so rather than move its now-stale route bodies I re-extracted the routes and the two serializer helpers from `dev`'s current `_api.py`. The result is a true no-op move - behavior matches `dev` exactly, which the shortname tests and the URL-surface snapshot both confirm.

Note: `just lint` reports one pre-existing F401 in `app/models/validators.py` (`URL_SLUG_LEN` unused), already on `dev` and unrelated to this PR - left alone.

## Linked issues

Refs #174

## Screenshots / repro

No UI or API-shape change. Same URLs, same methods, same payloads - verified by the URL-surface snapshot test (fixture unchanged from `dev`).

---

### Pre-review checklist

- [x] Title prefixed with `[Refactor]`.
- [x] Branch name follows `category/name` (`feature/refactor-registration`).
- [x] Targeting `dev`, not `main`.
- [x] `just lint` and `just format` clean on touched files (one unrelated pre-existing warning noted above).
- [x] ~~Tests added or updated~~ - verbatim relocation; URL-surface gate + existing registration/shortname tests cover it.
- [x] New module docs: `registration_serializer` already carries an `app.serializers.registration_serializer.rst` automodule entry (shipped with the facade); no new module added.
- [x] ~~Developer workflow docs~~ - unchanged.
- [x] No merge conflicts with the base branch (rebuilt on current `dev`).
