### PR TITLE
[Bugfix] fix local links in markdown

### DIFF
--- a/app/filters.py
+++ b/app/filters.py
@@ -130,6 +130,7 @@ def render_markdown(text: str | None) -> str:
             "extra",  # tables, fenced code, etc.
             "sane_lists",
             "smarty",
+            "toc",
             "admonition",  # !!! note "Title" style callouts
         ],
         output_format="html5",

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -72,7 +72,7 @@ create a bunch of fake teams on the official site. What can i do?**
 
    - You can change your *display name*, but your username is
      permanent. This is to ensure links to your profile anywhere will
-     always work (unless you delete your aaccount).
+     always work (unless you delete your account).
 
 **How is my data used? What can and can't other people see?**
 


### PR DESCRIPTION
## Summary

On the /docs page the table of contents links don't work. This PR adds the markdown [toc](https://python-markdown.github.io/extensions/toc/) extension to add id attributes to all the headers in generated html so that these links work like they do on github.

Also fix a typo in docs.md

## What changed

- add [toc](https://python-markdown.github.io/extensions/toc/) markdown extension.
- fix typo in docs.md

## Test plan

Tested and the links in the table of contents the /docs page work now. I'm dumb and can't figure out how to get `just test` and `just coverage-check` (even though I can get the dev server to work??), so I'm leaving those unchecked. (But it's literally a one line change).

- [ ] `just test` passes locally
- [ ] `just coverage-check` passes locally, or CI coverage is sufficient

### Pre-review checklist

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [x] Targeting `dev`, not `main` (unless this is a release PR).
- [x] `just lint` and `just format` are clean.
~~- [ ] Tests added or updated for the new behavior.~~
~~- [ ] If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated.~~
~~- [ ] If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.~~
- [x] No merge conflicts with the base branch.
