### PR TITLE
[Improvement] Run linter and format checker in github actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@
      Don't just check the boxes; say what you actually ran. -->
 
 - [ ] `just test` passes locally
+- [ ] `just lint` passes locally, or CI coverage is sufficient
 - [ ] `just coverage-check` passes locally, or CI coverage is sufficient
 - [ ] Manual verification:
   -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run test suite with coverage
         run: just coverage-check
+
+      - name: Run linter
+        run: just lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Run linter
         run: just lint
+
+      - name: Run format checker
+        run: uv run ruff format --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: Run tests
 
 on:
-  workflow_dispatch:
   pull_request:
     branches: [main, dev]
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Run tests
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main, dev]
   push:


### PR DESCRIPTION
## Summary

Adds the linter (`just lint`) and format checker (`uv run ruff check .`) to github actions.

## What changed

New "Run linter" and "Run format checker" steps in the test workflow.

"Run linter" runs `just lint`, and "Run format checker" runs `uv run ruff check .`.

## Test plan

CI ran properly in my repo, also confirmed that `uv run ruff check .` exits with a non-zero status code when a format change needs to be made.

## Linked issues

Closes #177

### Pre-review checklist

(is improvement ok?)
- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [x] Targeting `dev`, not `main` (unless this is a release PR).
- [x] `just lint` and `just format` are clean.
~~- [] Tests added or updated for the new behavior.~~
~~- [ ] If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated.~~
~~- [] If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.~~
- [x] No merge conflicts with the base branch.
