### PR TITLE
[Improvement] show team pseudonym on player profiles instead of the team url

### DIFF
--- a/frontend/src/pages/player_profile.rs
+++ b/frontend/src/pages/player_profile.rs
@@ -291,8 +291,8 @@ pub fn PlayerProfile(id: Signal<String>) -> Element {
                                                         }
                                                     }
                                                     td {
-                                                        if let Some(team) = &r.team {
-                                                            Link { to: Route::TeamProfilePage { id: team.clone() }, "{team}" }
+                                                        if let (Some(team), Some(id)) = (&r.team_pseudonym, &r.team) {
+                                                            Link { to: Route::TeamProfilePage { id: id.clone() }, "{team}" }
                                                         } else {
                                                             "Unattached"
                                                         }


### PR DESCRIPTION
## Summary

Show team pseudonym on player profiles instead of the team url.

## Test plan

Tested on the UI, the difference can be seen in the screenshots section.

## Screenshots / repro

Before:

<img width="1061" height="459" alt="image" src="https://github.com/user-attachments/assets/4f02e77f-99b9-4e46-93f4-54ff94fbe17e" />

After:

<img width="1069" height="449" alt="image" src="https://github.com/user-attachments/assets/7caae30e-6152-4862-a4f6-9dd7582ca70f" />


### Pre-review checklist

<!-- Strike through (~~item~~) anything that doesn't apply, rather than
     deleting, so reviewers can see you thought about it. -->

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [x] Targeting `dev`, not `main` (unless this is a release PR).
~~- [ ] `just lint` and `just format` are clean.~~ (no python changes)
~~- [ ] Tests added or updated for the new behavior.~~
~~- [ ] If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated.~~
~~- [ ] If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.~~
- [x] No merge conflicts with the base branch.
