### PR TITLE
[Feature] run match page usability upgrades

### DIFF
--- a/app/routes/notes.py
+++ b/app/routes/notes.py
@@ -397,7 +397,7 @@ def delete_point_note(tournament_url: str):
 
     from app.utils.helpers import can_head_ref_match
 
-    if not can_head_ref_match(tournament_url, current_user.id, note.match):
+    if not can_head_ref_match(tournament_url, current_user.id, match):
         return json_error("Not authorized", status_code=403)
 
     db.session.delete(note)

--- a/frontend/src/pages/run_match.rs
+++ b/frontend/src/pages/run_match.rs
@@ -198,6 +198,24 @@ fn stones_elapsed_with_filter(
     (end_beat - start_beat).max(0) as u32
 }
 
+/// Max length of a team shortname (mirrors SHORTNAME_LEN in app/models/constants.py).
+const SHORTNAME_LEN: usize = 8;
+
+/// Team label for the winner buttons: the shortname if set, otherwise the name truncated to
+/// SHORTNAME_LEN-1 chars ending in "…" (never the full name).
+fn team_short_label(shortname: Option<&str>, name: &str) -> String {
+    if let Some(s) = shortname.filter(|s| !s.is_empty()) {
+        return s.to_string();
+    }
+    let max_len = SHORTNAME_LEN - 1;
+    if name.chars().count() <= max_len {
+        name.to_string()
+    } else {
+        let head: String = name.chars().take(max_len - 1).collect();
+        format!("{head}…")
+    }
+}
+
 #[component]
 pub fn RunMatch(url: String, match_id: String) -> Element {
     let navigator = use_navigator();
@@ -452,8 +470,8 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                 }
                 let team1 = m.team1_name.as_str();
                 let team2 = m.team2_name.as_str();
-                let team1_short = m.team1_shortname.as_deref().filter(|s| !s.is_empty()).unwrap_or(team1);
-                let team2_short = m.team2_shortname.as_deref().filter(|s| !s.is_empty()).unwrap_or(team2);
+                let team1_short = team_short_label(m.team1_shortname.as_deref(), team1);
+                let team2_short = team_short_label(m.team2_shortname.as_deref(), team2);
                 let team1_photo = m.team1_photo.clone();
                 let team2_photo = m.team2_photo.clone();
                 let base_url = api::base_url();
@@ -975,11 +993,10 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     #score-stones-card .card-body{padding:0.5rem}\
                     #score-stones-card h4{font-size:1rem;margin-bottom:0.1rem!important}\
                     #score-stones-card #stones-remaining{font-size:2rem!important;height:40px!important;line-height:1!important}\
-                    #score-stones-card #time-elapsed{font-size:1.75rem}\
                     #score-stones-card .col-md-6.mb-4{margin-bottom:0.5rem!important}\
                     #score-by-set .row{margin-bottom:0!important}\
                     #score-by-set h4{font-size:1rem}\
-                    #score-by-set strong{font-size:0.95rem}\
+                    #score-by-set strong,#score-by-set #time-elapsed{font-size:0.95rem}\
                     #score-by-set small{font-size:0.75rem}}";
                 let mut state_signal = state_signal;
                 let mut action_error = action_error;
@@ -1020,9 +1037,10 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let u_t2 = u_winner.clone();
                         let winner_is_t1 = winner_val == "TEAM1";
                         let winner_is_t2 = winner_val == "TEAM2";
+                        let notes_for_point = point_notes_map_signal().get(&pid_list).cloned().unwrap_or_default();
                         rsx! {
                             tr { key: "{pt_id}", id: "point-row-{pt_id}",
-                                td { class: "text-muted text-center", "{point_index}" }
+                                td { class: "text-muted text-center align-middle", "{point_index}" }
                                 td {
                                     div { class: "set-number-controls",
                                         button {
@@ -1092,7 +1110,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                         }
                                     }
                                 }
-                                td { id: "stones-{pt_id}", "{elapsed}" }
+                                td { class: "align-middle", id: "stones-{pt_id}", "{elapsed}" }
                                 td {
                                     div { class: "winner-cell",
                                         div { class: "winner-options-group",
@@ -1169,7 +1187,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                         }
                                     }
                                 }
-                                td {
+                                td { class: "align-middle",
                                     div { class: "form-check",
                                         input {
                                             class: "form-check-input",
@@ -1233,8 +1251,8 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                         }
                                     }
                                 }
-                                td {
-                                    div { class: "d-flex gap-1",
+                                td { class: "align-middle",
+                                    div { class: "d-flex flex-column gap-1",
                                         {
                                             let pid_notes = pid.clone();
                                             let pid_penalties = pid.clone();
@@ -1310,46 +1328,8 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                             }
                                         }
                                     }
-                                    div { class: "mt-1",
-                                        for note_val in point_notes_map_signal().get(&pid_list).cloned().unwrap_or_default().iter() {
-                                            {
-                                                let note_text = note_val.get("text").and_then(|t| t.as_str()).unwrap_or("");
-                                                let target = note_val.get("target").and_then(|t| t.as_str()).unwrap_or("match");
-                                                let target_display = note_val.get("player_display").and_then(|p| p.as_str())
-                                                    .or_else(|| note_val.get("player_name").and_then(|p| p.as_str()))
-                                                    .unwrap_or(if target == "match" { "Point" } else { target })
-                                                    .to_string();
-                                                let target_profile_id = note_val.get("player_id").and_then(|v| v.as_str()).map(String::from);
-                                                let pt_id = note_val.get("penalty_type_id").and_then(|v| v.as_i64()).map(|v| v as i32);
-                                                let penalty_info = if let Some(id) = pt_id {
-                                                    d.penalty_types.iter().find(|t| t.id == id)
-                                                } else {
-                                                    None
-                                                };
-                                                let (border_color, display_text) = if let Some(pt) = penalty_info {
-                                                    (pt.color.clone(), pt.name.clone())
-                                                } else {
-                                                    ("808080".to_string(), if note_text.is_empty() { "Other".to_string() } else { note_text.to_string() })
-                                                };
-                                                let description = penalty_info
-                                                    .and_then(|pt| pt.desc.clone())
-                                                    .filter(|s| !s.is_empty());
-
-                                                rsx! {
-                                                    PenaltyDisplay {
-                                                        border_color,
-                                                        display_text,
-                                                        description,
-                                                        target_display: Some(target_display),
-                                                        target_profile_id,
-                                                        on_description_click: move |d: Option<String>| penalty_desc_modal.set(d),
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
                                 }
-                                td {
+                                td { class: "align-middle",
                                     button {
                                         class: "delete-point-btn",
                                         title: "Delete",
@@ -1389,6 +1369,50 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                     }
                                 }
                             }
+                            if !notes_for_point.is_empty() {
+                                tr { key: "{pt_id}-notes",
+                                    td { colspan: "7", class: "pt-0 pb-2 border-0",
+                                        div { class: "d-flex flex-wrap gap-1",
+                                            for note_val in notes_for_point.iter() {
+                                                {
+                                                    let note_text = note_val.get("text").and_then(|t| t.as_str()).unwrap_or("");
+                                                    let target = note_val.get("target").and_then(|t| t.as_str()).unwrap_or("match");
+                                                    let target_display = note_val.get("player_display").and_then(|p| p.as_str())
+                                                        .or_else(|| note_val.get("player_name").and_then(|p| p.as_str()))
+                                                        .unwrap_or(if target == "match" { "Point" } else { target })
+                                                        .to_string();
+                                                    let target_profile_id = note_val.get("player_id").and_then(|v| v.as_str()).map(String::from);
+                                                    let pt_id = note_val.get("penalty_type_id").and_then(|v| v.as_i64()).map(|v| v as i32);
+                                                    let penalty_info = if let Some(id) = pt_id {
+                                                        d.penalty_types.iter().find(|t| t.id == id)
+                                                    } else {
+                                                        None
+                                                    };
+                                                    let (border_color, display_text) = if let Some(pt) = penalty_info {
+                                                        (pt.color.clone(), pt.name.clone())
+                                                    } else {
+                                                        ("808080".to_string(), if note_text.is_empty() { "Other".to_string() } else { note_text.to_string() })
+                                                    };
+                                                    let description = penalty_info
+                                                        .and_then(|pt| pt.desc.clone())
+                                                        .filter(|s| !s.is_empty());
+
+                                                    rsx! {
+                                                        PenaltyDisplay {
+                                                            border_color,
+                                                            display_text,
+                                                            description,
+                                                            target_display: Some(target_display),
+                                                            target_profile_id,
+                                                            on_description_click: move |d: Option<String>| penalty_desc_modal.set(d),
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     })
                     .collect();
@@ -1398,9 +1422,6 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         div { class: "row",
                             div { class: "col-md-12",
                                 h2 { "Run Match: {m.name}" }
-                                p { class: "small text-muted mb-1",
-                                    "Note: although there's a delay when clicking start/end point, the stone count is done correctly (it's computed from when you first click it)."
-                                }
                                 div { class: "row d-none d-md-flex",
                                     div { class: "col-md-4",
                                         p { class: "mb-0",
@@ -1432,8 +1453,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                 div { class: "row d-md-none",
                                     div { class: "col-12",
                                         p { class: "small mb-0",
-                                            "{team1} vs {team2}"
-                                            " | Refs: {refs_display}"
+                                            "Refs: {refs_display}"
                                             if let Some(len) = m.nominal_length {
                                                 " | {len}m"
                                             }
@@ -1451,11 +1471,13 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                         div { class: "row",
                                             div { class: "col-md-6 mb-4 mb-md-0",
                                                 div { id: "score-by-set",
-                                                    div { class: "row mb-1",
+                                                    div { class: "row mb-1 align-items-center",
                                                         div { class: "col-5 text-center",
                                                             small { class: "text-muted", "{team1}" }
                                                         }
-                                                        div { class: "col-2" }
+                                                        div { class: "col-2 text-center",
+                                                            span { id: "time-elapsed", "{time_elapsed_str}" }
+                                                        }
                                                         div { class: "col-5 text-center",
                                                             small { class: "text-muted", "{team2}" }
                                                         }
@@ -1480,51 +1502,47 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                                 }
                                             }
                                             div { class: "col-md-6",
-                                                div { class: "row",
-                                                    if set_type_stones {
-                                                        div { class: "col-6 text-center d-flex flex-column align-items-center",
-                                                            h4 { class: "mb-1", "Stone Count" }
-                                                            p { class: "small mb-0", "(click to edit)" }
-                                                            input {
-                                                                r#type: "number",
-                                                                class: "form-control-plaintext text-center display-4 m-0 p-0",
-                                                                id: "stones-remaining",
-                                                                style: "width: 6ch; line-height: 1; font-size: 3rem; height: 64px; min-width: 6ch;",
-                                                                value: "{stones_input_value}",
-                                                                onfocus: move |_| {
-                                                                    stones_input_focused.set(true);
-                                                                    stones_edit_value.set(display_stones.map(|n| n.to_string()).unwrap_or_default());
-                                                                },
-                                                                onblur: move |_| {
-                                                                    let s = stones_edit_value();
-                                                                    if let Ok(n) = s.parse::<u32>() {
-                                                                        stones_remaining.set(Some(n));
-                                                                        let u = url_stones_blur.clone();
-                                                                        let id = id_stones_blur.clone();
-                                                                        spawn(async move {
-                                                                            let _ = api::update_stones(&u, &id, n).await;
-                                                                        });
-                                                                    }
-                                                                    stones_input_focused.set(false);
-                                                                },
-                                                                oninput: move |ev| {
-                                                                    let s = ev.value();
-                                                                    stones_edit_value.set(s.clone());
-                                                                    if let Ok(n) = s.parse::<u32>() {
-                                                                        stones_remaining.set(Some(n));
-                                                                        let u = url.clone();
-                                                                        let id = match_id.clone();
-                                                                        spawn(async move {
-                                                                            let _ = api::update_stones(&u, &id, n).await;
-                                                                        });
-                                                                    }
-                                                                },
-                                                            }
+                                                if set_type_stones {
+                                                    div { class: "d-flex align-items-center justify-content-center gap-3",
+                                                        div { class: "text-start",
+                                                            h4 { class: "mb-0", "Stone Count" }
+                                                            p { class: "small text-muted mb-0", "(click to edit)" }
                                                         }
-                                                    }
-                                                    div { class: if set_type_stones { "col-6 text-center" } else { "col-12 text-center" },
-                                                        h4 { class: "mb-1", "Time Elapsed" }
-                                                        h2 { id: "time-elapsed", class: "mb-0", "{time_elapsed_str}" }
+                                                        input {
+                                                            r#type: "number",
+                                                            class: "form-control-plaintext text-center display-4 m-0 p-0",
+                                                            id: "stones-remaining",
+                                                            style: "width: 6ch; line-height: 1; font-size: 3rem; height: 64px; min-width: 6ch;",
+                                                            value: "{stones_input_value}",
+                                                            onfocus: move |_| {
+                                                                stones_input_focused.set(true);
+                                                                stones_edit_value.set(display_stones.map(|n| n.to_string()).unwrap_or_default());
+                                                            },
+                                                            onblur: move |_| {
+                                                                let s = stones_edit_value();
+                                                                if let Ok(n) = s.parse::<u32>() {
+                                                                    stones_remaining.set(Some(n));
+                                                                    let u = url_stones_blur.clone();
+                                                                    let id = id_stones_blur.clone();
+                                                                    spawn(async move {
+                                                                        let _ = api::update_stones(&u, &id, n).await;
+                                                                    });
+                                                                }
+                                                                stones_input_focused.set(false);
+                                                            },
+                                                            oninput: move |ev| {
+                                                                let s = ev.value();
+                                                                stones_edit_value.set(s.clone());
+                                                                if let Ok(n) = s.parse::<u32>() {
+                                                                    stones_remaining.set(Some(n));
+                                                                    let u = url.clone();
+                                                                    let id = match_id.clone();
+                                                                    spawn(async move {
+                                                                        let _ = api::update_stones(&u, &id, n).await;
+                                                                    });
+                                                                }
+                                                            },
+                                                        }
                                                     }
                                                 }
                                                 div { class: "row mt-3",

--- a/frontend/src/pages/run_match.rs
+++ b/frontend/src/pages/run_match.rs
@@ -403,7 +403,8 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
     let mut point_notes_seeded = use_signal(|| false);
     let mut penalty_desc_modal = use_signal(|| None::<String>);
     // Local stones remaining (for STONES set type); synced from match/state when not ticking.
-    let mut stones_remaining = use_signal(|| 100u32);
+    // None means the count is not yet known (neither stones_remaining nor stones_per_set is set).
+    let mut stones_remaining = use_signal(|| None as Option<u32>);
     // When true, stones input shows stones_edit_value so we don't overwrite typing with display_stones.
     let mut stones_input_focused = use_signal(|| false);
     let mut stones_edit_value = use_signal(|| String::new());
@@ -441,10 +442,13 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
             Some(Ok(d)) => {
                 let m = &d.match_data;
                 let set_type_stones = m.set_type.as_deref() == Some("STONES");
-                let initial_stones = m.stones_remaining.or(m.stones_per_set).unwrap_or(100);
-                // Initialize stones once from match
-                if stones_remaining() == 100 && initial_stones != 100 {
-                    stones_remaining.set(initial_stones);
+                // Initialize the local count from the match's stored value the first time it
+                // becomes known. None stays None until there's a real value, so user edits and
+                // tick-downs are never clobbered, and an unconfigured count surfaces as unknown.
+                if stones_remaining().is_none() {
+                    if let Some(known) = m.stones_remaining.or(m.stones_per_set) {
+                        stones_remaining.set(Some(known));
+                    }
                 }
                 let team1 = m.team1_name.as_str();
                 let team2 = m.team2_name.as_str();
@@ -552,7 +556,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     .collect();
 
                 // Stones display: during an active point show stones_at_start - elapsed (ticks down); otherwise show stones_remaining.
-                let display_stones = if set_type_stones {
+                let display_stones: Option<u32> = if set_type_stones {
                     if let Some(ref cp) = current_point() {
                         points
                             .iter()
@@ -568,7 +572,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                 let elapsed = stones_elapsed_beats(stamp, None) as u64;
                                 Some((at_start.saturating_sub(elapsed)) as u32)
                             })
-                            .unwrap_or(stones_remaining())
+                            .or(stones_remaining())
                     } else {
                         stones_remaining()
                     }
@@ -584,14 +588,14 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         set_type_stones && current_point().is_some() && !stones_input_focused();
                     let prev = prev_stones_for_beep();
                     if is_counting_down {
-                        if prev.map(|p| p > 15).unwrap_or(false) && display_stones == 15 {
+                        if prev.map(|p| p > 15).unwrap_or(false) && display_stones == Some(15) {
                             spawn(async move {
                                 gloo_timers::future::TimeoutFuture::new(0).await;
                                 play_stones_warning_beeps();
                             });
                         }
-                        if prev != Some(display_stones) {
-                            prev_stones_for_beep.set(Some(display_stones));
+                        if prev != display_stones {
+                            prev_stones_for_beep.set(display_stones);
                         }
                     } else if prev.is_some() {
                         prev_stones_for_beep.set(None);
@@ -600,8 +604,9 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                 let stones_input_value = if stones_input_focused() {
                     stones_edit_value().clone()
                 } else {
-                    display_stones.to_string()
+                    display_stones.map(|n| n.to_string()).unwrap_or_default()
                 };
+                let stones_known = display_stones.is_some();
                 let url_stones_blur = url.clone();
                 let id_stones_blur = match_id.clone();
 
@@ -663,7 +668,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                                     as u64;
                                                 let remaining =
                                                     (at_start.saturating_sub(elapsed)) as u32;
-                                                stones_remaining.set(remaining);
+                                                stones_remaining.set(Some(remaining));
                                                 final_stones_for_api = Some(remaining);
                                             }
                                             break;
@@ -717,11 +722,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                             state_signal.set(Some(Ok(state)));
                         }
                         current_point.set(Some(pending_id.clone()));
-                        let stones_at_start = if set_type_stones {
-                            Some(stones_val)
-                        } else {
-                            None
-                        };
+                        let stones_at_start = if set_type_stones { stones_val } else { None };
                         spawn(async move {
                             err_out.set(None);
                             match api::add_point(
@@ -827,7 +828,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                                     as u64;
                                                 let remaining =
                                                     (at_start.saturating_sub(elapsed)) as u32;
-                                                stones_remaining.set(remaining);
+                                                stones_remaining.set(Some(remaining));
                                                 final_stones_for_api = Some(remaining);
                                             }
                                             break;
@@ -880,11 +881,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                             state_signal.set(Some(Ok(state)));
                         }
                         current_point.set(Some(pending_id.clone()));
-                        let stones_at_start = if set_type_stones {
-                            Some(stones_val)
-                        } else {
-                            None
-                        };
+                        let stones_at_start = if set_type_stones { stones_val } else { None };
                         spawn(async move {
                             err_out.set(None);
                             match api::add_point(
@@ -949,6 +946,14 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     "btn btn-danger btn-lg w-100 mobile-sticky-button"
                 } else {
                     "btn btn-success btn-lg w-100 mobile-sticky-button"
+                };
+                // Block starting a point until the stone count is known (can't record stones_at_start otherwise).
+                let needs_stone_count = set_type_stones && !stones_known && !has_in_progress;
+                let point_button_disabled = finalized || needs_stone_count;
+                let point_button_text = if needs_stone_count {
+                    "Set stone count to start"
+                } else {
+                    point_button_text
                 };
 
                 let run_match_css = ".set-number-controls{display:flex;flex-direction:column;align-items:center;gap:0;width:40px}\
@@ -1185,18 +1190,20 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                                     }
                                                     state_signal.set(Some(Ok(state)));
                                                 }
-                                                // Adjust stone counter: rerun = add this point's stones back, un-rerun = subtract
+                                                // Adjust stone counter: rerun = add this point's stones back, un-rerun = subtract.
+                                                // Only when the count is known; otherwise just toggle the rerolled flag.
                                                 let prev_stones = stones_remaining_reroll();
-                                                let (stones_to_send, stones_prev) = if set_type_stones_reroll {
-                                                    let new_val = if checked {
-                                                        prev_stones + elapsed
-                                                    } else {
-                                                        prev_stones.saturating_sub(elapsed)
-                                                    };
-                                                    stones_remaining_reroll.set(new_val);
-                                                    (Some(new_val), prev_stones)
-                                                } else {
-                                                    (None, prev_stones)
+                                                let (stones_to_send, stones_prev) = match (set_type_stones_reroll, prev_stones) {
+                                                    (true, Some(prev)) => {
+                                                        let new_val = if checked {
+                                                            prev + elapsed
+                                                        } else {
+                                                            prev.saturating_sub(elapsed)
+                                                        };
+                                                        stones_remaining_reroll.set(Some(new_val));
+                                                        (Some(new_val), prev_stones)
+                                                    }
+                                                    _ => (None, prev_stones),
                                                 };
                                                 let u = u_reroll.clone();
                                                 let id_reroll = id_reroll_match.clone();
@@ -1486,12 +1493,12 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                                                 value: "{stones_input_value}",
                                                                 onfocus: move |_| {
                                                                     stones_input_focused.set(true);
-                                                                    stones_edit_value.set(display_stones.to_string());
+                                                                    stones_edit_value.set(display_stones.map(|n| n.to_string()).unwrap_or_default());
                                                                 },
                                                                 onblur: move |_| {
                                                                     let s = stones_edit_value();
                                                                     if let Ok(n) = s.parse::<u32>() {
-                                                                        stones_remaining.set(n);
+                                                                        stones_remaining.set(Some(n));
                                                                         let u = url_stones_blur.clone();
                                                                         let id = id_stones_blur.clone();
                                                                         spawn(async move {
@@ -1504,7 +1511,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                                                     let s = ev.value();
                                                                     stones_edit_value.set(s.clone());
                                                                     if let Ok(n) = s.parse::<u32>() {
-                                                                        stones_remaining.set(n);
+                                                                        stones_remaining.set(Some(n));
                                                                         let u = url.clone();
                                                                         let id = match_id.clone();
                                                                         spawn(async move {
@@ -1526,7 +1533,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                                             id: "point-button",
                                                             class: "{point_button_class}",
                                                             onclick: on_start_end_point,
-                                                            disabled: finalized,
+                                                            disabled: point_button_disabled,
                                                             "{point_button_text}"
                                                         }
                                                     }
@@ -1612,7 +1619,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         button {
                             class: "{point_button_class}",
                             onclick: on_start_end_point_mobile,
-                            disabled: finalized,
+                            disabled: point_button_disabled,
                             "{point_button_text}"
                         }
                     }

--- a/frontend/src/pages/run_match.rs
+++ b/frontend/src/pages/run_match.rs
@@ -1,11 +1,11 @@
+use crate::Route;
 use crate::api;
 use crate::components::PenaltyDisplay;
-use crate::Route;
 use crate::stones_filter::BayesianOffsetFilter;
 use dioxus::prelude::*;
-use serde_json::Value;
 #[cfg(target_arch = "wasm32")]
 use gloo_timers::callback::Interval;
+use serde_json::Value;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsCast;
 
@@ -17,12 +17,15 @@ fn parse_iso_epoch(s: &str) -> Option<i64> {
         .ok()
         .map(|dt| dt.timestamp())
         .or_else(|| {
-            let with_z = if s.ends_with('Z') || s.contains('+') || (s.contains('-') && s.len() > 10) {
+            let with_z = if s.ends_with('Z') || s.contains('+') || (s.contains('-') && s.len() > 10)
+            {
                 s.to_string()
             } else {
                 format!("{}Z", s.trim_end_matches('z').trim_end_matches('Z'))
             };
-            chrono::DateTime::parse_from_rfc3339(&with_z).ok().map(|dt| dt.timestamp())
+            chrono::DateTime::parse_from_rfc3339(&with_z)
+                .ok()
+                .map(|dt| dt.timestamp())
         })
         .or_else(|| {
             // Naive ISO from Python isoformat() (no Z), possibly with fractional seconds
@@ -72,7 +75,11 @@ fn point_button_feedback(is_end_point: bool) {
             let _ = ctx.resume();
             if let (Ok(osc), Ok(gain)) = (ctx.create_oscillator(), ctx.create_gain()) {
                 gain.gain().set_value(0.4);
-                let (freq, duration) = if is_end_point { (440.0, 0.2) } else { (880.0, 0.25) };
+                let (freq, duration) = if is_end_point {
+                    (440.0, 0.2)
+                } else {
+                    (880.0, 0.25)
+                };
                 osc.set_type(web_sys::OscillatorType::Sine);
                 osc.frequency().set_value(freq);
                 let _ = osc.connect_with_audio_node(&gain);
@@ -85,13 +92,39 @@ fn point_button_feedback(is_end_point: bool) {
     }
 }
 
+/// Play five fast beeps to warn that 15 stones remain in a stones match.
+#[cfg(target_arch = "wasm32")]
+fn play_stones_warning_beeps() {
+    if let Ok(ctx) = web_sys::AudioContext::new() {
+        let _ = ctx.resume();
+        let start = ctx.current_time();
+        let beep = 0.08;
+        let gap = 0.12;
+        for i in 0..5 {
+            if let (Ok(osc), Ok(gain)) = (ctx.create_oscillator(), ctx.create_gain()) {
+                gain.gain().set_value(0.4);
+                osc.set_type(web_sys::OscillatorType::Square);
+                osc.frequency().set_value(1000.0);
+                let _ = osc.connect_with_audio_node(&gain);
+                let _ = gain.connect_with_audio_node(&ctx.destination());
+                let at = start + (i as f64) * gap;
+                let _ = osc.start_with_when(at);
+                let _ = osc.stop_with_when(at + beep);
+            }
+        }
+    }
+}
+
 /// Compute scores_by_set from points array (client-authoritative; same logic as server).
 fn scores_by_set_from_points(points: &[&Value]) -> Vec<(String, u64, u64)> {
     let mut by_set: std::collections::BTreeMap<u64, (u64, u64)> = std::collections::BTreeMap::new();
     for pt in points {
         let set_num = pt.get("set_number").and_then(|n| n.as_u64()).unwrap_or(1);
         let winner = pt.get("winner").and_then(|w| w.as_str()).unwrap_or("none");
-        let rerolled = pt.get("rerolled").and_then(|r| r.as_bool()).unwrap_or(false);
+        let rerolled = pt
+            .get("rerolled")
+            .and_then(|r| r.as_bool())
+            .unwrap_or(false);
         if rerolled {
             continue;
         }
@@ -111,9 +144,7 @@ fn scores_by_set_from_points(points: &[&Value]) -> Vec<(String, u64, u64)> {
 /// Stones elapsed = number of global 1.5s beat boundaries crossed (so counters tick in sync with global clock).
 fn stones_elapsed_beats(stamp_opt: Option<&str>, end_opt: Option<&str>) -> u32 {
     const BEAT: f64 = 1.5;
-    let start = stamp_opt
-        .and_then(parse_iso_epoch)
-        .unwrap_or(0) as f64;
+    let start = stamp_opt.and_then(parse_iso_epoch).unwrap_or(0) as f64;
     let end = end_opt
         .and_then(parse_iso_epoch)
         .map(|t| t as f64)
@@ -240,7 +271,9 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
             let guard = binding.try_read();
             let Ok(ref g) = guard else { return };
             let Some(Ok(d)) = g.as_ref() else { return };
-            if d.match_data.set_type.as_deref() == Some("STONES") && d.match_data.status == "IN_PROGRESS" {
+            if d.match_data.set_type.as_deref() == Some("STONES")
+                && d.match_data.status == "IN_PROGRESS"
+            {
                 server_time_loop_started.set(true);
                 let mut filter = time_filter;
                 spawn(async move {
@@ -279,11 +312,13 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     Ok(v) if !v.is_undefined() && !v.is_null() => v,
                     _ => return,
                 };
-                let request_js =
-                    match js_sys::Reflect::get(&wake_lock_js, &wasm_bindgen::JsValue::from_str("request")) {
-                        Ok(v) if v.is_function() => v,
-                        _ => return,
-                    };
+                let request_js = match js_sys::Reflect::get(
+                    &wake_lock_js,
+                    &wasm_bindgen::JsValue::from_str("request"),
+                ) {
+                    Ok(v) if v.is_function() => v,
+                    _ => return,
+                };
 
                 let request_fn = match request_js.dyn_ref::<js_sys::Function>() {
                     Some(f) => f,
@@ -312,9 +347,10 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
         use_drop(move || {
             if let Some(sentinel) = wake_lock_for_drop() {
                 let release_js =
-                    js_sys::Reflect::get(&sentinel, &wasm_bindgen::JsValue::from_str("release")).ok();
-                if let Some(release_fn) = release_js
-                    .and_then(|f| f.dyn_ref::<js_sys::Function>().map(|f| f.clone()))
+                    js_sys::Reflect::get(&sentinel, &wasm_bindgen::JsValue::from_str("release"))
+                        .ok();
+                if let Some(release_fn) =
+                    release_js.and_then(|f| f.dyn_ref::<js_sys::Function>().map(|f| f.clone()))
                 {
                     let _ = release_fn.call0(&sentinel);
                 }
@@ -358,7 +394,8 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
     let mut penalties_other_text = use_signal(|| String::new());
     let mut penalties_other_selected = use_signal(|| false);
     /// (player_id, penalties) after fetching for selected player.
-    let mut penalty_history_signal = use_signal(|| None as Option<(String, Vec<crate::types::PlayerPenaltyHistoryItem>)>);
+    let mut penalty_history_signal =
+        use_signal(|| None as Option<(String, Vec<crate::types::PlayerPenaltyHistoryItem>)>);
     /// Display name of the player currently selected in the penalties modal (step 2).
     let mut penalties_selected_player_display = use_signal(|| String::new());
     let mut point_notes_map_signal =
@@ -370,6 +407,9 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
     // When true, stones input shows stones_edit_value so we don't overwrite typing with display_stones.
     let mut stones_input_focused = use_signal(|| false);
     let mut stones_edit_value = use_signal(|| String::new());
+    // Previous live stone count, for detecting a tick-down to the 15-stone warning threshold.
+    #[cfg(target_arch = "wasm32")]
+    let mut prev_stones_for_beep = use_signal(|| None as Option<u32>);
     // Time elapsed (seconds) from match confirmed start (UTC); correct after reload.
     let mut time_elapsed_secs = use_signal(|| 0u64);
 
@@ -378,8 +418,12 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
             return;
         }
         let binding = detail.value();
-        let Ok(guard) = binding.try_read() else { return };
-        let Some(Ok(ref d)) = guard.as_ref() else { return };
+        let Ok(guard) = binding.try_read() else {
+            return;
+        };
+        let Some(Ok(ref d)) = guard.as_ref() else {
+            return;
+        };
         point_notes_seeded.set(true);
         let mut map = point_notes_map_signal();
         for (pid, notes) in &d.point_notes_map {
@@ -397,16 +441,15 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
             Some(Ok(d)) => {
                 let m = &d.match_data;
                 let set_type_stones = m.set_type.as_deref() == Some("STONES");
-                let initial_stones = m
-                    .stones_remaining
-                    .or(m.stones_per_set)
-                    .unwrap_or(100);
+                let initial_stones = m.stones_remaining.or(m.stones_per_set).unwrap_or(100);
                 // Initialize stones once from match
                 if stones_remaining() == 100 && initial_stones != 100 {
                     stones_remaining.set(initial_stones);
                 }
                 let team1 = m.team1_name.as_str();
                 let team2 = m.team2_name.as_str();
+                let team1_short = m.team1_shortname.as_deref().filter(|s| !s.is_empty()).unwrap_or(team1);
+                let team2_short = m.team2_shortname.as_deref().filter(|s| !s.is_empty()).unwrap_or(team2);
                 let team1_photo = m.team1_photo.clone();
                 let team2_photo = m.team2_photo.clone();
                 let base_url = api::base_url();
@@ -464,6 +507,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     .unwrap_or(1) as u32;
 
                 struct PointRow {
+                    index: usize,
                     point_id: String,
                     set_num: u32,
                     winner: String,
@@ -472,18 +516,38 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                 }
                 let point_rows: Vec<PointRow> = points
                     .iter()
-                    .map(|pt| {
-                        let point_id = pt.get("uuid").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                        let set_num = pt.get("set_number").and_then(|v| v.as_u64()).unwrap_or(1) as u32;
-                        let winner = pt.get("winner").and_then(|v| v.as_str()).unwrap_or("none").to_string();
-                        let rerolled = pt.get("rerolled").and_then(|v| v.as_bool()).unwrap_or(false);
+                    .enumerate()
+                    .map(|(index, pt)| {
+                        let point_id = pt
+                            .get("uuid")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let set_num =
+                            pt.get("set_number").and_then(|v| v.as_u64()).unwrap_or(1) as u32;
+                        let winner = pt
+                            .get("winner")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("none")
+                            .to_string();
+                        let rerolled = pt
+                            .get("rerolled")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
                         let stamp = pt.get("stamp").and_then(|s| s.as_str());
                         let end_stamp = pt.get("end_stamp").and_then(|e| e.as_str());
                         #[cfg(target_arch = "wasm32")]
                         let elapsed = stones_elapsed_with_filter(stamp, end_stamp, &time_filter);
                         #[cfg(not(target_arch = "wasm32"))]
                         let elapsed = stones_elapsed_beats(stamp, end_stamp);
-                        PointRow { point_id, set_num, winner, rerolled, elapsed }
+                        PointRow {
+                            index: index + 1,
+                            point_id,
+                            set_num,
+                            winner,
+                            rerolled,
+                            elapsed,
+                        }
                     })
                     .collect();
 
@@ -494,10 +558,12 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                             .iter()
                             .find(|p| p.get("uuid").and_then(|u| u.as_str()) == Some(cp.as_str()))
                             .and_then(|pt| {
-                                let at_start = pt.get("stones_at_start").and_then(|s| s.as_u64())?;
+                                let at_start =
+                                    pt.get("stones_at_start").and_then(|s| s.as_u64())?;
                                 let stamp = pt.get("stamp").and_then(|s| s.as_str());
                                 #[cfg(target_arch = "wasm32")]
-                                let elapsed = stones_elapsed_with_filter(stamp, None, &time_filter) as u64;
+                                let elapsed =
+                                    stones_elapsed_with_filter(stamp, None, &time_filter) as u64;
                                 #[cfg(not(target_arch = "wasm32"))]
                                 let elapsed = stones_elapsed_beats(stamp, None) as u64;
                                 Some((at_start.saturating_sub(elapsed)) as u32)
@@ -509,6 +575,28 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                 } else {
                     stones_remaining()
                 };
+                // Warn with five fast beeps when the live countdown ticks down to 15 stones.
+                // Only during an active point (the countdown path) and not while the operator is
+                // editing the count, so manually typing 15 doesn't beep; re-arms above 15.
+                #[cfg(target_arch = "wasm32")]
+                {
+                    let is_counting_down =
+                        set_type_stones && current_point().is_some() && !stones_input_focused();
+                    let prev = prev_stones_for_beep();
+                    if is_counting_down {
+                        if prev.map(|p| p > 15).unwrap_or(false) && display_stones == 15 {
+                            spawn(async move {
+                                gloo_timers::future::TimeoutFuture::new(0).await;
+                                play_stones_warning_beeps();
+                            });
+                        }
+                        if prev != Some(display_stones) {
+                            prev_stones_for_beep.set(Some(display_stones));
+                        }
+                    } else if prev.is_some() {
+                        prev_stones_for_beep.set(None);
+                    }
+                }
                 let stones_input_value = if stones_input_focused() {
                     stones_edit_value().clone()
                 } else {
@@ -554,15 +642,27 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                             let mut final_stones_for_api: Option<u32> = None;
                             if let Some(Ok(ref state)) = prev.clone() {
                                 let mut state = state.clone();
-                                if let Some(points) = state.get_mut("points").and_then(|p| p.as_array_mut()) {
+                                if let Some(points) =
+                                    state.get_mut("points").and_then(|p| p.as_array_mut())
+                                {
                                     for p in points.iter_mut() {
-                                        if p.get("uuid").and_then(|v| v.as_str()) == Some(point_id.as_str()) {
+                                        if p.get("uuid").and_then(|v| v.as_str())
+                                            == Some(point_id.as_str())
+                                        {
                                             p["end_stamp"] = serde_json::json!(end_iso);
                                             if set_type_stones {
-                                                let at_start = p.get("stones_at_start").and_then(|s| s.as_u64()).unwrap_or(0);
+                                                let at_start = p
+                                                    .get("stones_at_start")
+                                                    .and_then(|s| s.as_u64())
+                                                    .unwrap_or(0);
                                                 let stamp = p.get("stamp").and_then(|s| s.as_str());
-                                                let elapsed = stones_elapsed_beats_ms(stamp, Some(end_iso.as_str())) as u64;
-                                                let remaining = (at_start.saturating_sub(elapsed)) as u32;
+                                                let elapsed = stones_elapsed_beats_ms(
+                                                    stamp,
+                                                    Some(end_iso.as_str()),
+                                                )
+                                                    as u64;
+                                                let remaining =
+                                                    (at_start.saturating_sub(elapsed)) as u32;
                                                 stones_remaining.set(remaining);
                                                 final_stones_for_api = Some(remaining);
                                             }
@@ -574,12 +674,15 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                             }
                             current_point.set(None);
                             err_out.set(None);
-                            let body = serde_json::json!({ "point_id": point_id, "end_stamp": end_iso });
+                            let body =
+                                serde_json::json!({ "point_id": point_id, "end_stamp": end_iso });
                             match api::update_point(&u_for_stones, &point_id, &body).await {
                                 Ok(_) => {
                                     err_out.set(None);
                                     if let Some(n) = final_stones_for_api {
-                                        let _ = api::update_stones(&u_for_stones, &id_for_stones, n).await;
+                                        let _ =
+                                            api::update_stones(&u_for_stones, &id_for_stones, n)
+                                                .await;
                                     }
                                 }
                                 Err(e) => {
@@ -591,7 +694,8 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         });
                     } else {
                         // Start new point — optimistic: add pending point, set current_point
-                        let pending_id = format!("pending-{}", chrono::Utc::now().timestamp_millis());
+                        let pending_id =
+                            format!("pending-{}", chrono::Utc::now().timestamp_millis());
                         let stamp_iso = chrono::Utc::now().to_rfc3339();
                         let new_point = serde_json::json!({
                             "uuid": pending_id,
@@ -605,24 +709,47 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let prev = state_signal().clone();
                         if let Some(Ok(ref state)) = prev.clone() {
                             let mut state = state.clone();
-                            if let Some(points) = state.get_mut("points").and_then(|p| p.as_array_mut()) {
+                            if let Some(points) =
+                                state.get_mut("points").and_then(|p| p.as_array_mut())
+                            {
                                 points.push(new_point);
                             }
                             state_signal.set(Some(Ok(state)));
                         }
                         current_point.set(Some(pending_id.clone()));
-                        let stones_at_start = if set_type_stones { Some(stones_val) } else { None };
+                        let stones_at_start = if set_type_stones {
+                            Some(stones_val)
+                        } else {
+                            None
+                        };
                         spawn(async move {
                             err_out.set(None);
-                            match api::add_point(&u, &id, default_set, Some(chrono::Utc::now().timestamp_millis() as u64), stones_at_start).await {
+                            match api::add_point(
+                                &u,
+                                &id,
+                                default_set,
+                                Some(chrono::Utc::now().timestamp_millis() as u64),
+                                stones_at_start,
+                            )
+                            .await
+                            {
                                 Ok(resp) => {
-                                    let real_id = resp.get("point_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                                    let real_id = resp
+                                        .get("point_id")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("")
+                                        .to_string();
                                     if !real_id.is_empty() {
                                         if let Some(Ok(ref state)) = state_signal() {
                                             let mut state = state.clone();
-                                            if let Some(points) = state.get_mut("points").and_then(|p| p.as_array_mut()) {
+                                            if let Some(points) = state
+                                                .get_mut("points")
+                                                .and_then(|p| p.as_array_mut())
+                                            {
                                                 for p in points.iter_mut() {
-                                                    if p.get("uuid").and_then(|v| v.as_str()) == Some(pending_id.as_str()) {
+                                                    if p.get("uuid").and_then(|v| v.as_str())
+                                                        == Some(pending_id.as_str())
+                                                    {
                                                         p["uuid"] = serde_json::json!(real_id);
                                                         break;
                                                     }
@@ -679,15 +806,27 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                             let mut final_stones_for_api: Option<u32> = None;
                             if let Some(Ok(ref state)) = prev.clone() {
                                 let mut state = state.clone();
-                                if let Some(points) = state.get_mut("points").and_then(|p| p.as_array_mut()) {
+                                if let Some(points) =
+                                    state.get_mut("points").and_then(|p| p.as_array_mut())
+                                {
                                     for p in points.iter_mut() {
-                                        if p.get("uuid").and_then(|v| v.as_str()) == Some(point_id.as_str()) {
+                                        if p.get("uuid").and_then(|v| v.as_str())
+                                            == Some(point_id.as_str())
+                                        {
                                             p["end_stamp"] = serde_json::json!(end_iso);
                                             if set_type_stones {
-                                                let at_start = p.get("stones_at_start").and_then(|s| s.as_u64()).unwrap_or(0);
+                                                let at_start = p
+                                                    .get("stones_at_start")
+                                                    .and_then(|s| s.as_u64())
+                                                    .unwrap_or(0);
                                                 let stamp = p.get("stamp").and_then(|s| s.as_str());
-                                                let elapsed = stones_elapsed_beats_ms(stamp, Some(end_iso.as_str())) as u64;
-                                                let remaining = (at_start.saturating_sub(elapsed)) as u32;
+                                                let elapsed = stones_elapsed_beats_ms(
+                                                    stamp,
+                                                    Some(end_iso.as_str()),
+                                                )
+                                                    as u64;
+                                                let remaining =
+                                                    (at_start.saturating_sub(elapsed)) as u32;
                                                 stones_remaining.set(remaining);
                                                 final_stones_for_api = Some(remaining);
                                             }
@@ -699,12 +838,15 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                             }
                             current_point.set(None);
                             err_out.set(None);
-                            let body = serde_json::json!({ "point_id": point_id, "end_stamp": end_iso });
+                            let body =
+                                serde_json::json!({ "point_id": point_id, "end_stamp": end_iso });
                             match api::update_point(&u_for_stones, &point_id, &body).await {
                                 Ok(_) => {
                                     err_out.set(None);
                                     if let Some(n) = final_stones_for_api {
-                                        let _ = api::update_stones(&u_for_stones, &id_for_stones, n).await;
+                                        let _ =
+                                            api::update_stones(&u_for_stones, &id_for_stones, n)
+                                                .await;
                                     }
                                 }
                                 Err(e) => {
@@ -715,7 +857,8 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                             }
                         });
                     } else {
-                        let pending_id = format!("pending-{}", chrono::Utc::now().timestamp_millis());
+                        let pending_id =
+                            format!("pending-{}", chrono::Utc::now().timestamp_millis());
                         let stamp_iso = chrono::Utc::now().to_rfc3339();
                         let new_point = serde_json::json!({
                             "uuid": pending_id,
@@ -729,24 +872,47 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let prev = state_signal().clone();
                         if let Some(Ok(ref state)) = prev.clone() {
                             let mut state = state.clone();
-                            if let Some(points) = state.get_mut("points").and_then(|p| p.as_array_mut()) {
+                            if let Some(points) =
+                                state.get_mut("points").and_then(|p| p.as_array_mut())
+                            {
                                 points.push(new_point);
                             }
                             state_signal.set(Some(Ok(state)));
                         }
                         current_point.set(Some(pending_id.clone()));
-                        let stones_at_start = if set_type_stones { Some(stones_val) } else { None };
+                        let stones_at_start = if set_type_stones {
+                            Some(stones_val)
+                        } else {
+                            None
+                        };
                         spawn(async move {
                             err_out.set(None);
-                            match api::add_point(&u, &id, default_set, Some(chrono::Utc::now().timestamp_millis() as u64), stones_at_start).await {
+                            match api::add_point(
+                                &u,
+                                &id,
+                                default_set,
+                                Some(chrono::Utc::now().timestamp_millis() as u64),
+                                stones_at_start,
+                            )
+                            .await
+                            {
                                 Ok(resp) => {
-                                    let real_id = resp.get("point_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                                    let real_id = resp
+                                        .get("point_id")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("")
+                                        .to_string();
                                     if !real_id.is_empty() {
                                         if let Some(Ok(ref state)) = state_signal() {
                                             let mut state = state.clone();
-                                            if let Some(points) = state.get_mut("points").and_then(|p| p.as_array_mut()) {
+                                            if let Some(points) = state
+                                                .get_mut("points")
+                                                .and_then(|p| p.as_array_mut())
+                                            {
                                                 for p in points.iter_mut() {
-                                                    if p.get("uuid").and_then(|v| v.as_str()) == Some(pending_id.as_str()) {
+                                                    if p.get("uuid").and_then(|v| v.as_str())
+                                                        == Some(pending_id.as_str())
+                                                    {
                                                         p["uuid"] = serde_json::json!(real_id);
                                                         break;
                                                     }
@@ -785,9 +951,10 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     "btn btn-success btn-lg w-100 mobile-sticky-button"
                 };
 
-                let run_match_css = ".set-number-controls{display:flex;flex-direction:column;align-items:center;gap:2px;width:40px}\
-                    .set-number-controls .set-number-display{font-size:1rem;font-weight:600;text-align:center;min-width:30px;padding:4px 0}\
-                    .set-number-controls button{width:28px;height:24px;padding:0;font-size:14px}\
+                let run_match_css = ".set-number-controls{display:flex;flex-direction:column;align-items:center;gap:0;width:40px}\
+                    .set-number-controls .set-number-display{font-size:1rem;font-weight:600;text-align:center;min-width:30px;padding:0}\
+                    .set-number-controls button.set-step-btn{width:32px;height:26px;padding:0;font-size:13px;line-height:1;border:none;background:transparent;color:#6c757d;cursor:pointer;touch-action:manipulation}\
+                    .set-number-controls button.set-step-btn:hover{color:#212529}\
                     .delete-point-btn{background:#dc3545;color:white;border:none;width:28px;height:28px;padding:0;border-radius:3px;display:flex;align-items:center;justify-content:center;font-size:16px;line-height:1;cursor:pointer}\
                     .delete-point-btn:hover{background:#c82333}\
                     .winner-cell{display:flex;flex-wrap:wrap;align-items:center;min-width:0}\
@@ -798,8 +965,17 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     .winner-option .winner-avatar{width:26px;height:26px;border-radius:50%;object-fit:cover;flex-shrink:0}\
                     .winner-option .winner-name{min-width:3ch;max-width:12em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}\
                     @media (max-width:768px){.mobile-button-wrapper{position:fixed;bottom:0;left:0;right:0;z-index:1000;background:white;padding:0;margin:0;box-shadow:0 -2px 10px rgba(0,0,0,0.1);display:flex;flex-direction:row}\
-                    .mobile-button-wrapper .btn{border-radius:0;margin:0;flex:1}\
-                    .container .mobile-sticky-button,.container #finalize-match-btn{display:none}}";
+                    .mobile-button-wrapper .btn{border-radius:0;margin:0;flex:1;min-height:96px}\
+                    .container .mobile-sticky-button,.container #finalize-match-btn{display:none}\
+                    #score-stones-card .card-body{padding:0.5rem}\
+                    #score-stones-card h4{font-size:1rem;margin-bottom:0.1rem!important}\
+                    #score-stones-card #stones-remaining{font-size:2rem!important;height:40px!important;line-height:1!important}\
+                    #score-stones-card #time-elapsed{font-size:1.75rem}\
+                    #score-stones-card .col-md-6.mb-4{margin-bottom:0.5rem!important}\
+                    #score-by-set .row{margin-bottom:0!important}\
+                    #score-by-set h4{font-size:1rem}\
+                    #score-by-set strong{font-size:0.95rem}\
+                    #score-by-set small{font-size:0.75rem}}";
                 let mut state_signal = state_signal;
                 let mut action_error = action_error;
                 let set_type_stones_reroll = set_type_stones;
@@ -808,6 +984,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     .iter()
                     .map(|r| {
                         let pt_id = r.point_id.as_str();
+                        let point_index = r.index;
                         let set_num = r.set_num;
                         let winner_val = r.winner.as_str();
                         let rerolled = r.rerolled;
@@ -827,23 +1004,24 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let pid_reroll = pid.clone();
                         let pid_del = pid.clone();
                         let pid_list = pid.clone();
-                        let team1 = team1.to_string();
-                        let team2 = team2.to_string();
+                        let team1_short = team1_short.to_string();
+                        let team2_short = team2_short.to_string();
                         let team1_photo = team1_photo.clone();
                         let team2_photo = team2_photo.clone();
                         let base_url_winner = base_url.clone();
-                        let pid_none = pid_winner.clone();
-                        let u_none = u_winner.clone();
                         let pid_t1 = pid_winner.clone();
                         let u_t1 = u_winner.clone();
                         let pid_t2 = pid_winner.clone();
                         let u_t2 = u_winner.clone();
+                        let winner_is_t1 = winner_val == "TEAM1";
+                        let winner_is_t2 = winner_val == "TEAM2";
                         rsx! {
                             tr { key: "{pt_id}", id: "point-row-{pt_id}",
+                                td { class: "text-muted text-center", "{point_index}" }
                                 td {
                                     div { class: "set-number-controls",
                                         button {
-                                            class: "btn btn-sm btn-outline-secondary",
+                                            class: "set-step-btn",
                                             r#type: "button",
                                             onclick: move |_| {
                                                 let new_set = (set_num + 1).max(1);
@@ -876,7 +1054,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                         }
                                         span { class: "set-number-display", id: "set-display-{pt_id}", "{set_num}" }
                                         button {
-                                            class: "btn btn-sm btn-outline-secondary",
+                                            class: "set-step-btn",
                                             r#type: "button",
                                             onclick: move |_| {
                                                 let new_set = (set_num as i64 - 1).max(1) as u32;
@@ -914,42 +1092,10 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                     div { class: "winner-cell",
                                         div { class: "winner-options-group",
                                         button {
-                                            class: format!("winner-option{}", if winner_val == "none" { " active" } else { "" }),
-                                            r#type: "button",
-                                            onclick: move |_| {
-                                                let val = "none";
-                                                let prev = state_signal().clone();
-                                                if let Some(Ok(ref state)) = prev.clone() {
-                                                    let mut state = state.clone();
-                                                    if let Some(points) = state.get_mut("points").and_then(|p| p.as_array_mut()) {
-                                                        for p in points.iter_mut() {
-                                                            if p.get("uuid").and_then(|v| v.as_str()) == Some(pid_none.as_str()) {
-                                                                p["winner"] = serde_json::json!(val);
-                                                                break;
-                                                            }
-                                                        }
-                                                    }
-                                                    state_signal.set(Some(Ok(state)));
-                                                }
-                                                let u = u_none.clone();
-                                                let p = pid_none.clone();
-                                                let mut state_signal = state_signal;
-                                                let mut action_error = action_error;
-                                                spawn(async move {
-                                                    let body = serde_json::json!({ "point_id": p, "winner": val });
-                                                    match api::update_point(&u, &p, &body).await {
-                                                        Ok(_) => { action_error.set(None); }
-                                                        Err(e) => { action_error.set(Some(e)); state_signal.set(prev); }
-                                                    }
-                                                });
-                                            },
-                                            "None"
-                                        }
-                                        button {
                                             class: format!("winner-option{}", if winner_val == "TEAM1" { " active" } else { "" }),
                                             r#type: "button",
                                             onclick: move |_| {
-                                                let val = "TEAM1";
+                                                let val = if winner_is_t1 { "none" } else { "TEAM1" };
                                                 let prev = state_signal().clone();
                                                 if let Some(Ok(ref state)) = prev.clone() {
                                                     let mut state = state.clone();
@@ -978,13 +1124,13 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                             if let Some(ref ph) = team1_photo {
                                                 img { class: "winner-avatar", src: "{base_url_winner}/static/{ph}", alt: "" }
                                             }
-                                            span { class: "winner-name", "{team1}" }
+                                            span { class: "winner-name", "{team1_short}" }
                                         }
                                         button {
                                             class: format!("winner-option{}", if winner_val == "TEAM2" { " active" } else { "" }),
                                             r#type: "button",
                                             onclick: move |_| {
-                                                let val = "TEAM2";
+                                                let val = if winner_is_t2 { "none" } else { "TEAM2" };
                                                 let prev = state_signal().clone();
                                                 if let Some(Ok(ref state)) = prev.clone() {
                                                     let mut state = state.clone();
@@ -1013,7 +1159,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                             if let Some(ref ph) = team2_photo {
                                                 img { class: "winner-avatar", src: "{base_url_winner}/static/{ph}", alt: "" }
                                             }
-                                            span { class: "winner-name", "{team2}" }
+                                            span { class: "winner-name", "{team2_short}" }
                                         }
                                         }
                                     }
@@ -1201,6 +1347,15 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                         class: "delete-point-btn",
                                         title: "Delete",
                                         onclick: move |_| {
+                                            #[cfg(target_arch = "wasm32")]
+                                            {
+                                                let confirmed = web_sys::window()
+                                                    .and_then(|w| w.confirm_with_message("Delete this point?").ok())
+                                                    .unwrap_or(false);
+                                                if !confirmed {
+                                                    return;
+                                                }
+                                            }
                                             let prev = state_signal().clone();
                                             if let Some(Ok(ref state)) = prev.clone() {
                                                 let mut state = state.clone();
@@ -1284,16 +1439,11 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
 
                         div { class: "row mb-4",
                             div { class: "col-md-12",
-                                div { class: "card",
+                                div { class: "card", id: "score-stones-card",
                                     div { class: "card-body",
                                         div { class: "row",
                                             div { class: "col-md-6 mb-4 mb-md-0",
                                                 div { id: "score-by-set",
-                                                    div { class: "row mb-1",
-                                                        div { class: "col-12 text-center mb-1",
-                                                            h4 { class: "mb-0", "Score" }
-                                                        }
-                                                    }
                                                     div { class: "row mb-1",
                                                         div { class: "col-5 text-center",
                                                             small { class: "text-muted", "{team1}" }
@@ -1403,6 +1553,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                             table { class: "table table-sm", id: "points-table",
                                                 thead {
                                                     tr {
+                                                        th { "#" }
                                                         th { "Set" }
                                                         th { "🪨" }
                                                         th { "Winner" }
@@ -1412,7 +1563,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                                     }
                                                 }
                                                 tbody { id: "points-table-body",
-                                                    for node in point_table_rows.iter() {
+                                                    for node in point_table_rows.iter().rev() {
                                                         {node.clone()}
                                                     }
                                                 }

--- a/frontend/src/pages/run_match.rs
+++ b/frontend/src/pages/run_match.rs
@@ -115,6 +115,52 @@ fn play_stones_warning_beeps() {
     }
 }
 
+/// Play five beeps spread across ~2 seconds to signal a quick timer reaching zero.
+#[cfg(target_arch = "wasm32")]
+fn play_timer_end_beeps() {
+    if let Ok(ctx) = web_sys::AudioContext::new() {
+        let _ = ctx.resume();
+        let start = ctx.current_time();
+        let beep = 0.12;
+        let gap = 0.5; // 5 beeps at 0.0, 0.5, 1.0, 1.5, 2.0s.
+        for i in 0..5 {
+            if let (Ok(osc), Ok(gain)) = (ctx.create_oscillator(), ctx.create_gain()) {
+                gain.gain().set_value(0.4);
+                osc.set_type(web_sys::OscillatorType::Square);
+                osc.frequency().set_value(660.0);
+                let _ = osc.connect_with_audio_node(&gain);
+                let _ = gain.connect_with_audio_node(&ctx.destination());
+                let at = start + (i as f64) * gap;
+                let _ = osc.start_with_when(at);
+                let _ = osc.stop_with_when(at + beep);
+            }
+        }
+    }
+}
+
+/// Capture the given pointer on the quick-timer element so drag move/up events
+/// keep arriving even after the cursor leaves the small element's bounds.
+#[cfg(target_arch = "wasm32")]
+fn capture_quick_timer_pointer(pointer_id: i32) {
+    if let Some(el) = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.get_element_by_id("quick-timer"))
+    {
+        let _ = el.set_pointer_capture(pointer_id);
+    }
+}
+
+/// State of the ref-only quick timer beside the stone counter.
+#[derive(Clone, PartialEq)]
+enum QuickTimer {
+    /// Showing the ⏱ icon.
+    Idle,
+    /// Finger down; previewing a value derived from drag magnitude.
+    Dragging { start_stones: u32 },
+    /// Counting down from start_stones since start_time (server unix seconds).
+    Running { start_time: f64, start_stones: u32 },
+}
+
 /// Compute scores_by_set from points array (client-authoritative; same logic as server).
 fn scores_by_set_from_points(points: &[&Value]) -> Vec<(String, u64, u64)> {
     let mut by_set: std::collections::BTreeMap<u64, (u64, u64)> = std::collections::BTreeMap::new();
@@ -168,6 +214,27 @@ fn stones_elapsed_beats_ms(stamp_opt: Option<&str>, end_opt: Option<&str>) -> u3
     let start_beat = (start / BEAT).floor() as i64;
     let end_beat = (end / BEAT).floor() as i64;
     (end_beat - start_beat).max(0) as u32
+}
+
+/// Px of drag magnitude per 5 stones when arming the quick timer.
+const PX_PER_5: f64 = 12.0;
+/// Global beat length (seconds) for the quick timer countdown.
+const QUICK_TIMER_BEAT: f64 = 1.5;
+
+/// Radial drag magnitude (px) -> stones, snapped to the nearest multiple of 5.
+fn drag_magnitude_to_stones(dx: f64, dy: f64) -> u32 {
+    let magnitude = (dx * dx + dy * dy).sqrt();
+    let steps = (magnitude / PX_PER_5).round();
+    (steps.max(0.0) as u32) * 5
+}
+
+/// Stones remaining for a running quick timer: start_stones minus the number of
+/// global 1.5s beat boundaries crossed between start_time and now_server (both
+/// server-synced unix seconds). Can go negative (-1 signals "return to idle").
+fn quick_timer_current(start_time: f64, start_stones: u32, now_server: f64) -> i64 {
+    let start_beat = (start_time / QUICK_TIMER_BEAT).floor() as i64;
+    let now_beat = (now_server / QUICK_TIMER_BEAT).floor() as i64;
+    start_stones as i64 - (now_beat - start_beat).max(0)
 }
 
 /// Stones elapsed = global 1.5s beat boundaries crossed. Uses Bayesian filter for server time when end is None (ongoing point).
@@ -272,6 +339,16 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
         }
     }
 
+    // Ref-only quick timer beside the stone counter (local, not persisted).
+    // Declared before the server-time sync effect so that effect can react to it.
+    let mut quick_timer = use_signal(|| QuickTimer::Idle);
+    // Page coordinates captured at pointerdown, for computing drag magnitude.
+    #[cfg(target_arch = "wasm32")]
+    let mut quick_drag_start = use_signal(|| None as Option<(f64, f64)>);
+    // Edge latch so the end tone fires once when the countdown reaches zero.
+    #[cfg(target_arch = "wasm32")]
+    let mut quick_timer_fired_zero = use_signal(|| false);
+
     // Bayesian filter for server time sync (stones elapsed during ongoing point).
     #[cfg(target_arch = "wasm32")]
     let time_filter = use_signal(|| BayesianOffsetFilter::default());
@@ -289,8 +366,10 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
             let guard = binding.try_read();
             let Ok(ref g) = guard else { return };
             let Some(Ok(d)) = g.as_ref() else { return };
-            if d.match_data.set_type.as_deref() == Some("STONES")
-                && d.match_data.status == "IN_PROGRESS"
+            let quick_timer_running = matches!(quick_timer(), QuickTimer::Running { .. });
+            if quick_timer_running
+                || (d.match_data.set_type.as_deref() == Some("STONES")
+                    && d.match_data.status == "IN_PROGRESS")
             {
                 server_time_loop_started.set(true);
                 let mut filter = time_filter;
@@ -987,7 +1066,14 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     .winner-option.active{background:#0d6efd;color:#fff;border-color:#0d6efd}\
                     .winner-option .winner-avatar{width:26px;height:26px;border-radius:50%;object-fit:cover;flex-shrink:0}\
                     .winner-option .winner-name{min-width:3ch;max-width:12em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}\
+                    #quick-timer{position:relative;flex:0 0 auto;min-width:3.5rem;padding:0 0.75rem;font-size:1.75rem;line-height:1;cursor:pointer;touch-action:none;border:1px solid #dee2e6;border-radius:0.375rem;background:#fff;color:#212529}\
+                    #quick-timer:hover{background:#f8f9fa}\
+                    #quick-timer.qt-dragging{z-index:2001;background:#fff;box-shadow:0 0 0 4px rgba(13,110,253,0.5)}\
+                    #quick-timer-scrim{position:fixed;inset:0;z-index:2000;background:rgba(0,0,0,0.6);pointer-events:none;display:flex;align-items:flex-start;justify-content:center}\
+                    #quick-timer-scrim .qt-scrim-text{margin-top:20vh;color:#fff;text-align:center;font-size:1.5rem;line-height:1.5}\
+                    #quick-timer-scrim .qt-scrim-title{font-size:2rem;font-weight:600}\
                     @media (max-width:768px){.mobile-button-wrapper{position:fixed;bottom:0;left:0;right:0;z-index:1000;background:white;padding:0;margin:0;box-shadow:0 -2px 10px rgba(0,0,0,0.1);display:flex;flex-direction:row}\
+                    #quick-timer{position:fixed;top:64px;right:8px;z-index:1030;min-width:3rem;height:3rem;padding:0 0.5rem;font-size:1.5rem;box-shadow:0 2px 6px rgba(0,0,0,0.2)}\
                     .mobile-button-wrapper .btn{border-radius:0;margin:0;flex:1;min-height:96px}\
                     .container .mobile-sticky-button,.container #finalize-match-btn{display:none}\
                     #score-stones-card .card-body{padding:0.5rem}\
@@ -1416,9 +1502,111 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         }
                     })
                     .collect();
+
+                // Quick timer: derive display + drive end-tone/transitions each tick.
+                let _ = live_tick();
+                let quick_timer_label: Option<String> = match quick_timer() {
+                    QuickTimer::Idle => None,
+                    QuickTimer::Dragging { start_stones } => Some(start_stones.to_string()),
+                    QuickTimer::Running { start_time, start_stones } => {
+                        #[cfg(target_arch = "wasm32")]
+                        let now_server = js_sys::Date::now() / 1000.0 + time_filter.read().get_mean();
+                        #[cfg(not(target_arch = "wasm32"))]
+                        let now_server = now_epoch_secs();
+                        let current = quick_timer_current(start_time, start_stones, now_server);
+                        if current <= -1 {
+                            quick_timer.set(QuickTimer::Idle);
+                            #[cfg(target_arch = "wasm32")]
+                            quick_timer_fired_zero.set(false);
+                            None
+                        } else {
+                            #[cfg(target_arch = "wasm32")]
+                            {
+                                if current == 0 && !quick_timer_fired_zero() {
+                                    quick_timer_fired_zero.set(true);
+                                    spawn(async move {
+                                        gloo_timers::future::TimeoutFuture::new(0).await;
+                                        play_timer_end_beeps();
+                                    });
+                                }
+                            }
+                            Some(current.max(0).to_string())
+                        }
+                    }
+                };
+                let quick_timer_is_idle = quick_timer_label.is_none();
+                let quick_timer_dragging = matches!(quick_timer(), QuickTimer::Dragging { .. });
+                // Single quick-timer element; CSS positions it (right of the Start Point button on
+                // wide screens, fixed top-right corner on narrow). Rendered for all match types.
+                // While dragging it gets `qt-dragging` to lift above the full-screen scrim.
+                #[cfg(target_arch = "wasm32")]
+                let quick_timer_el = rsx! {
+                    div {
+                        id: "quick-timer",
+                        class: if quick_timer_dragging { "d-flex align-items-center justify-content-center user-select-none qt-dragging" } else { "d-flex align-items-center justify-content-center user-select-none" },
+                        title: "Quick timer: drag to set",
+                        onpointerdown: move |ev: Event<PointerData>| {
+                            // Capture the pointer so move/up events keep arriving after the cursor
+                            // leaves this small element; otherwise the drag stalls and never releases.
+                            capture_quick_timer_pointer(ev.pointer_id());
+                            let p = ev.page_coordinates();
+                            quick_drag_start.set(Some((p.x, p.y)));
+                            quick_timer.set(QuickTimer::Dragging { start_stones: 0 });
+                        },
+                        onpointermove: move |ev: Event<PointerData>| {
+                            if let Some((sx, sy)) = quick_drag_start() {
+                                let p = ev.page_coordinates();
+                                let stones = drag_magnitude_to_stones(p.x - sx, p.y - sy);
+                                quick_timer.set(QuickTimer::Dragging { start_stones: stones });
+                            }
+                        },
+                        onpointerup: move |_| {
+                            if quick_drag_start().is_some() {
+                                quick_drag_start.set(None);
+                                if let QuickTimer::Dragging { start_stones } = quick_timer() {
+                                    if start_stones == 0 {
+                                        quick_timer.set(QuickTimer::Idle);
+                                    } else {
+                                        let now_server = js_sys::Date::now() / 1000.0 + time_filter.read().get_mean();
+                                        quick_timer_fired_zero.set(false);
+                                        quick_timer.set(QuickTimer::Running { start_time: now_server, start_stones });
+                                    }
+                                }
+                            }
+                        },
+                        onpointercancel: move |_| {
+                            // Browser cancelled the gesture (e.g. scroll): abandon the in-progress
+                            // drag without arming a timer, and clear the stale start point.
+                            if quick_drag_start().is_some() {
+                                quick_drag_start.set(None);
+                                if matches!(quick_timer(), QuickTimer::Dragging { .. }) {
+                                    quick_timer.set(QuickTimer::Idle);
+                                }
+                            }
+                        },
+                        if quick_timer_is_idle {
+                            "⏱"
+                        } else {
+                            "{quick_timer_label.clone().unwrap_or_default()}"
+                        }
+                    }
+                };
+                #[cfg(not(target_arch = "wasm32"))]
+                let quick_timer_el = rsx! {
+                    div { id: "quick-timer", "⏱" }
+                };
+
                 rsx! {
                     div { class: "container mt-4",
                         style { "{run_match_css}" }
+                        if quick_timer_dragging {
+                            div { id: "quick-timer-scrim",
+                                div { class: "qt-scrim-text",
+                                    div { class: "qt-scrim-title", "Stone Timer Utility" }
+                                    div { "drag to set time" }
+                                }
+                            }
+                        }
                         div { class: "row",
                             div { class: "col-md-12",
                                 h2 { "Run Match: {m.name}" }
@@ -1546,14 +1734,17 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                                     }
                                                 }
                                                 div { class: "row mt-3",
-                                                    div { class: "col-12",
-                                                        button {
-                                                            id: "point-button",
-                                                            class: "{point_button_class}",
-                                                            onclick: on_start_end_point,
-                                                            disabled: point_button_disabled,
-                                                            "{point_button_text}"
+                                                    div { class: "col-12 d-flex align-items-stretch gap-2",
+                                                        div { class: "flex-grow-1",
+                                                            button {
+                                                                id: "point-button",
+                                                                class: "{point_button_class}",
+                                                                onclick: on_start_end_point,
+                                                                disabled: point_button_disabled,
+                                                                "{point_button_text}"
+                                                            }
                                                         }
+                                                        {quick_timer_el}
                                                     }
                                                 }
                                             }
@@ -2167,4 +2358,43 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
         Err(_) => rsx! { p { "Loading…" } },
     };
     rsx! { {detail_view} }
+}
+
+#[cfg(test)]
+mod quick_timer_tests {
+    use super::{drag_magnitude_to_stones, quick_timer_current};
+
+    #[test]
+    fn magnitude_snaps_to_multiples_of_five() {
+        assert_eq!(drag_magnitude_to_stones(0.0, 0.0), 0);
+        // 12px per 5 stones; ~6px (half step) rounds to 5.
+        assert_eq!(drag_magnitude_to_stones(6.5, 0.0), 5);
+        // 24px -> 10, direction-independent (use y, and negatives).
+        assert_eq!(drag_magnitude_to_stones(0.0, -24.0), 10);
+        // 3-4-5 triangle: magnitude 60px -> 25 stones.
+        assert_eq!(drag_magnitude_to_stones(36.0, 48.0), 25);
+        // Small jitter below half a step stays 0 (tap cancel).
+        assert_eq!(drag_magnitude_to_stones(3.0, 0.0), 0);
+    }
+
+    #[test]
+    fn current_counts_down_on_beat_boundaries() {
+        // start at t=0.0 with 20 stones.
+        assert_eq!(quick_timer_current(0.0, 20, 0.0), 20);
+        // just before first beat boundary (1.5s) -> still 20.
+        assert_eq!(quick_timer_current(0.0, 20, 1.49), 20);
+        // crossed one boundary -> 19.
+        assert_eq!(quick_timer_current(0.0, 20, 1.5), 19);
+        // 30s -> 20 boundaries -> 0.
+        assert_eq!(quick_timer_current(0.0, 20, 30.0), 0);
+        // one more beat past zero -> -1.
+        assert_eq!(quick_timer_current(0.0, 20, 31.5), -1);
+    }
+
+    #[test]
+    fn current_uses_floor_of_both_endpoints() {
+        // start mid-beat: flooring both endpoints means elapsed counts
+        // global boundaries crossed, not raw elapsed / 1.5.
+        assert_eq!(quick_timer_current(0.4, 5, 1.6), 4);
+    }
 }

--- a/frontend/src/pages/run_match.rs
+++ b/frontend/src/pages/run_match.rs
@@ -1083,9 +1083,8 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     #quick-timer-scrim .qt-scrim-text{margin-top:20vh;color:#fff;text-align:center;font-size:1.5rem;line-height:1.5}\
                     #quick-timer-scrim .qt-scrim-title{font-size:2rem;font-weight:600}\
                     @keyframes point-row-flash-kf{0%{background-color:#adb5bd}100%{background-color:transparent}}\
-                    @keyframes point-row-slide-kf{0%{transform:translateY(-8px);opacity:0.4}100%{transform:translateY(0);opacity:1}}\
                     tr.point-row-flash>td{animation:point-row-flash-kf 1.1s ease-out}\
-                    tr.point-row-flash>td>*{animation:point-row-slide-kf 0.25s ease-out}\
+                    #points-table tr.point-row-no-border>td{border-bottom-width:0}\
                     @media (max-width:768px){.mobile-button-wrapper{position:fixed;bottom:0;left:0;right:0;z-index:1000;background:white;padding:0;margin:0;box-shadow:0 -2px 10px rgba(0,0,0,0.1);display:flex;flex-direction:row}\
                     #quick-timer{position:fixed;top:64px;right:8px;z-index:1030;min-width:3rem;height:3rem;padding:0 0.5rem;font-size:1.5rem;box-shadow:0 2px 6px rgba(0,0,0,0.2)}\
                     .mobile-button-wrapper .btn{border-radius:0;margin:0;flex:1;min-height:96px}\
@@ -1139,11 +1138,20 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let winner_is_t1 = winner_val == "TEAM1";
                         let winner_is_t2 = winner_val == "TEAM2";
                         let notes_for_point = point_notes_map_signal().get(&pid_list).cloned().unwrap_or_default();
+                        let has_notes = !notes_for_point.is_empty();
+                        // When a point has penalties, drop the main row's bottom border so the grey
+                        // separator falls below the penalties (which belong to this point), not above them.
+                        let main_row_class = match (is_flash, has_notes) {
+                            (true, true) => "point-row-flash point-row-no-border",
+                            (true, false) => "point-row-flash",
+                            (false, true) => "point-row-no-border",
+                            (false, false) => "",
+                        };
                         rsx! {
                             tr {
                                 key: "{pt_id}",
                                 id: "point-row-{pt_id}",
-                                class: if is_flash { "point-row-flash" } else { "" },
+                                class: "{main_row_class}",
                                 td { class: "text-muted text-center align-middle", "{point_index}" }
                                 td {
                                     div { class: "set-number-controls",
@@ -1473,9 +1481,9 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                     }
                                 }
                             }
-                            if !notes_for_point.is_empty() {
+                            if has_notes {
                                 tr { key: "{pt_id}-notes",
-                                    td { colspan: "7", class: "pt-0 pb-2 border-0",
+                                    td { colspan: "7", class: "pt-0 pb-2",
                                         div { class: "d-flex flex-wrap gap-1",
                                             for note_val in notes_for_point.iter() {
                                                 {

--- a/frontend/src/pages/run_match.rs
+++ b/frontend/src/pages/run_match.rs
@@ -502,6 +502,8 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
     // Local stones remaining (for STONES set type); synced from match/state when not ticking.
     // None means the count is not yet known (neither stones_remaining nor stones_per_set is set).
     let mut stones_remaining = use_signal(|| None as Option<u32>);
+    // uuid of the most recently added point, to play a one-shot slide-in/highlight on its row.
+    let mut flash_point_id = use_signal(|| None as Option<String>);
     // When true, stones input shows stones_edit_value so we don't overwrite typing with display_stones.
     let mut stones_input_focused = use_signal(|| false);
     let mut stones_edit_value = use_signal(|| String::new());
@@ -819,6 +821,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                             state_signal.set(Some(Ok(state)));
                         }
                         current_point.set(Some(pending_id.clone()));
+                        flash_point_id.set(Some(pending_id.clone()));
                         let stones_at_start = if set_type_stones { stones_val } else { None };
                         spawn(async move {
                             err_out.set(None);
@@ -854,6 +857,9 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                                 }
                                             }
                                             state_signal.set(Some(Ok(state)));
+                                        }
+                                        if flash_point_id().as_deref() == Some(pending_id.as_str()) {
+                                            flash_point_id.set(Some(real_id.clone()));
                                         }
                                         current_point.set(Some(real_id));
                                     }
@@ -978,6 +984,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                             state_signal.set(Some(Ok(state)));
                         }
                         current_point.set(Some(pending_id.clone()));
+                        flash_point_id.set(Some(pending_id.clone()));
                         let stones_at_start = if set_type_stones { stones_val } else { None };
                         spawn(async move {
                             err_out.set(None);
@@ -1013,6 +1020,9 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                                 }
                                             }
                                             state_signal.set(Some(Ok(state)));
+                                        }
+                                        if flash_point_id().as_deref() == Some(pending_id.as_str()) {
+                                            flash_point_id.set(Some(real_id.clone()));
                                         }
                                         current_point.set(Some(real_id));
                                     }
@@ -1072,6 +1082,10 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     #quick-timer-scrim{position:fixed;inset:0;z-index:2000;background:rgba(0,0,0,0.6);pointer-events:none;display:flex;align-items:flex-start;justify-content:center}\
                     #quick-timer-scrim .qt-scrim-text{margin-top:20vh;color:#fff;text-align:center;font-size:1.5rem;line-height:1.5}\
                     #quick-timer-scrim .qt-scrim-title{font-size:2rem;font-weight:600}\
+                    @keyframes point-row-flash-kf{0%{background-color:#adb5bd}100%{background-color:transparent}}\
+                    @keyframes point-row-slide-kf{0%{transform:translateY(-8px);opacity:0.4}100%{transform:translateY(0);opacity:1}}\
+                    tr.point-row-flash>td{animation:point-row-flash-kf 1.1s ease-out}\
+                    tr.point-row-flash>td>*{animation:point-row-slide-kf 0.25s ease-out}\
                     @media (max-width:768px){.mobile-button-wrapper{position:fixed;bottom:0;left:0;right:0;z-index:1000;background:white;padding:0;margin:0;box-shadow:0 -2px 10px rgba(0,0,0,0.1);display:flex;flex-direction:row}\
                     #quick-timer{position:fixed;top:64px;right:8px;z-index:1030;min-width:3rem;height:3rem;padding:0 0.5rem;font-size:1.5rem;box-shadow:0 2px 6px rgba(0,0,0,0.2)}\
                     .mobile-button-wrapper .btn{border-radius:0;margin:0;flex:1;min-height:96px}\
@@ -1093,6 +1107,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     .map(|r| {
                         let pt_id = r.point_id.as_str();
                         let point_index = r.index;
+                        let is_flash = flash_point_id().as_deref() == Some(pt_id);
                         let set_num = r.set_num;
                         let winner_val = r.winner.as_str();
                         let rerolled = r.rerolled;
@@ -1125,7 +1140,10 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let winner_is_t2 = winner_val == "TEAM2";
                         let notes_for_point = point_notes_map_signal().get(&pid_list).cloned().unwrap_or_default();
                         rsx! {
-                            tr { key: "{pt_id}", id: "point-row-{pt_id}",
+                            tr {
+                                key: "{pt_id}",
+                                id: "point-row-{pt_id}",
+                                class: if is_flash { "point-row-flash" } else { "" },
                                 td { class: "text-muted text-center align-middle", "{point_index}" }
                                 td {
                                     div { class: "set-number-controls",


### PR DESCRIPTION
## Summary

a collection of QoL improvements to the run match page, post HSO and MHO.

## What changed

- start/end match buttons are larger
- list of points in match is reversed so you can keep the latest point and the score table + stones in view at the same time
- when a point starts, the newly added row flashes grey as an indicator that it was added
- makes some beeps at 15 stones remaining, for stones-based matches (so you don't forget to count)
- fix bug where you can't reset to 100 stones because 100 was used as a sentinel value :skull: 
- remove "None" option for winner, now just deselect the winner and leave both teams unselected. makes it more compact
- use shortnames for the winner selection options
- confirm dialog before delete point
- utility timer: click and drag to set little timer in stones. 

## Screenshots / repro

https://photos.cftocp.gay/share/wNOAeSUD-POtkSn5Xy27QP4ui_S7msoSd7QAq9kDEUnAGPcLf-VNAyG_8ipaspTNGB0

---

### Pre-review checklist

<!-- Strike through (~~item~~) anything that doesn't apply, rather than
     deleting, so reviewers can see you thought about it. -->

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [x] Targeting `dev`, not `main` (unless this is a release PR).
- [ ] ~~`just lint` and `just format` are clean.~~ (this is just frontend)
- [ ] ~~Tests added or updated for the new behavior.~~
- [ ] ~~If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated.~~
- [ ] ~~If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.~~
- [x] No merge conflicts with the base branch.
