### PR TITLE
[Bugfix] make docs actually deploy to right url

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -39,7 +39,7 @@ systemctl --user start arctos
 if [ "$BUILD_DOCS" -eq 1 ]; then
   just docs
   chmod -R a+rwX docs/_build
-  cp -r docs/_build/html $DOCS_SERVER_ROOT
+  cp -r docs/_build/html/* $DOCS_SERVER_ROOT
 fi
 
 set +e


### PR DESCRIPTION
## Summary

we were just copying the html folder into the docs public folder, so the updated docs were always at `base url/html/*`

## What changed

now we copy all the contents of the html dir instead of the dir itself

## Test plan

ssh'd dev server and ran the cp command manually

### Pre-review checklist

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [x] Targeting `dev`, not `main` (unless this is a release PR).
- [ ] ~~`just lint` and `just format` are clean.~~
- [ ] ~~Tests added or updated for the new behavior.~~
- [ ] ~~If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated.~~
- [ ] ~~If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.~~
- [x] No merge conflicts with the base branch.
