### PR TITLE
[Feature] Tunable Stones!

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -187,7 +187,7 @@ With the above goals in mind, Arctos has been designed to be:
 Arctos is an open-source project, hosted on
 [github](https://github.com/reid23/arctos) and licensed with
 GPLv3. Anyone can view the source code and propose their own changes
-by forking the repository, commiting changes, and opening a pull
+by forking the repository, committing changes, and opening a pull
 request. If you are interested in contributing, please see see the
 [contributing guide](https://github.com/reid23/arctos/CONTRIBUTING.md)
 for more information.
@@ -257,7 +257,7 @@ Here's, briefly, how it works.
      just the points and displayed in the same place as the live
      stream footage.
   2. TOs set up stones, playing them from the stones player. Multiple
-     devices can be used to play syncronized stones from multiple
+     devices can be used to play synchronized stones from multiple
      speakers.
   3. Players check the schedule to see when they need to play.
      - guarantees provided by the dynamic scheduling system ensure
@@ -302,7 +302,7 @@ devices have very good clocks, so once we compute the offset between
 our clock and the server's clock, clients know exactly when stones are
 played, without needing any expensive low-latency network shenanigans.
 
-When head refs run games, we use this to syncronize the stone counter
+When head refs run games, we use this to synchronize the stone counter
 on their device with the actual stones being played on the field, so
 their device counts stones precisely just based on when they start and
 stop the point locally, regardless of the server ping time.
@@ -318,8 +318,10 @@ play from two separate devices and it'll be in sync.
     putting the devices in question right next to each other and see
     if the issue persists. Unfortunately there's nothing I can do
     about this issue :\(
-
-
+	
+If you use a bluetooth speaker, you'll need to do a quick calibration
+to compensate for the bluetooth delay. This tends to be somewhere on
+the order of 200ms.
 
 ## Account Types
 
@@ -485,7 +487,7 @@ All matches have (among other things) the following information:
 ### Tags and References: Specifying Teams
 
 Each match as two teams playing in it as well as any number of teams
-assigned to ref. Let's take a breif aside on how to specify teams. You
+assigned to ref. Let's take a brief aside on how to specify teams. You
 have three options:
 
   1. explicit team name: just type their name (autocomplete will help
@@ -718,4 +720,3 @@ this may take a while, since it involves re-encoding all of the video.
 If you want to add overlays like the scoreboard, you'll still need to
 run OBS and use a virtual camera setup to pass the feed to the
 recording page.
-

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -38,8 +38,11 @@ web-sys = { version = "0.3", features = [
     "MediaDeviceInfo", "MediaStreamTrack",
     "Storage",
     "StorageManager",
+    "StorageEvent",
 ] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+dioxus-web = "0.7"
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 gloo-timers = { version = "0.3", features = ["futures"] }
 idb = "0.6"
 js-sys = "0.3"

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -10,6 +10,7 @@ mod url_slug;
 #[cfg(target_arch = "wasm32")]
 mod record_idb;
 mod stones_filter;
+mod time_sync;
 mod types;
 
 use dioxus::prelude::*;

--- a/frontend/src/pages/match_page.rs
+++ b/frontend/src/pages/match_page.rs
@@ -3,7 +3,6 @@ use crate::api;
 use crate::components::{PenaltyDisplay, all_tokens_known, resolve_value_to_team_ids};
 use crate::display::short_or_truncate;
 use crate::pages::TeamSelectionField;
-use crate::stones_filter::BayesianOffsetFilter;
 use crate::time_format::format_match_display_local;
 use crate::types::{
     ConflictingMatchInfo, ForceStartMatchRequest, MatchDetailData, PointData, PointTimestamp,
@@ -341,7 +340,7 @@ fn parse_iso_to_secs(s: &str) -> Option<f64> {
 fn compute_stones_elapsed(
     start_stamp: Option<&str>,
     end_stamp: Option<&str>,
-    filter: &Signal<BayesianOffsetFilter>,
+    time_sync: &crate::time_sync::TimeSync,
 ) -> String {
     const BEAT: f64 = 1.5;
 
@@ -352,10 +351,7 @@ fn compute_stones_elapsed(
 
     let end = match end_stamp.and_then(|s| parse_iso_to_secs(s)) {
         Some(secs) => secs,
-        None => {
-            let client_time = js_sys::Date::now() / 1000.0;
-            client_time + filter.read().get_mean()
-        }
+        None => time_sync.server_now_secs(),
     };
 
     let start_beat = (start / BEAT).floor() as i64;
@@ -368,7 +364,7 @@ fn compute_stones_elapsed(
 #[cfg(target_arch = "wasm32")]
 fn compute_stones_remaining(
     points: &[&crate::types::PointData],
-    filter: &Signal<BayesianOffsetFilter>,
+    time_sync: &crate::time_sync::TimeSync,
 ) -> String {
     if points.is_empty() {
         return "??".to_string();
@@ -382,7 +378,7 @@ fn compute_stones_remaining(
     if last_point_is_ongoing {
         if let Some(stones_at_start) = last_point.stones_at_start {
             if let Some(start_stamp) = &last_point.stamp {
-                let elapsed_str = compute_stones_elapsed(Some(start_stamp), None, filter);
+                let elapsed_str = compute_stones_elapsed(Some(start_stamp), None, time_sync);
                 if let Ok(elapsed) = elapsed_str.parse::<u32>() {
                     let remaining = stones_at_start.saturating_sub(elapsed);
                     return remaining.to_string();
@@ -397,7 +393,7 @@ fn compute_stones_remaining(
             if let Some(stones_at_start) = pt.stones_at_start {
                 if let (Some(start_stamp), Some(end_stamp)) = (&pt.stamp, &pt.end_stamp) {
                     let elapsed_str =
-                        compute_stones_elapsed(Some(start_stamp), Some(end_stamp), filter);
+                        compute_stones_elapsed(Some(start_stamp), Some(end_stamp), time_sync);
                     if let Ok(elapsed) = elapsed_str.parse::<u32>() {
                         let remaining = stones_at_start.saturating_sub(elapsed);
                         return remaining.to_string();
@@ -922,33 +918,10 @@ fn match_page_inner(url: String, match_id: Option<String>, match_name: Option<St
     let user_info = use_resource(move || async move { api::me().await.ok() });
 
     // Bayesian filter for server time sync (for stones elapsed calculation)
-    #[cfg(target_arch = "wasm32")]
-    let time_filter = use_signal(|| BayesianOffsetFilter::default());
-
-    #[cfg(target_arch = "wasm32")]
-    {
-        use_effect(move || {
-            if let Some(Ok(d)) = data.value().read().as_ref() {
-                if d.match_data.status == "IN_PROGRESS"
-                    && d.match_data.set_type.as_deref() == Some("STONES")
-                {
-                    let mut filter = time_filter;
-                    spawn(async move {
-                        loop {
-                            let client_send = js_sys::Date::now() / 1000.0;
-                            if let Ok(res) = api::server_time().await {
-                                let client_receive = js_sys::Date::now() / 1000.0;
-                                let rtt = client_receive - client_send;
-                                let offset = res.server_time - client_receive + (rtt / 2.0);
-                                filter.write().update(offset);
-                            }
-                            gloo_timers::future::TimeoutFuture::new(997).await;
-                        }
-                    });
-                }
-            }
-        });
-    }
+    // Shared client-server time sync (converges to the server clock; the probe
+    // loop lives in the module).
+    #[cfg_attr(not(target_arch = "wasm32"), allow(unused_variables))]
+    let time_sync = crate::time_sync::use_time_sync();
 
     // Stones elapsed update interval (for ongoing points)
     #[cfg(target_arch = "wasm32")]
@@ -2121,12 +2094,12 @@ fn match_page_inner(url: String, match_id: Option<String>, match_name: Option<St
                                         let between_points = !points_refs.is_empty() && !last_ongoing;
                                         if between_points {
                                         if let Some(Ok(state)) = state_signal.read().as_ref() {
-                                            state.get("stones_remaining").and_then(|v| v.as_u64()).map(|s| s.to_string()).unwrap_or_else(|| compute_stones_remaining(&points_refs, &time_filter))
+                                            state.get("stones_remaining").and_then(|v| v.as_u64()).map(|s| s.to_string()).unwrap_or_else(|| compute_stones_remaining(&points_refs, &time_sync))
                                         } else {
-                                            compute_stones_remaining(&points_refs, &time_filter)
+                                            compute_stones_remaining(&points_refs, &time_sync)
                                         }
                                         } else {
-                                            compute_stones_remaining(&points_refs, &time_filter)
+                                            compute_stones_remaining(&points_refs, &time_sync)
                                         }
                                     };
                                     #[cfg(not(target_arch = "wasm32"))]
@@ -2317,7 +2290,7 @@ fn match_page_inner(url: String, match_id: Option<String>, match_name: Option<St
                                                                                     compute_stones_elapsed(
                                                                                         pt.stamp.as_deref(),
                                                                                         pt.end_stamp.as_deref(),
-                                                                                        &time_filter,
+                                                                                        &time_sync,
                                                                                     )
                                                                                 }
                                                                                 #[cfg(not(target_arch = "wasm32"))] { "0" }

--- a/frontend/src/pages/match_page.rs
+++ b/frontend/src/pages/match_page.rs
@@ -917,7 +917,6 @@ fn match_page_inner(url: String, match_id: Option<String>, match_name: Option<St
     // User info for permissions
     let user_info = use_resource(move || async move { api::me().await.ok() });
 
-    // Bayesian filter for server time sync (for stones elapsed calculation)
     // Shared client-server time sync (converges to the server clock; the probe
     // loop lives in the module).
     #[cfg_attr(not(target_arch = "wasm32"), allow(unused_variables))]

--- a/frontend/src/pages/run_match.rs
+++ b/frontend/src/pages/run_match.rs
@@ -1,7 +1,6 @@
 use crate::Route;
 use crate::api;
 use crate::components::PenaltyDisplay;
-use crate::stones_filter::BayesianOffsetFilter;
 use dioxus::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use gloo_timers::callback::Interval;
@@ -431,12 +430,13 @@ fn quick_timer_current(start_time: f64, start_stones: u32, now_server: f64) -> i
     start_stones as i64 - (now_beat - start_beat).max(0)
 }
 
-/// Stones elapsed = global 1.5s beat boundaries crossed. Uses Bayesian filter for server time when end is None (ongoing point).
+/// Stones elapsed = global 1.5s beat boundaries crossed. Uses the shared time
+/// sync for corrected server time when end is None (ongoing point).
 #[cfg(target_arch = "wasm32")]
 fn stones_elapsed_with_filter(
     stamp_opt: Option<&str>,
     end_opt: Option<&str>,
-    filter: &Signal<BayesianOffsetFilter>,
+    time_sync: &crate::time_sync::TimeSync,
 ) -> u32 {
     const BEAT: f64 = 1.5;
     let start = match stamp_opt.and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok()) {
@@ -447,12 +447,10 @@ fn stones_elapsed_with_filter(
         if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(e) {
             parsed.timestamp_millis() as f64 / 1000.0
         } else {
-            let client_time = js_sys::Date::now() / 1000.0;
-            client_time + filter.read().get_mean()
+            time_sync.server_now_secs()
         }
     } else {
-        let client_time = js_sys::Date::now() / 1000.0;
-        client_time + filter.read().get_mean()
+        time_sync.server_now_secs()
     };
     let start_beat = (start / BEAT).floor() as i64;
     let end_beat = (end / BEAT).floor() as i64;
@@ -475,6 +473,19 @@ fn team_short_label(shortname: Option<&str>, name: &str) -> String {
         let head: String = name.chars().take(max_len - 1).collect();
         format!("{head}…")
     }
+}
+
+/// Corrected-server-time millis for the moment a point starts, so its anchor
+/// lands on the same grid the stone counter uses.
+fn point_start_server_millis(time_sync: &crate::time_sync::TimeSync) -> u64 {
+    (time_sync.server_now_secs() * 1000.0).round() as u64
+}
+
+/// Convert unix-epoch millis to an RFC3339 string for the optimistic local point.
+fn server_millis_to_rfc3339(millis: u64) -> String {
+    chrono::DateTime::from_timestamp_millis(millis as i64)
+        .unwrap_or_else(chrono::Utc::now)
+        .to_rfc3339()
 }
 
 #[component]
@@ -534,7 +545,6 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
     }
 
     // Ref-only quick timer beside the stone counter (local, not persisted).
-    // Declared before the server-time sync effect so that effect can react to it.
     let mut quick_timer = use_signal(|| QuickTimer::Idle);
     // Page coordinates captured at pointerdown, for computing drag magnitude.
     #[cfg(target_arch = "wasm32")]
@@ -543,45 +553,9 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
     #[cfg(target_arch = "wasm32")]
     let mut quick_timer_fired_zero = use_signal(|| false);
 
-    // Bayesian filter for server time sync (stones elapsed during ongoing point).
-    #[cfg(target_arch = "wasm32")]
-    let time_filter = use_signal(|| BayesianOffsetFilter::default());
-    #[cfg(target_arch = "wasm32")]
-    let server_time_loop_started = use_signal(|| false);
-    #[cfg(target_arch = "wasm32")]
-    {
-        let binding = detail.value();
-        let mut time_filter = time_filter;
-        let mut server_time_loop_started = server_time_loop_started;
-        use_effect(move || {
-            if server_time_loop_started() {
-                return;
-            }
-            let guard = binding.try_read();
-            let Ok(ref g) = guard else { return };
-            let Some(Ok(d)) = g.as_ref() else { return };
-            let quick_timer_running = matches!(quick_timer(), QuickTimer::Running { .. });
-            if quick_timer_running
-                || (d.match_data.set_type.as_deref() == Some("STONES")
-                    && d.match_data.status == "IN_PROGRESS")
-            {
-                server_time_loop_started.set(true);
-                let mut filter = time_filter;
-                spawn(async move {
-                    loop {
-                        let client_send = js_sys::Date::now() / 1000.0;
-                        if let Ok(res) = api::server_time().await {
-                            let client_receive = js_sys::Date::now() / 1000.0;
-                            let rtt = client_receive - client_send;
-                            let offset = res.server_time - client_receive + (rtt / 2.0);
-                            filter.write().update(offset);
-                        }
-                        gloo_timers::future::TimeoutFuture::new(997).await;
-                    }
-                });
-            }
-        });
-    }
+    // Shared client-server time sync (stones elapsed during an ongoing point,
+    // quick timer countdown, and server-time stamping of new points).
+    let time_sync = crate::time_sync::use_time_sync();
 
     // Screen wake lock: keep the device awake while the match page is open (wasm only).
     #[cfg(target_arch = "wasm32")]
@@ -831,7 +805,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let stamp = pt.get("stamp").and_then(|s| s.as_str());
                         let end_stamp = pt.get("end_stamp").and_then(|e| e.as_str());
                         #[cfg(target_arch = "wasm32")]
-                        let elapsed = stones_elapsed_with_filter(stamp, end_stamp, &time_filter);
+                        let elapsed = stones_elapsed_with_filter(stamp, end_stamp, &time_sync);
                         #[cfg(not(target_arch = "wasm32"))]
                         let elapsed = stones_elapsed_beats(stamp, end_stamp);
                         PointRow {
@@ -858,8 +832,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                     pt.get("stones_at_start").and_then(|s| s.as_u64())?;
                                 let stamp = pt.get("stamp").and_then(|s| s.as_str());
                                 #[cfg(target_arch = "wasm32")]
-                                let elapsed =
-                                    stones_elapsed_with_filter(stamp, None, &time_filter) as u64;
+                                let elapsed = stones_elapsed_with_filter(stamp, None, &time_sync) as u64;
                                 #[cfg(not(target_arch = "wasm32"))]
                                 let elapsed = stones_elapsed_beats(stamp, None) as u64;
                                 Some((at_start.saturating_sub(elapsed)) as u32)
@@ -935,6 +908,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let id_for_stones = id.clone();
                         let u_for_stones = u.clone();
                         spawn(async move {
+                            #[cfg(target_arch = "wasm32")]
                             gloo_timers::future::TimeoutFuture::new(0).await;
                             let mut final_stones_for_api: Option<u32> = None;
                             if let Some(Ok(ref state)) = prev.clone() {
@@ -990,10 +964,12 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                             }
                         });
                     } else {
-                        // Start new point — optimistic: add pending point, set current_point
-                        let pending_id =
-                            format!("pending-{}", chrono::Utc::now().timestamp_millis());
-                        let stamp_iso = chrono::Utc::now().to_rfc3339();
+                        // Start new point — optimistic: add pending point, set current_point.
+                        // Anchor the point to corrected server time so it lands on the same
+                        // 1.5s grid the stone counter measures against.
+                        let point_start_ms = point_start_server_millis(&time_sync);
+                        let pending_id = format!("pending-{}", point_start_ms);
+                        let stamp_iso = server_millis_to_rfc3339(point_start_ms);
                         let new_point = serde_json::json!({
                             "uuid": pending_id,
                             "set_number": default_set,
@@ -1018,15 +994,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let stones_at_start = if set_type_stones { stones_val } else { None };
                         spawn(async move {
                             err_out.set(None);
-                            match api::add_point(
-                                &u,
-                                &id,
-                                default_set,
-                                Some(chrono::Utc::now().timestamp_millis() as u64),
-                                stones_at_start,
-                            )
-                            .await
-                            {
+                            match api::add_point(&u, &id, default_set, Some(point_start_ms), stones_at_start).await {
                                 Ok(resp) => {
                                     let real_id = resp
                                         .get("point_id")
@@ -1100,6 +1068,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let id_for_stones = id.clone();
                         let u_for_stones = u.clone();
                         spawn(async move {
+                            #[cfg(target_arch = "wasm32")]
                             gloo_timers::future::TimeoutFuture::new(0).await;
                             let mut final_stones_for_api: Option<u32> = None;
                             if let Some(Ok(ref state)) = prev.clone() {
@@ -1155,9 +1124,9 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                             }
                         });
                     } else {
-                        let pending_id =
-                            format!("pending-{}", chrono::Utc::now().timestamp_millis());
-                        let stamp_iso = chrono::Utc::now().to_rfc3339();
+                        let point_start_ms = point_start_server_millis(&time_sync);
+                        let pending_id = format!("pending-{}", point_start_ms);
+                        let stamp_iso = server_millis_to_rfc3339(point_start_ms);
                         let new_point = serde_json::json!({
                             "uuid": pending_id,
                             "set_number": default_set,
@@ -1182,15 +1151,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let stones_at_start = if set_type_stones { stones_val } else { None };
                         spawn(async move {
                             err_out.set(None);
-                            match api::add_point(
-                                &u,
-                                &id,
-                                default_set,
-                                Some(chrono::Utc::now().timestamp_millis() as u64),
-                                stones_at_start,
-                            )
-                            .await
-                            {
+                            match api::add_point(&u, &id, default_set, Some(point_start_ms), stones_at_start).await {
                                 Ok(resp) => {
                                     let real_id = resp
                                         .get("point_id")
@@ -1671,7 +1632,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                     } => {
                         #[cfg(target_arch = "wasm32")]
                         let now_server =
-                            js_sys::Date::now() / 1000.0 + time_filter.read().get_mean();
+                            time_sync.server_now_secs();
                         #[cfg(not(target_arch = "wasm32"))]
                         let now_server = now_epoch_secs();
                         let current = quick_timer_current(start_time, start_stones, now_server);
@@ -1733,7 +1694,7 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                                     } else {
                                         // Re-prime audio on the release gesture that arms the timer.
                                         unlock_run_match_audio();
-                                        let now_server = js_sys::Date::now() / 1000.0 + time_filter.read().get_mean();
+                                        let now_server = time_sync.server_now_secs();
                                         quick_timer_fired_zero.set(false);
                                         quick_timer.set(QuickTimer::Running { start_time: now_server, start_stones });
                                     }

--- a/frontend/src/pages/run_match.rs
+++ b/frontend/src/pages/run_match.rs
@@ -2494,14 +2494,14 @@ mod quick_timer_tests {
     #[test]
     fn magnitude_snaps_to_multiples_of_five() {
         assert_eq!(drag_magnitude_to_stones(0.0, 0.0), 0);
-        // 12px per 5 stones; ~6px (half step) rounds to 5.
-        assert_eq!(drag_magnitude_to_stones(6.5, 0.0), 5);
-        // 24px -> 10, direction-independent (use y, and negatives).
-        assert_eq!(drag_magnitude_to_stones(0.0, -24.0), 10);
-        // 3-4-5 triangle: magnitude 60px -> 25 stones.
-        assert_eq!(drag_magnitude_to_stones(36.0, 48.0), 25);
+        // 30px per 5 stones; ~15px (half step) rounds to 5.
+        assert_eq!(drag_magnitude_to_stones(15.5, 0.0), 5);
+        // 60px -> 10, direction-independent (use y, and negatives).
+        assert_eq!(drag_magnitude_to_stones(0.0, -60.0), 10);
+        // 3-4-5 triangle: magnitude 150px -> 25 stones.
+        assert_eq!(drag_magnitude_to_stones(90.0, 120.0), 25);
         // Small jitter below half a step stays 0 (tap cancel).
-        assert_eq!(drag_magnitude_to_stones(3.0, 0.0), 0);
+        assert_eq!(drag_magnitude_to_stones(10.0, 0.0), 0);
     }
 
     #[test]

--- a/frontend/src/pages/scoreboard.rs
+++ b/frontend/src/pages/scoreboard.rs
@@ -1,5 +1,4 @@
 use crate::api;
-use crate::stones_filter::BayesianOffsetFilter;
 use crate::types::ScoreboardPointForStones;
 use dioxus::prelude::*;
 #[cfg(target_arch = "wasm32")]
@@ -10,17 +9,14 @@ use gloo_timers::callback::Interval;
 fn scoreboard_stones_elapsed(
     start_stamp: Option<&str>,
     end_stamp: Option<&str>,
-    filter: &Signal<BayesianOffsetFilter>,
+    time_sync: &crate::time_sync::TimeSync,
 ) -> Option<u32> {
     const BEAT: f64 = 1.5;
     let start = start_stamp.and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())?;
     let start_secs = start.timestamp_millis() as f64 / 1000.0;
     let end_secs = match end_stamp {
         Some(e) => chrono::DateTime::parse_from_rfc3339(e).ok()?.timestamp_millis() as f64 / 1000.0,
-        None => {
-            let client_time = js_sys::Date::now() / 1000.0;
-            client_time + filter.read().get_mean()
-        }
+        None => time_sync.server_now_secs(),
     };
     let start_beat = (start_secs / BEAT).floor() as i64;
     let end_beat = (end_secs / BEAT).floor() as i64;
@@ -31,7 +27,7 @@ fn scoreboard_stones_elapsed(
 #[cfg(target_arch = "wasm32")]
 fn scoreboard_compute_stones_remaining(
     points: &[ScoreboardPointForStones],
-    filter: &Signal<BayesianOffsetFilter>,
+    time_sync: &crate::time_sync::TimeSync,
 ) -> Option<u32> {
     if points.is_empty() {
         return None;
@@ -40,7 +36,7 @@ fn scoreboard_compute_stones_remaining(
     // Ongoing point: compute from last point's stones_at_start and elapsed to now
     if last.end_stamp.is_none() {
         let stones_at_start = last.stones_at_start?;
-        let elapsed = scoreboard_stones_elapsed(last.stamp.as_deref(), None, filter)?;
+        let elapsed = scoreboard_stones_elapsed(last.stamp.as_deref(), None, time_sync)?;
         return Some(stones_at_start.saturating_sub(elapsed));
     }
     // Between points: use last completed point's remaining (stones_at_start - elapsed for that point)
@@ -48,7 +44,7 @@ fn scoreboard_compute_stones_remaining(
         if let (Some(stones_at_start), Some(start), Some(end)) =
             (pt.stones_at_start, pt.stamp.as_deref(), pt.end_stamp.as_deref())
         {
-            if let Some(elapsed) = scoreboard_stones_elapsed(Some(start), Some(end), filter) {
+            if let Some(elapsed) = scoreboard_stones_elapsed(Some(start), Some(end), time_sync) {
                 return Some(stones_at_start.saturating_sub(elapsed));
             }
         }
@@ -101,19 +97,16 @@ pub fn Scoreboard(url: String, field: String) -> Element {
     });
     let val = data.value();
 
-    // Bayesian filter and 100ms tick for live stones during a point (same as match page).
-    #[cfg(target_arch = "wasm32")]
-    let time_filter = use_signal(|| BayesianOffsetFilter::default());
+    // Shared client-server time sync (converges to the server clock; the probe
+    // loop lives in the module). A 100ms tick drives live re-render during a point.
+    #[cfg_attr(not(target_arch = "wasm32"), allow(unused_variables))]
+    let time_sync = crate::time_sync::use_time_sync();
     #[cfg(target_arch = "wasm32")]
     let stones_update_tick = use_signal(|| 0u32);
-    #[cfg(target_arch = "wasm32")]
-    let server_time_started = use_signal(|| false);
     #[cfg(target_arch = "wasm32")]
     let stones_interval_handle = use_signal(|| None as Option<Interval>);
     #[cfg(target_arch = "wasm32")]
     {
-        let mut time_filter = time_filter;
-        let mut server_time_started = server_time_started;
         let mut stones_update_tick = stones_update_tick;
         let mut stones_interval_handle = stones_interval_handle;
         use_effect(move || {
@@ -123,22 +116,6 @@ pub fn Scoreboard(url: String, field: String) -> Element {
             if !s.has_active_match || s.stones_info.is_none() {
                 stones_interval_handle.set(None);
                 return;
-            }
-            if !server_time_started() {
-                server_time_started.set(true);
-                let mut filter = time_filter;
-                spawn(async move {
-                    loop {
-                        let client_send = js_sys::Date::now() / 1000.0;
-                        if let Ok(res) = api::server_time().await {
-                            let client_receive = js_sys::Date::now() / 1000.0;
-                            let rtt = client_receive - client_send;
-                            let offset = res.server_time - client_receive + (rtt / 2.0);
-                            filter.write().update(offset);
-                        }
-                        gloo_timers::future::TimeoutFuture::new(997).await;
-                    }
-                });
             }
             if stones_interval_handle.read().is_none() {
                 let handle = Interval::new(100, move || {
@@ -236,9 +213,9 @@ pub fn Scoreboard(url: String, field: String) -> Element {
                             let remaining = {
                                 let during_point = s.points_for_stones.as_ref().and_then(|pts| pts.last()).map_or(false, |last| last.end_stamp.is_none());
                                 if during_point {
-                                    s.points_for_stones.as_ref().and_then(|pts| scoreboard_compute_stones_remaining(pts, &time_filter)).unwrap_or_else(|| stones.stones_remaining.unwrap_or(0))
+                                    s.points_for_stones.as_ref().and_then(|pts| scoreboard_compute_stones_remaining(pts, &time_sync)).unwrap_or_else(|| stones.stones_remaining.unwrap_or(0))
                                 } else {
-                                    stones.stones_remaining.or_else(|| s.points_for_stones.as_ref().and_then(|pts| scoreboard_compute_stones_remaining(pts, &time_filter))).unwrap_or(0)
+                                    stones.stones_remaining.or_else(|| s.points_for_stones.as_ref().and_then(|pts| scoreboard_compute_stones_remaining(pts, &time_sync))).unwrap_or(0)
                                 }
                             };
                             #[cfg(not(target_arch = "wasm32"))]

--- a/frontend/src/pages/stones.rs
+++ b/frontend/src/pages/stones.rs
@@ -1,7 +1,6 @@
 //! Stones Player: globally synchronized stones using a Bayesian filter for time offset.
 
 use crate::api;
-use crate::stones_filter::BayesianOffsetFilter;
 use crate::types::StonesResponse;
 use dioxus::prelude::*;
 
@@ -15,10 +14,19 @@ use std::rc::Rc;
 use wasm_bindgen::JsCast;
 
 const BEAT_INTERVAL: f64 = 1.5;
-const SYNC_INTERVAL_MS: u32 = 997;
-const SCHEDULE_INTERVAL_MS: u32 = 500;
+// Kept short so that after a calibration change clears the queue, the loop
+// re-queues quickly and the new timing lands on the next stone.
+const SCHEDULE_INTERVAL_MS: u32 = 200;
 const SCHEDULE_AHEAD_SEC: f64 = 7.0;
 const MIN_GAP_SEC: f64 = 1.0;
+// Visual metronome: how long the flash stays lit, and a floor gap afterward so
+// we never busy-loop if the next boundary computes as essentially now.
+const BEAT_FLASH_MS: u32 = 120;
+const BEAT_MIN_GAP_MS: u32 = 50;
+// Step 2 of calibration: after resetting the estimate, poll this often and wait
+// at most this long for it to settle before letting the user tune the offset.
+const STEP2_POLL_MS: u32 = 100;
+const STEP2_MAX_SYNC_MS: u32 = 3000;
 
 #[component]
 pub fn Stones() -> Element {
@@ -52,9 +60,19 @@ pub fn Stones() -> Element {
 fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>>>) -> Element {
     let mut is_playing = use_signal(|| false);
     let mut selected_index = use_signal(|| 0usize);
-    let mut filter = use_signal(|| BayesianOffsetFilter::default());
-    let rtt_ms = use_signal(|| Option::<f64>::None);
+    let mut time_sync = crate::time_sync::use_time_sync();
     let mut custom_status = use_signal(|| Option::<String>::None);
+    // Pulses true (briefly) on each server beat, driving the visual metronome
+    // shown inside the calibration walkthrough.
+    let beat_flash = use_signal(|| false);
+    // Calibration walkthrough: 0 = closed, 1 = audio-delay step, 2 = clock-offset step.
+    let mut calibration_step = use_signal(|| 0u8);
+    // Calibration snapshot taken when the walkthrough opens, so Cancel can roll
+    // back the live changes the user made while dragging.
+    let mut calibration_snapshot = use_signal(|| crate::time_sync::Calibration::default());
+    // True while step 2 is re-syncing after a reset (waiting for the estimate
+    // to settle, up to a timeout) before the user tunes the clock offset.
+    let step2_syncing = use_signal(|| false);
 
     let mut audio_ctx = use_signal(|| Option::<web_sys::AudioContext>::None);
     let mut audio_buffer = use_signal(|| Option::<web_sys::AudioBuffer>::None);
@@ -68,37 +86,24 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
         }))
     });
 
-    // Sync loop
-    use_effect(move || {
-        let mut filter = filter.clone();
-        let mut rtt_ms = rtt_ms.clone();
-        spawn(async move {
-            loop {
-                let client_send = js_sys::Date::now() / 1000.0;
-                if let Ok(res) = api::server_time().await {
-                    let client_receive = js_sys::Date::now() / 1000.0;
-                    let rtt = client_receive - client_send;
-                    let offset = res.server_time - client_receive + (rtt / 2.0);
-                    filter.write().update(offset);
-                    rtt_ms.set(Some(rtt * 1000.0));
-                }
-                gloo_timers::future::TimeoutFuture::new(SYNC_INTERVAL_MS).await;
-            }
-        });
-    });
-
     // Schedule loop when playing
     use_effect(move || {
         if !is_playing() {
             return;
         }
         let is_playing_sig = is_playing.clone();
-        let filter_sig = filter.clone();
         let audio_ctx_sig = audio_ctx.clone();
         let audio_buffer_sig = audio_buffer.clone();
         let ctx_start_time_sig = ctx_start_time.clone();
         let schedule_rc = schedule_state.read().clone();
         spawn(async move {
+            // Track the calibration used to schedule the currently-queued
+            // stones. When it changes we drop the not-yet-played sources once
+            // and let this loop re-queue with the new timing. Checking here (at
+            // the loop's fixed cadence) rather than on every slider `oninput`
+            // keeps the live-MediaStream audio graph from churning dozens of
+            // times a second, which is what made the pitch wobble.
+            let mut last_cal = time_sync.calibration();
             while is_playing_sig() {
                 let ctx = audio_ctx_sig.read().clone();
                 let buf = audio_buffer_sig.read().clone();
@@ -106,19 +111,26 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
                 if let (Some(ref ctx), Some(ref buf), Some(_start)) =
                     (ctx, buf, *start_time)
                 {
-                    let now = js_sys::Date::now() / 1000.0;
+                    let cal = time_sync.calibration();
+                    if cal.clock_offset_ms != last_cal.clock_offset_ms
+                        || cal.audio_delay_ms != last_cal.audio_delay_ms
+                    {
+                        clear_future_scheduled(schedule_rc.clone(), ctx);
+                        last_cal = cal;
+                    }
                     let audio_now = ctx.current_time();
-                    let mean = filter_sig.read().get_mean();
-                    let mut beat_time = next_beat_time(now, mean);
-                    let max_wall = now + SCHEDULE_AHEAD_SEC;
+                    let server_now = time_sync.server_now_secs();
+                    let audio_delay = time_sync.audio_delay_secs();
+                    let mut next_server_beat =
+                        crate::time_sync::next_beat_boundary(server_now, BEAT_INTERVAL);
                     let mut scheduled = 0u32;
-                    while beat_time <= max_wall && scheduled < 5 {
+                    while next_server_beat - server_now <= SCHEDULE_AHEAD_SEC && scheduled < 5 {
                         if !is_playing_sig() {
                             break;
                         }
-                        let delay = beat_time - now;
+                        let delay = next_server_beat - server_now;
                         if delay > 0.05 && delay < 60.0 {
-                            let audio_time = audio_now + delay;
+                            let audio_time = audio_now + delay + audio_delay;
                             if schedule_sound_at(
                                 ctx.clone(),
                                 buf.clone(),
@@ -128,7 +140,7 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
                                 scheduled += 1;
                             }
                         }
-                        beat_time += BEAT_INTERVAL;
+                        next_server_beat += BEAT_INTERVAL;
                     }
                 }
                 gloo_timers::future::TimeoutFuture::new(SCHEDULE_INTERVAL_MS).await;
@@ -136,10 +148,55 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
         });
     });
 
-    let on_play_pause = move |_| {
+    // Visual beat loop: pulse `beat_flash` on every server beat (clock-offset
+    // adjusted grid, so it moves with the offset slider). Drives the metronome
+    // dot shown inside the calibration walkthrough.
+    use_effect(move || {
+        let mut beat_flash = beat_flash;
+        spawn(async move {
+            loop {
+                let server_now = time_sync.server_now_secs();
+                let next_beat = crate::time_sync::next_beat_boundary(server_now, BEAT_INTERVAL);
+                let wait_ms = ((next_beat - server_now) * 1000.0).max(0.0);
+                gloo_timers::future::TimeoutFuture::new(wait_ms as u32).await;
+                beat_flash.set(true);
+                gloo_timers::future::TimeoutFuture::new(BEAT_FLASH_MS).await;
+                beat_flash.set(false);
+                gloo_timers::future::TimeoutFuture::new(BEAT_MIN_GAP_MS).await;
+            }
+        });
+    });
+
+    // Step 2 entry: reset the estimate and wait (up to STEP2_MAX_SYNC_MS) for it
+    // to settle before the user tunes the clock offset against a neighboring
+    // device's stones.
+    use_effect(move || {
+        if calibration_step() != 2 {
+            return;
+        }
+        let mut time_sync = time_sync;
+        let mut step2_syncing = step2_syncing;
+        spawn(async move {
+            time_sync.reping();
+            step2_syncing.set(true);
+            let mut waited = 0u32;
+            while waited < STEP2_MAX_SYNC_MS {
+                if time_sync.quality().converged {
+                    break;
+                }
+                gloo_timers::future::TimeoutFuture::new(STEP2_POLL_MS).await;
+                waited += STEP2_POLL_MS;
+            }
+            step2_syncing.set(false);
+        });
+    });
+
+    let on_play_pause = use_callback(move |_: ()| {
         if is_playing() {
             is_playing.set(false);
-            clear_scheduled(schedule_state.read().clone());
+            if let Some(ctx) = audio_ctx.read().clone() {
+                clear_future_scheduled(schedule_state.read().clone(), &ctx);
+            }
             // Stop the hidden audio element immediately so mobile doesn't keep playing
             // buffered MediaStream data or loop a segment.
             pause_audio_stream_element();
@@ -205,21 +262,51 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
                 .await;
             });
         }
+    });
+
+    let on_reping = move |_| {
+        time_sync.reping();
     };
 
-    let on_reset = move |_| {
-        filter.write().reset();
+    // Open the calibration walkthrough: snapshot current calibration (so Cancel
+    // can roll back live edits) and go to step 1.
+    let on_open_calibration = move |_| {
+        calibration_snapshot.set(time_sync.calibration());
+        calibration_step.set(1);
+    };
+
+    // Advance step 1 -> 2 -> done. Finishing keeps the live-applied values.
+    let on_calibration_next = move |_| {
+        let step = calibration_step();
+        if step >= 2 {
+            calibration_step.set(0);
+        } else {
+            calibration_step.set(step + 1);
+        }
+    };
+
+    // Cancel: roll back to the snapshot taken when the walkthrough opened, and close.
+    let on_calibration_cancel = move |_| {
+        let snap = *calibration_snapshot.read();
+        time_sync.set_clock_offset_ms(snap.clock_offset_ms);
+        time_sync.set_audio_delay_ms(snap.audio_delay_ms);
+        calibration_step.set(0);
     };
 
     let stones_ok = stones_val.read().as_ref().and_then(|r| r.as_ref().ok()).cloned();
     let stones_len = stones_ok.as_ref().map(|s| s.stones.len()).unwrap_or(0);
     let base_url = api::base_url();
-    let offset_str = format!("{:.6}", filter.read().get_mean());
-    let var_str = format!("{:.6}", filter.read().get_variance());
-    let rtt_display = match *rtt_ms.read() {
+    let quality = time_sync.quality();
+    let calibration = time_sync.calibration();
+    let offset_str = format!("{:.1} ms", quality.offset_ms);
+    let var_str = format!("{:.1} ms\u{00B2}", quality.variance_ms2);
+    let converged_str = if quality.converged { "yes" } else { "not yet" };
+    let rtt_display = match quality.rtt_ms {
         Some(ms) => format!("{:.1} ms", ms),
         None => "-".to_string(),
     };
+    let clock_offset_val = format!("{:.0}", calibration.clock_offset_ms);
+    let audio_delay_val = format!("{:.0}", calibration.audio_delay_ms);
 
     #[cfg(target_arch = "wasm32")]
     fn ensure_media_destination(
@@ -320,6 +407,18 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
         .unwrap_or_default();
 
     rsx! {
+        style { r#"
+        .stones-beat-dot {{
+            width: 44px; height: 44px; border-radius: 50%;
+            background: #3a3f44; border: 2px solid #555;
+            flex: 0 0 auto; transition: background 90ms ease-out, box-shadow 90ms ease-out, transform 90ms ease-out;
+        }}
+        .stones-beat-dot-on {{
+            background: #4ecdc4; border-color: #4ecdc4;
+            box-shadow: 0 0 18px 4px rgba(78, 205, 196, 0.8);
+            transform: scale(1.12);
+        }}
+        "# }
         div { class: "container mt-4",
             div { class: "row",
                 div { class: "col-12",
@@ -330,9 +429,8 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
                     p { strong { "Important Notes:" } }
                     ul {
                         li { "The speed of sound is about 343 m/s (~110 ms to cross a 40 m field). If stones sound out of sync, try standing equidistant from speakers." }
-                        li { "It should only take a few (3–5) stones to sync. If not syncing, click \"Reset Sync\" on all devices at roughly the same time." }
-                        li { "Bluetooth can add up to ~250 ms delay; prefer wired connections if latency differs between devices." }
-                        li { "When changing the audio device, the first few stones may be out of sync while the buffer clears." }
+                        li { "It should only take a few (3–5) stones to sync." }
+                        li { "Bluetooth can add up to ~250 ms delay; if you are using bluetooth, click \"calibrate manually\" to compensate for this delay." }
                         li { "Custom files: keep them under 1.5 s and avoid dead space at the start." }
                     }
 
@@ -354,7 +452,9 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
                                                     key: "{key_name}",
                                                     class: if is_selected { "btn btn-primary" } else { "btn btn-outline-primary" },
                                                     onclick: move |_| {
-                                                        clear_scheduled(schedule_state.read().clone());
+                                                        if let Some(ctx) = audio_ctx.read().clone() {
+                                                            clear_future_scheduled(schedule_state.read().clone(), &ctx);
+                                                        }
                                                         selected_index.set(idx);
                                                         audio_buffer.set(None);
                                                         let base = base_url.clone();
@@ -378,7 +478,9 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
                                     button {
                                         class: if selected_index() >= stones_len { "btn btn-primary" } else { "btn btn-outline-primary" },
                                         onclick: move |_| {
-                                            clear_scheduled(schedule_state.read().clone());
+                                            if let Some(ctx) = audio_ctx.read().clone() {
+                                                clear_future_scheduled(schedule_state.read().clone(), &ctx);
+                                            }
                                             selected_index.set(stones_len);
                                             audio_buffer.set(custom_buffer.read().clone());
                                         },
@@ -419,16 +521,25 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
                             div { class: "mb-3",
                                 button {
                                     class: if is_playing() { "btn btn-warning btn-lg mb-3" } else { "btn btn-primary btn-lg mb-3" },
-                                    onclick: on_play_pause,
+                                    onclick: move |_| on_play_pause.call(()),
                                     if is_playing() { "Pause" } else { "Play" }
                                 }
                                 button {
                                     class: "btn btn-danger mb-3 ms-2",
-                                    onclick: on_reset,
-                                    "Reset Sync"
+                                    onclick: on_reping,
+                                    "Re-ping / Reset Sync"
                                 }
                                 if let Some(ref msg) = *custom_status.read() {
                                     p { class: "form-text mt-2 text-danger", "{msg}" }
+                                }
+                            }
+
+                            div { class: "mb-3",
+                                p { class: "form-text mb-1", "Something doesn't look or sound right?" }
+                                button {
+                                    class: "btn btn-outline-secondary",
+                                    onclick: on_open_calibration,
+                                    "Calibrate manually"
                                 }
                             }
 
@@ -443,8 +554,9 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
 
                             div { class: "mb-3",
                                 h5 { "Stats" }
-                                p { "Offset (x\u{0302}): {offset_str} s" }
-                                p { "Variance (P): {var_str} s\u{00B2}" }
+                                p { "Offset (x\u{0302}): {offset_str}" }
+                                p { "Variance (P): {var_str}" }
+                                p { "Converged: {converged_str}" }
                                 p { "Round trip time: {rtt_display}" }
                             }
                         }
@@ -456,13 +568,116 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
         if let Some(Err(e)) = stones_val.read().as_ref() {
             p { class: "text-danger", "{e}" }
         }
-    }
-}
 
-fn next_beat_time(now: f64, offset: f64) -> f64 {
-    let server_now = now + offset;
-    let next_server = (server_now / BEAT_INTERVAL).ceil() * BEAT_INTERVAL;
-    next_server - offset
+        if calibration_step() != 0 {
+            div { class: "modal show", style: "display: block;",
+                div { class: "modal-dialog modal-dialog-centered",
+                    div { class: "modal-content",
+                        div { class: "modal-header",
+                            h5 { class: "modal-title",
+                                if calibration_step() == 1 { "Calibrate — Step 1 of 2: Audio delay" }
+                                else { "Calibrate — Step 2 of 2: Clock offset" }
+                            }
+                            button { r#type: "button", class: "btn-close", onclick: on_calibration_cancel }
+                        }
+                        div { class: "modal-body",
+                            div { class: "d-flex flex-column align-items-center mb-3",
+                                div {
+                                    class: if beat_flash() { "stones-beat-dot stones-beat-dot-on" } else { "stones-beat-dot" },
+                                }
+                                span { class: "form-text mt-2 text-center", "this should light up on the stone beat" }
+                            }
+
+                            if calibration_step() == 1 {
+                                p {
+                                    "Press Play, then drag the slider until the stones you hear from "
+                                    strong { "this device" }
+                                    " line up with the flashing indicator above."
+                                }
+                                p { class: "form-text",
+                                    "If you're not playing stones from this device, you can skip this step — just press Next."
+                                }
+                                div { class: "mb-3",
+                                    button {
+                                        r#type: "button",
+                                        class: if is_playing() { "btn btn-warning" } else { "btn btn-primary" },
+                                        onclick: move |_| on_play_pause.call(()),
+                                        if is_playing() { "Pause" } else { "Play" }
+                                    }
+                                }
+                                label { class: "form-label d-flex justify-content-between",
+                                    span { "Audio delay" }
+                                    strong { class: "ms-2", "{audio_delay_val} ms" }
+                                }
+                                input {
+                                    r#type: "range",
+                                    class: "form-range",
+                                    min: "-750",
+                                    max: "750",
+                                    step: "10",
+                                    value: "{audio_delay_val}",
+                                    onmounted: move |evt: Event<MountedData>| {
+                                        set_input_value_on_mount(&evt.data(), time_sync.calibration().audio_delay_ms);
+                                    },
+                                    oninput: move |evt| {
+                                        if let Ok(v) = evt.value().parse::<f64>() {
+                                            time_sync.set_audio_delay_ms(v);
+                                        }
+                                    },
+                                }
+                            } else {
+                                if step2_syncing() {
+                                    div { class: "d-flex align-items-center gap-2 mb-2",
+                                        div { class: "spinner-border spinner-border-sm", role: "status" }
+                                        span { "Re-syncing the clock… (up to 3 seconds)" }
+                                    }
+                                }
+                                p {
+                                    "Drag the slider until the flashing indicator lines up with the stones playing from "
+                                    strong { "another already-synced device" }
+                                    " nearby."
+                                }
+                                p { class: "form-text",
+                                    "This adjusts this device's whole sense of server time, so it also fixes the live stone counter when you run a match."
+                                }
+                                label { class: "form-label d-flex justify-content-between",
+                                    span { "Clock offset" }
+                                    strong { class: "ms-2", "{clock_offset_val} ms" }
+                                }
+                                input {
+                                    r#type: "range",
+                                    class: "form-range",
+                                    min: "-750",
+                                    max: "750",
+                                    step: "10",
+                                    value: "{clock_offset_val}",
+                                    disabled: step2_syncing(),
+                                    onmounted: move |evt: Event<MountedData>| {
+                                        set_input_value_on_mount(&evt.data(), time_sync.calibration().clock_offset_ms);
+                                    },
+                                    oninput: move |evt| {
+                                        if let Ok(v) = evt.value().parse::<f64>() {
+                                            time_sync.set_clock_offset_ms(v);
+                                        }
+                                    },
+                                }
+                            }
+                        }
+                        div { class: "modal-footer",
+                            button { r#type: "button", class: "btn btn-secondary", onclick: on_calibration_cancel, "Cancel" }
+                            button {
+                                r#type: "button",
+                                class: "btn btn-primary",
+                                onclick: on_calibration_next,
+                                if calibration_step() == 1 { "Next" } else { "Done" }
+                            }
+                        }
+                    }
+                }
+            }
+            div { class: "modal-backdrop show" }
+        }
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -529,14 +744,44 @@ fn schedule_sound_at(
     true
 }
 
+/// Force a range/number input's value on mount. Range inputs clamp an
+/// un-applied value to the track midpoint, so a stored calibration would show
+/// as 0 without this; setting the DOM value directly reflects the real value.
 #[cfg(target_arch = "wasm32")]
-fn clear_scheduled(state_rc: Rc<RefCell<ScheduleState>>) {
-    // Drain sources and clear times inside the borrow, then stop/disconnect
-    // outside so that any onended callback can safely borrow the RefCell.
+fn set_input_value_on_mount(event: &MountedData, value: f64) {
+    use dioxus_web::WebEventExt;
+    if let Some(el) = event.try_as_web_event() {
+        if let Ok(input) = el.dyn_into::<web_sys::HtmlInputElement>() {
+            input.set_value(&format!("{value:.0}"));
+        }
+    }
+}
+
+/// Cancel only sources whose scheduled start is still in the future, leaving
+/// any currently-sounding stone to finish. Cutting the source that is actively
+/// feeding the live MediaStream starves it, and the browser time-stretches the
+/// gap and drops the pitch — so pause, sound changes, and calibration tweaks
+/// all clear this way and let the in-flight stone play out.
+#[cfg(target_arch = "wasm32")]
+fn clear_future_scheduled(state_rc: Rc<RefCell<ScheduleState>>, ctx: &web_sys::AudioContext) {
+    // A source is "playing" (do not touch) if it started at or before now; a
+    // small margin keeps one that is about to start from being cut mid-attack.
+    let cutoff_ms = ((ctx.current_time() + 0.05) * 1000.0) as i64;
     let to_stop: Vec<web_sys::AudioBufferSourceNode> = {
         let mut state = state_rc.borrow_mut();
-        state.times.clear();
-        state.sources.drain().map(|(_, s)| s).collect()
+        let future: Vec<i64> = state
+            .times
+            .iter()
+            .copied()
+            .filter(|&t_ms| t_ms > cutoff_ms)
+            .collect();
+        for t_ms in &future {
+            state.times.remove(t_ms);
+        }
+        future
+            .iter()
+            .filter_map(|t_ms| state.sources.remove(t_ms))
+            .collect()
     };
     for source in to_stop {
         #[allow(deprecated)]

--- a/frontend/src/pages/stones.rs
+++ b/frontend/src/pages/stones.rs
@@ -527,7 +527,7 @@ fn StonesPlayerWasm(stones_val: ReadSignal<Option<Result<StonesResponse, String>
                                 button {
                                     class: "btn btn-danger mb-3 ms-2",
                                     onclick: on_reping,
-                                    "Re-ping / Reset Sync"
+                                    "Reset Sync"
                                 }
                                 if let Some(ref msg) = *custom_status.read() {
                                     p { class: "form-text mt-2 text-danger", "{msg}" }

--- a/frontend/src/stones_filter.rs
+++ b/frontend/src/stones_filter.rs
@@ -1,82 +1,225 @@
-//! Simple Bayesian filter for client–server time offset estimation.
-//! Gaussian prior and likelihood; conjugate update with optional outlier rejection.
+//! Bayesian filter for client–server clock-offset estimation.
+//!
+//! The filter tracks a single scalar — the clock offset, in **milliseconds** —
+//! with a Gaussian posterior. Two operations advance it:
+//!
+//! * [`BayesianOffsetFilter::predict`] advances the random-walk dynamics one
+//!   tick, inflating the variance by the process noise `Q`. Call this every
+//!   tick regardless of whether a network measurement was taken.
+//! * [`BayesianOffsetFilter::observe`] folds in one measurement with a
+//!   caller-supplied measurement variance `R` (the sync loop derives `R` from
+//!   the sample's round-trip time, so a slow/asymmetric sample is trusted
+//!   less). A light innovation sanity-gate rejects an offset that is absurdly
+//!   far from the current estimate given the current uncertainty.
+//!
+//! `server_time_ms = client_time_ms + mean_ms`.
 
-/// Bayesian filter for a single scalar (time offset) with Gaussian prior and measurement noise.
+/// Process noise added to the variance on every [`predict`](BayesianOffsetFilter::predict)
+/// tick (random-walk drift). Defined against the sync loop's fixed tick
+/// interval; if that interval changes, scale this with it.
+pub const PROCESS_NOISE_MS2_PER_TICK: f64 = 7.5;
+
+/// Variance (ms²) below which the estimate is considered converged: tight
+/// enough to stop probing (coast) and tight enough to run a stones match.
+/// √100 = 10 ms per-client stdev → ~14 ms between two independent clients,
+/// inside the ±15 ms goal.
+pub const CONVERGED_VARIANCE_MS2: f64 = 100.0;
+
+/// Innovation sanity-gate width. A measurement is rejected only when it lands
+/// more than this many standard deviations from the current estimate — a
+/// generous last-resort guard against a low-RTT-but-garbage sample, not the
+/// primary outlier mechanism (RTT-scaled `R` is).
+const INNOVATION_SIGMA: f64 = 6.0;
+
+/// Initial variance: "no idea yet". Large relative to any real measurement.
+const INITIAL_VARIANCE_MS2: f64 = 1e12;
+
 #[derive(Clone, Debug)]
 pub struct BayesianOffsetFilter {
-    /// Posterior mean (estimated offset in seconds): server_time = client_time + mean
-    pub mean: f64,
-    /// Posterior variance (uncertainty in seconds²)
-    pub variance: f64,
-    /// Process noise per step (variance added each update to allow drift)
-    pub process_noise: f64,
-    /// Measurement noise variance (R)
-    pub measurement_variance: f64,
-    /// Reject measurement if |z - mean| > outlier_sigma * sqrt(variance + measurement_variance)
-    pub outlier_sigma: f64,
-    /// Don't reject until variance drops below this (avoid rejecting during initial convergence)
-    pub min_variance_for_rejection: f64,
+    /// Posterior mean: estimated offset in milliseconds.
+    pub mean_ms: f64,
+    /// Posterior variance in ms².
+    pub variance_ms2: f64,
+    /// Process noise per predict tick (ms²).
+    pub process_noise_ms2: f64,
     pub rejected_count: u32,
 }
 
 impl Default for BayesianOffsetFilter {
     fn default() -> Self {
         Self {
-            mean: 0.0,
-            variance: 1e10, // high initial uncertainty
-            process_noise: 1e-8,
-            measurement_variance: 0.0015, // measurement noise variance (s²)
-            outlier_sigma: 2.0,
-            min_variance_for_rejection: 1.0,
+            mean_ms: 0.0,
+            variance_ms2: INITIAL_VARIANCE_MS2,
+            process_noise_ms2: PROCESS_NOISE_MS2_PER_TICK,
             rejected_count: 0,
         }
     }
 }
 
 impl BayesianOffsetFilter {
-    /// Update with a new measurement (offset in seconds). Returns current posterior mean.
-    pub fn update(&mut self, measurement: f64) -> f64 {
-        // Predict: add process noise (random walk)
-        self.variance += self.process_noise;
+    /// Advance random-walk dynamics one tick.
+    pub fn predict(&mut self) {
+        self.variance_ms2 += self.process_noise_ms2;
+    }
 
-        // Outlier rejection
-        if self.variance < self.min_variance_for_rejection {
-            let innovation = measurement - self.mean;
-            let innovation_var = self.variance + self.measurement_variance;
-            let std_dev = innovation_var.sqrt();
-            if std_dev > 1e-20 {
-                let z_score = innovation.abs() / std_dev;
-                if z_score > self.outlier_sigma {
-                    self.rejected_count += 1;
-                    return self.mean;
-                }
+    /// Fold in one measurement (offset in ms) with its measurement variance
+    /// `R` (ms²). Returns the posterior mean. Does **not** advance dynamics;
+    /// call [`predict`](Self::predict) for that.
+    pub fn observe(&mut self, measurement_ms: f64, measurement_variance_ms2: f64) -> f64 {
+        if self.is_converged() {
+            let innovation = measurement_ms - self.mean_ms;
+            let innovation_std = (self.variance_ms2 + measurement_variance_ms2).sqrt();
+            if innovation_std > 0.0 && innovation.abs() > INNOVATION_SIGMA * innovation_std {
+                self.rejected_count += 1;
+                return self.mean_ms;
             }
         }
 
-        // Update: Gaussian conjugate prior × likelihood → posterior
-        // posterior precision = prior_precision + likelihood_precision
-        // posterior_mean = (prior_mean * prior_precision + measurement * likelihood_precision) / posterior_precision
-        let prior_precision = 1.0 / self.variance;
-        let likelihood_precision = 1.0 / self.measurement_variance;
+        let prior_precision = 1.0 / self.variance_ms2;
+        let likelihood_precision = 1.0 / measurement_variance_ms2;
         let posterior_precision = prior_precision + likelihood_precision;
-        self.variance = 1.0 / posterior_precision;
-        self.mean = (self.mean * prior_precision + measurement * likelihood_precision)
+        self.variance_ms2 = 1.0 / posterior_precision;
+        self.mean_ms = (self.mean_ms * prior_precision + measurement_ms * likelihood_precision)
             / posterior_precision;
-
-        self.mean
+        self.mean_ms
     }
 
-    pub fn get_mean(&self) -> f64 {
-        self.mean
+    pub fn get_mean_ms(&self) -> f64 {
+        self.mean_ms
     }
 
-    pub fn get_variance(&self) -> f64 {
-        self.variance
+    pub fn get_variance_ms2(&self) -> f64 {
+        self.variance_ms2
+    }
+
+    pub fn is_converged(&self) -> bool {
+        self.variance_ms2 < CONVERGED_VARIANCE_MS2
     }
 
     pub fn reset(&mut self) {
-        self.mean = 0.0;
-        self.variance = 1e10;
+        self.mean_ms = 0.0;
+        self.variance_ms2 = INITIAL_VARIANCE_MS2;
         self.rejected_count = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_close(actual: f64, expected: f64, tol: f64) {
+        assert!(
+            (actual - expected).abs() <= tol,
+            "expected {expected} ± {tol}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn predict_inflates_variance_by_process_noise() {
+        let mut filter = BayesianOffsetFilter::default();
+        filter.variance_ms2 = 50.0;
+        filter.process_noise_ms2 = 7.5;
+        filter.predict();
+        assert_close(filter.get_variance_ms2(), 57.5, 1e-9);
+    }
+
+    #[test]
+    fn first_observation_snaps_mean_toward_measurement() {
+        // With huge initial variance, the first measurement dominates: the
+        // posterior mean lands essentially on the measurement.
+        let mut filter = BayesianOffsetFilter::default();
+        filter.observe(120.0, 4.0);
+        assert_close(filter.get_mean_ms(), 120.0, 0.1);
+    }
+
+    #[test]
+    fn observation_shrinks_variance() {
+        let mut filter = BayesianOffsetFilter::default();
+        let before = filter.get_variance_ms2();
+        filter.observe(10.0, 4.0);
+        assert!(
+            filter.get_variance_ms2() < before,
+            "variance should shrink after an observation"
+        );
+        // Posterior variance is bounded above by the measurement variance.
+        assert!(filter.get_variance_ms2() <= 4.0 + 1e-6);
+    }
+
+    #[test]
+    fn low_variance_measurement_moves_mean_more_than_high_variance() {
+        // Two filters in the same (not-yet-converged) state, so the innovation
+        // gate is inactive and this isolates the precision weighting: feed the
+        // same offset with different measurement variances. The low-R (trusted)
+        // sample should pull the mean further.
+        let mut trusted = BayesianOffsetFilter::default();
+        trusted.mean_ms = 0.0;
+        trusted.variance_ms2 = 200.0;
+        let mut distrusted = trusted.clone();
+
+        trusted.observe(30.0, 2.0);
+        distrusted.observe(30.0, 2000.0);
+
+        assert!(
+            trusted.get_mean_ms() > distrusted.get_mean_ms(),
+            "trusted (low R) sample should pull the mean further: {} vs {}",
+            trusted.get_mean_ms(),
+            distrusted.get_mean_ms()
+        );
+    }
+
+    #[test]
+    fn innovation_gate_rejects_absurd_sample_when_converged() {
+        // Converged filter (small variance). A wildly off measurement with a
+        // small R should be rejected and leave the mean essentially untouched.
+        let mut filter = BayesianOffsetFilter::default();
+        filter.mean_ms = 5.0;
+        filter.variance_ms2 = 4.0;
+        let before = filter.get_mean_ms();
+        filter.observe(100_000.0, 4.0);
+        assert_close(filter.get_mean_ms(), before, 1e-9);
+        assert_eq!(filter.rejected_count, 1);
+    }
+
+    #[test]
+    fn innovation_gate_does_not_reject_during_initial_convergence() {
+        // With huge initial variance the innovation band is enormous, so even
+        // a large first measurement is accepted, not rejected.
+        let mut filter = BayesianOffsetFilter::default();
+        filter.observe(50_000.0, 4.0);
+        assert_eq!(filter.rejected_count, 0);
+        assert_close(filter.get_mean_ms(), 50_000.0, 1.0);
+    }
+
+    #[test]
+    fn is_converged_tracks_threshold() {
+        let mut filter = BayesianOffsetFilter::default();
+        assert!(!filter.is_converged());
+        filter.variance_ms2 = CONVERGED_VARIANCE_MS2 - 1.0;
+        assert!(filter.is_converged());
+        filter.variance_ms2 = CONVERGED_VARIANCE_MS2 + 1.0;
+        assert!(!filter.is_converged());
+    }
+
+    #[test]
+    fn reset_restores_high_uncertainty() {
+        let mut filter = BayesianOffsetFilter::default();
+        filter.observe(42.0, 4.0);
+        filter.reset();
+        assert_close(filter.get_mean_ms(), 0.0, 1e-9);
+        assert!(!filter.is_converged());
+        assert_eq!(filter.rejected_count, 0);
+    }
+
+    #[test]
+    fn repeated_consistent_observations_converge() {
+        // Feeding the same offset repeatedly (with predict between) should
+        // converge the mean to it and drive the filter to the converged state.
+        let mut filter = BayesianOffsetFilter::default();
+        for _ in 0..50 {
+            filter.predict();
+            filter.observe(200.0, 4.0);
+        }
+        assert_close(filter.get_mean_ms(), 200.0, 1.0);
+        assert!(filter.is_converged());
     }
 }

--- a/frontend/src/time_sync.rs
+++ b/frontend/src/time_sync.rs
@@ -1,0 +1,455 @@
+//! Shared client–server time synchronization for the stones grid.
+//!
+//! One module owns everything the stones player, the run-match view, and the
+//! scoreboard need to agree on the server's clock:
+//!
+//! * the [`BayesianOffsetFilter`](crate::stones_filter::BayesianOffsetFilter)
+//!   estimate of the clock offset,
+//! * a best-of-N, RTT-weighted probe loop that coasts when confident,
+//! * two persisted manual corrections — a **clock offset** (shifts this
+//!   device's whole notion of server time, affecting playback *and* the live
+//!   stone counters) and an **audio delay** (shifts only when sound leaves the
+//!   speaker), shared across tabs via `localStorage`,
+//! * a corrected `server_now()` and a `quality()` readout for the UI and the
+//!   run-match staleness gate.
+//!
+//! The pure, `cfg`-agnostic core (measurement model, sample selection, coast
+//! gate, calibration math, staleness predicate) is unit-tested natively; the
+//! wasm-only I/O (network probe, `localStorage`, `storage` events) is verified
+//! in the browser.
+
+use crate::stones_filter::{BayesianOffsetFilter, CONVERGED_VARIANCE_MS2};
+
+/// How many parallel probes to fire per measurement round; the lowest-RTT
+/// sample is kept (least queuing delay → least-biased one-way estimate).
+pub const PROBES_PER_ROUND: usize = 3;
+
+/// localStorage keys (namespaced, following the `record.rs` convention).
+pub const CLOCK_OFFSET_KEY: &str = "arctos_stones_clock_offset_ms";
+pub const AUDIO_DELAY_KEY: &str = "arctos_stones_audio_delay_ms";
+
+/// One round-trip probe result. Times are unix seconds; `server_time` is the
+/// server's clock at the moment it replied.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Probe {
+    pub client_send_secs: f64,
+    pub client_receive_secs: f64,
+    pub server_time_secs: f64,
+}
+
+impl Probe {
+    pub fn rtt_secs(&self) -> f64 {
+        self.client_receive_secs - self.client_send_secs
+    }
+
+    /// Cristian's estimate of `server − client` at receive, in milliseconds.
+    pub fn offset_ms(&self) -> f64 {
+        (self.server_time_secs - self.client_receive_secs + self.rtt_secs() / 2.0) * 1000.0
+    }
+}
+
+/// Measurement variance `R` (ms²) for a sample with the given round-trip time.
+/// `R = exp(rtt_ms · 0.01)²  = exp(rtt_ms · 0.02)`, so trust collapses
+/// super-linearly as RTT grows and a slow/asymmetric sample barely moves the
+/// estimate.
+pub fn measurement_variance_ms2(rtt_ms: f64) -> f64 {
+    (rtt_ms * 0.02).exp()
+}
+
+/// The next beat-grid boundary at or after `now_secs`, in the same time base
+/// as `now_secs`. Beats fall on integer multiples of `beat_secs` (unix time),
+/// so all clients that agree on the time also agree on the grid.
+pub fn next_beat_boundary(now_secs: f64, beat_secs: f64) -> f64 {
+    (now_secs / beat_secs).ceil() * beat_secs
+}
+
+/// Pick the sample with the lowest round-trip time.
+pub fn pick_lowest_rtt(samples: &[Probe]) -> Option<Probe> {
+    samples
+        .iter()
+        .copied()
+        .min_by(|a, b| a.rtt_secs().total_cmp(&b.rtt_secs()))
+}
+
+/// Whether to issue a network probe this tick, or coast on the model. Coast
+/// once the estimate is converged (variance below the shared threshold).
+pub fn should_probe(variance_ms2: f64) -> bool {
+    variance_ms2 >= CONVERGED_VARIANCE_MS2
+}
+
+/// The two persisted manual corrections. Milliseconds.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Calibration {
+    pub clock_offset_ms: f64,
+    pub audio_delay_ms: f64,
+}
+
+impl Default for Calibration {
+    fn default() -> Self {
+        Self {
+            clock_offset_ms: 0.0,
+            audio_delay_ms: 0.0,
+        }
+    }
+}
+
+impl Calibration {
+    /// Corrected server time in seconds, given the raw device clock (seconds)
+    /// and the filter's estimated offset (ms). Folds in the manual clock
+    /// offset — so this shifts both playback and the live stone counters.
+    pub fn server_now_secs(&self, raw_now_secs: f64, estimated_offset_ms: f64) -> f64 {
+        raw_now_secs + (estimated_offset_ms + self.clock_offset_ms) / 1000.0
+    }
+
+    /// Manual audio output delay in seconds (playback scheduling only; does
+    /// not affect `server_now_secs`).
+    pub fn audio_delay_secs(&self) -> f64 {
+        self.audio_delay_ms / 1000.0
+    }
+}
+
+/// Sync-quality snapshot for the stats UI and the run-match gate.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SyncQuality {
+    /// Raw filter estimate of the client→server offset (ms). Display-only; the
+    /// manual clock-offset knob is intentionally excluded.
+    pub offset_ms: f64,
+    pub variance_ms2: f64,
+    pub rtt_ms: Option<f64>,
+    pub converged: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Reactive handle + wasm-only I/O (network probe, localStorage, cross-tab).
+// ---------------------------------------------------------------------------
+
+use dioxus::prelude::*;
+
+/// Fixed tick period for the sync loop. Every tick advances the filter's
+/// random-walk dynamics; a network probe is issued only when not yet
+/// converged. `PROCESS_NOISE_MS2_PER_TICK` is defined against this period.
+pub const TICK_INTERVAL_MS: u32 = 1000;
+
+/// Reactive time-sync handle shared by the stones player, run-match view, and
+/// scoreboard. `Copy`, so it threads through closures and child components
+/// without cloning ceremony.
+#[derive(Clone, Copy)]
+pub struct TimeSync {
+    filter: Signal<BayesianOffsetFilter>,
+    calibration: Signal<Calibration>,
+    last_rtt_ms: Signal<Option<f64>>,
+}
+
+impl TimeSync {
+    /// Corrected server time, in unix seconds. Use this anywhere the old code
+    /// did `Date::now()/1000 + filter.mean`.
+    pub fn server_now_secs(&self) -> f64 {
+        let raw = raw_now_secs();
+        self.calibration
+            .read()
+            .server_now_secs(raw, self.filter.read().get_mean_ms())
+    }
+
+    /// Manual audio output delay in seconds (playback scheduling only).
+    pub fn audio_delay_secs(&self) -> f64 {
+        self.calibration.read().audio_delay_secs()
+    }
+
+    pub fn quality(&self) -> SyncQuality {
+        let filter = self.filter.read();
+        SyncQuality {
+            offset_ms: filter.get_mean_ms(),
+            variance_ms2: filter.get_variance_ms2(),
+            rtt_ms: *self.last_rtt_ms.read(),
+            converged: filter.is_converged(),
+        }
+    }
+
+    pub fn calibration(&self) -> Calibration {
+        *self.calibration.read()
+    }
+
+    /// Update the clock-offset knob and persist it (and the calibration
+    /// metadata) so other tabs pick it up.
+    pub fn set_clock_offset_ms(&mut self, value: f64) {
+        self.calibration.write().clock_offset_ms = value;
+        self.persist();
+    }
+
+    /// Update the audio-delay knob and persist it.
+    pub fn set_audio_delay_ms(&mut self, value: f64) {
+        self.calibration.write().audio_delay_ms = value;
+        self.persist();
+    }
+
+    /// Reset the estimator and force an immediate probe next tick (the
+    /// re-ping button).
+    pub fn reping(&mut self) {
+        self.filter.write().reset();
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn persist(&self) {
+        let cal = *self.calibration.read();
+        write_calibration(&cal);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn persist(&self) {}
+}
+
+/// Raw device clock in unix seconds.
+#[cfg(target_arch = "wasm32")]
+fn raw_now_secs() -> f64 {
+    js_sys::Date::now() / 1000.0
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn raw_now_secs() -> f64 {
+    chrono::Utc::now().timestamp_millis() as f64 / 1000.0
+}
+
+/// Set up the shared sync signals and, on wasm, spawn the probe loop and the
+/// cross-tab `storage` listener. Safe to call from each page that needs time;
+/// each gets its own estimator that converges to the same server clock.
+pub fn use_time_sync() -> TimeSync {
+    let filter = use_signal(BayesianOffsetFilter::default);
+    let calibration = use_signal(load_calibration);
+    let last_rtt_ms = use_signal(|| Option::<f64>::None);
+    let handle = TimeSync {
+        filter,
+        calibration,
+        last_rtt_ms,
+    };
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let mut filter = filter;
+        let mut last_rtt_ms = last_rtt_ms;
+        use_effect(move || {
+            spawn(async move {
+                loop {
+                    filter.write().predict();
+                    if should_probe(filter.read().get_variance_ms2()) {
+                        if let Some(best) = probe_lowest_rtt().await {
+                            let rtt_ms = best.rtt_secs() * 1000.0;
+                            let variance = measurement_variance_ms2(rtt_ms);
+                            filter.write().observe(best.offset_ms(), variance);
+                            last_rtt_ms.set(Some(rtt_ms));
+                        }
+                    }
+                    gloo_timers::future::TimeoutFuture::new(TICK_INTERVAL_MS).await;
+                }
+            });
+        });
+
+        let calibration = calibration;
+        use_effect(move || {
+            install_storage_listener(calibration);
+        });
+    }
+
+    handle
+}
+
+/// Fire `PROBES_PER_ROUND` server-time requests in parallel and return the
+/// lowest-RTT sample (the one with the least queuing delay).
+#[cfg(target_arch = "wasm32")]
+async fn probe_lowest_rtt() -> Option<Probe> {
+    let probes = (0..PROBES_PER_ROUND).map(|_| single_probe());
+    let samples: Vec<Probe> = futures::future::join_all(probes)
+        .await
+        .into_iter()
+        .flatten()
+        .collect();
+    pick_lowest_rtt(&samples)
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn single_probe() -> Option<Probe> {
+    let client_send_secs = raw_now_secs();
+    let res = crate::api::server_time().await.ok()?;
+    let client_receive_secs = raw_now_secs();
+    Some(Probe {
+        client_send_secs,
+        client_receive_secs,
+        server_time_secs: res.server_time,
+    })
+}
+
+// --- localStorage-backed calibration ---------------------------------------
+
+#[cfg(target_arch = "wasm32")]
+fn local_storage() -> Option<web_sys::Storage> {
+    web_sys::window().and_then(|w| w.local_storage().ok().flatten())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_ms(storage: &web_sys::Storage, key: &str) -> Option<f64> {
+    storage
+        .get_item(key)
+        .ok()
+        .flatten()
+        .and_then(|s| s.parse::<f64>().ok())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn load_calibration() -> Calibration {
+    let Some(storage) = local_storage() else {
+        return Calibration::default();
+    };
+    Calibration {
+        clock_offset_ms: read_ms(&storage, CLOCK_OFFSET_KEY).unwrap_or(0.0),
+        audio_delay_ms: read_ms(&storage, AUDIO_DELAY_KEY).unwrap_or(0.0),
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn load_calibration() -> Calibration {
+    Calibration::default()
+}
+
+/// Persist both knobs so other tabs can pick up the change.
+#[cfg(target_arch = "wasm32")]
+fn write_calibration(cal: &Calibration) {
+    if let Some(storage) = local_storage() {
+        let _ = storage.set_item(CLOCK_OFFSET_KEY, &cal.clock_offset_ms.to_string());
+        let _ = storage.set_item(AUDIO_DELAY_KEY, &cal.audio_delay_ms.to_string());
+    }
+}
+
+/// Reload the calibration signal whenever another tab writes one of our
+/// calibration keys (cross-tab consistency).
+#[cfg(target_arch = "wasm32")]
+fn install_storage_listener(mut calibration: Signal<Calibration>) {
+    use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::JsCast;
+
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let closure = Closure::wrap(Box::new(move |event: web_sys::StorageEvent| {
+        let key = event.key();
+        let touches_calibration = match key.as_deref() {
+            Some(k) => k == CLOCK_OFFSET_KEY || k == AUDIO_DELAY_KEY,
+            None => true,
+        };
+        if touches_calibration {
+            calibration.set(load_calibration());
+        }
+    }) as Box<dyn FnMut(web_sys::StorageEvent)>);
+    let _ = window.add_event_listener_with_callback("storage", closure.as_ref().unchecked_ref());
+    closure.forget();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_close(actual: f64, expected: f64, tol: f64) {
+        assert!(
+            (actual - expected).abs() <= tol,
+            "expected {expected} ± {tol}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn measurement_variance_matches_spec_table() {
+        // stdev = exp(rtt_ms * 0.01); R = stdev^2 = exp(rtt_ms * 0.02).
+        assert_close(measurement_variance_ms2(5.0), 1.05_f64.powi(2), 0.02);
+        assert_close(measurement_variance_ms2(50.0), 1.6487_f64.powi(2), 0.05);
+        assert_close(measurement_variance_ms2(500.0), 148.41_f64.powi(2), 50.0);
+        assert!(measurement_variance_ms2(1000.0) > 1e8);
+    }
+
+    #[test]
+    fn measurement_variance_is_monotonic_in_rtt() {
+        assert!(measurement_variance_ms2(10.0) < measurement_variance_ms2(100.0));
+        assert!(measurement_variance_ms2(100.0) < measurement_variance_ms2(1000.0));
+    }
+
+    #[test]
+    fn pick_lowest_rtt_selects_least_queued_sample() {
+        let samples = vec![
+            Probe { client_send_secs: 0.0, client_receive_secs: 0.30, server_time_secs: 100.0 },
+            Probe { client_send_secs: 0.0, client_receive_secs: 0.05, server_time_secs: 100.0 },
+            Probe { client_send_secs: 0.0, client_receive_secs: 0.20, server_time_secs: 100.0 },
+        ];
+        let best = pick_lowest_rtt(&samples).expect("some sample");
+        assert_close(best.rtt_secs(), 0.05, 1e-9);
+    }
+
+    #[test]
+    fn pick_lowest_rtt_none_when_empty() {
+        assert!(pick_lowest_rtt(&[]).is_none());
+    }
+
+    #[test]
+    fn offset_ms_uses_cristian_formula() {
+        // send at 10.0, receive at 10.2 (rtt 0.2s), server said 100.0s.
+        // offset = (100.0 - 10.2 + 0.1) * 1000 = 89_900 ms.
+        let probe = Probe {
+            client_send_secs: 10.0,
+            client_receive_secs: 10.2,
+            server_time_secs: 100.0,
+        };
+        assert_close(probe.offset_ms(), 89_900.0, 1e-6);
+    }
+
+    #[test]
+    fn next_beat_boundary_rounds_up_to_grid() {
+        // 1.5s grid: 10.0 -> 10.5, 10.4 -> 10.5, 10.6 -> 12.0.
+        assert_close(next_beat_boundary(10.0, 1.5), 10.5, 1e-9);
+        assert_close(next_beat_boundary(10.4, 1.5), 10.5, 1e-9);
+        assert_close(next_beat_boundary(10.6, 1.5), 12.0, 1e-9);
+    }
+
+    #[test]
+    fn next_beat_boundary_on_exact_boundary_returns_same() {
+        // Already exactly on a boundary: return it, not the next one.
+        assert_close(next_beat_boundary(9.0, 1.5), 9.0, 1e-9);
+        assert_close(next_beat_boundary(0.0, 1.5), 0.0, 1e-9);
+    }
+
+    #[test]
+    fn next_beat_boundary_is_always_at_or_after_now() {
+        for &now in &[0.1, 3.7, 100.25, 1_700_000_000.3] {
+            let b = next_beat_boundary(now, 1.5);
+            assert!(b >= now - 1e-9, "boundary {b} should be >= now {now}");
+            assert!(b - now < 1.5 + 1e-9, "boundary should be within one beat");
+        }
+    }
+
+    #[test]
+    fn should_probe_gates_on_converged_threshold() {
+        assert!(should_probe(CONVERGED_VARIANCE_MS2 + 1.0));
+        assert!(!should_probe(CONVERGED_VARIANCE_MS2 - 1.0));
+    }
+
+    #[test]
+    fn server_now_folds_in_clock_offset_only() {
+        let cal = Calibration { clock_offset_ms: 40.0, audio_delay_ms: 250.0 };
+        // raw 1000.0s, estimated offset 60ms, clock offset 40ms → +100ms.
+        assert_close(cal.server_now_secs(1000.0, 60.0), 1000.1, 1e-9);
+        // audio delay must not leak into server_now.
+        let cal_no_audio = Calibration { clock_offset_ms: 40.0, audio_delay_ms: 0.0 };
+        assert_close(
+            cal.server_now_secs(1000.0, 60.0),
+            cal_no_audio.server_now_secs(1000.0, 60.0),
+            1e-12,
+        );
+    }
+
+    #[test]
+    fn audio_delay_secs_converts_ms() {
+        let cal = Calibration { clock_offset_ms: 0.0, audio_delay_ms: 250.0 };
+        assert_close(cal.audio_delay_secs(), 0.25, 1e-12);
+    }
+
+    #[test]
+    fn filter_default_is_not_converged() {
+        // Sanity tie to the shared threshold constant.
+        let filter = BayesianOffsetFilter::default();
+        assert!(!filter.is_converged());
+    }
+}

--- a/frontend/src/time_sync.rs
+++ b/frontend/src/time_sync.rs
@@ -182,8 +182,8 @@ impl TimeSync {
         self.persist();
     }
 
-    /// Reset the estimator and force an immediate probe next tick (the
-    /// re-ping button).
+    /// Reset the estimator and force an immediate probe next tick
+    /// (the re-sync button).
     pub fn reping(&mut self) {
         self.filter.write().reset();
     }


### PR DESCRIPTION
## Summary

stones sync is kinda shitty rn. lets make it better.

## What changed

- change to ping multiple times and take the minimum to reduce the effect of network latency asymmetry
- change to make measurement variance increase with longer RTT (according to an empirically derived exponential)
- increase process variance to something roughly based on how much I saw my clock change one day over an hour. plus some safety factor
- add calibration procedure that walks the user through adjusting:
    - audio delay compensation: bc bluetooth has delay
    - total clock offset: just move the whole clock a constant amount. if theres a persistent offset.

## Test plan

- [x] `just test` passes locally
- [x] `just coverage-check` passes locally, or CI coverage is sufficient
- [x] Manual verification:
  - local testing must be done with a manually edited `api.rs` to make it ping prod, so we actually get nonzero RTT. same goes for testing on dev; that server is very close since it's in berkeley, so we'll get better than expected results!

## Linked issues

Closes #225 

## Screenshots / repro

<img width="320" height="463" alt="image" src="https://github.com/user-attachments/assets/3fa4c6cd-1f4e-4e6b-bb2a-cbba3ddcb3aa" />
<img width="517" height="512" alt="image" src="https://github.com/user-attachments/assets/33a95a47-09f6-4057-8099-9b8aed3e3751" />
<img width="517" height="458" alt="image" src="https://github.com/user-attachments/assets/d8bcf137-4922-4e34-838d-b0ceb0162939" />


### Pre-review checklist

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [x] Targeting `dev`, not `main` (unless this is a release PR).
- [x] `just lint` and `just format` are clean.
- [x] Tests added or updated for the new behavior.
- [ ] ~~If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated.~~
- [ ] ~~If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.~~
- [x] No merge conflicts with the base branch.
