### PR TITLE
[Bugfix] Fix league-scoped registration lookups

### DIFF
--- a/app/filters.py
+++ b/app/filters.py
@@ -18,6 +18,8 @@ bp = Blueprint("filters", __name__)
 def team_registration_for_tournament(team_id: str | None, tournament_url: str) -> "TeamRegistration | None":
     """Return the team registration record for the given team and tournament.
 
+    Honours league-scoped registrations when the tournament belongs to a league.
+
     Args:
         team_id: The team's unique identifier, or ``None`` / falsy to skip
             the database lookup.
@@ -29,12 +31,20 @@ def team_registration_for_tournament(team_id: str | None, tournament_url: str) -
     """
     if not team_id:
         return None
-    return TeamRegistration.query.filter_by(team=team_id, event=tournament_url).first()
+    from models import Tournament
+    from app.services.registration_resolver import team_registration_for_tournament as _resolve
+
+    tournament = Tournament.query.get(tournament_url)
+    if tournament is None:
+        return None
+    return _resolve(tournament, team_id)
 
 
 @bp.app_template_filter("team_by_pseudonym_for_tournament")
 def team_by_pseudonym_for_tournament(pseudonym: str | None, tournament_url: str) -> "TeamRegistration | None":
     """Return the team registration matching a pseudonym within a tournament.
+
+    Honours league-scoped registrations when the tournament belongs to a league.
 
     Args:
         pseudonym: The pseudonym string to search, or ``None`` / falsy to
@@ -47,7 +57,16 @@ def team_by_pseudonym_for_tournament(pseudonym: str | None, tournament_url: str)
     """
     if not pseudonym:
         return None
-    return TeamRegistration.query.filter_by(pseudonym=pseudonym, event=tournament_url).first()
+    from models import Tournament
+    from app.services.registration_resolver import team_registrations_for_tournament
+
+    tournament = Tournament.query.get(tournament_url)
+    if tournament is None:
+        return None
+    for reg in team_registrations_for_tournament(tournament):
+        if reg.pseudonym == pseudonym:
+            return reg
+    return None
 
 
 @bp.app_template_filter("is_head_ref")

--- a/app/routes/matches.py
+++ b/app/routes/matches.py
@@ -18,7 +18,6 @@ from models import (
     Match,
     Tournament,
     Point,
-    PlayerRegistration,
     Player,
     Field,
     PenaltyType,
@@ -52,7 +51,7 @@ def scoreboard():
     match = Match.query.filter_by(event=tournament_url, field=field_name, status=MatchStatus.IN_PROGRESS).first()
 
     # Get team information helper
-    from models import Team, TeamRegistration
+    from models import Team, Tournament
 
     def get_team_info(m):
         if not m:
@@ -62,13 +61,16 @@ def scoreboard():
 
         # Get team names - prefer initial (for dynamic teams), then registration pseudonym, then team name
         # Handle empty strings and missing registration (e.g. dynamic/unregistered team)
-        reg1 = TeamRegistration.query.filter_by(event=tournament_url, team=m.team1).first() if m.team1 else None
+        from app.services.registration_resolver import team_registration_for_tournament
+
+        tournament_obj = Tournament.query.get(tournament_url)
+        reg1 = team_registration_for_tournament(tournament_obj, m.team1) if (tournament_obj and m.team1) else None
         team1_name = (
             (reg1.pseudonym if reg1 and reg1.pseudonym else (team1_obj.name if team1_obj else m.team1_initial))
             if m.team1
             else m.team1_initial
         )
-        reg2 = TeamRegistration.query.filter_by(event=tournament_url, team=m.team2).first() if m.team2 else None
+        reg2 = team_registration_for_tournament(tournament_obj, m.team2) if (tournament_obj and m.team2) else None
         team2_name = (
             (reg2.pseudonym if reg2 and reg2.pseudonym else (team2_obj.name if team2_obj else m.team2_initial))
             if m.team2
@@ -263,7 +265,7 @@ def scoreboard_state():
     match = Match.query.filter_by(event=tournament_url, field=field_name, status=MatchStatus.IN_PROGRESS).first()
 
     # Get team information helper
-    from models import Team, TeamRegistration
+    from models import Team, Tournament
 
     def get_team_info(m):
         if not m:
@@ -273,13 +275,16 @@ def scoreboard_state():
 
         # Get team names - prefer initial (for dynamic teams), then registration pseudonym, then team name
         # Handle empty strings and missing registration (e.g. dynamic/unregistered team)
-        reg1 = TeamRegistration.query.filter_by(event=tournament_url, team=m.team1).first() if m.team1 else None
+        from app.services.registration_resolver import team_registration_for_tournament
+
+        tournament_obj = Tournament.query.get(tournament_url)
+        reg1 = team_registration_for_tournament(tournament_obj, m.team1) if (tournament_obj and m.team1) else None
         team1_name = (
             (reg1.pseudonym if reg1 and reg1.pseudonym else (team1_obj.name if team1_obj else m.team1_initial))
             if m.team1
             else m.team1_initial
         )
-        reg2 = TeamRegistration.query.filter_by(event=tournament_url, team=m.team2).first() if m.team2 else None
+        reg2 = team_registration_for_tournament(tournament_obj, m.team2) if (tournament_obj and m.team2) else None
         team2_name = (
             (reg2.pseudonym if reg2 and reg2.pseudonym else (team2_obj.name if team2_obj else m.team2_initial))
             if m.team2
@@ -785,37 +790,26 @@ def start_match(tournament_url: str):
 
     tournament = Tournament.query.get(tournament_url)
 
-    team1_players = (
-        db.session.query(PlayerRegistration, Player)
-        .join(Player, PlayerRegistration.player == Player.id)
-        .filter(
-            PlayerRegistration.event == tournament_url,
-            PlayerRegistration.team == match.team1,
-            PlayerRegistration.status == RegistrationStatus.CONFIRMED,
-        )
-        .all()
-    )
+    from app.services.registration_resolver import player_registrations_for_tournament
 
-    team2_players = (
-        db.session.query(PlayerRegistration, Player)
-        .join(Player, PlayerRegistration.player == Player.id)
-        .filter(
-            PlayerRegistration.event == tournament_url,
-            PlayerRegistration.team == match.team2,
-            PlayerRegistration.status == RegistrationStatus.CONFIRMED,
-        )
-        .all()
-    )
+    def _regs_with_players(team_id=None):
+        if tournament is None:
+            return []
+        kwargs = {"statuses": [RegistrationStatus.CONFIRMED]}
+        if team_id is not None:
+            if not team_id:
+                return []
+            kwargs["team_id"] = team_id
+        out = []
+        for pr in player_registrations_for_tournament(tournament, **kwargs):
+            player = Player.query.get(pr.player)
+            if player:
+                out.append((pr, player))
+        return out
 
-    all_players = (
-        db.session.query(PlayerRegistration, Player)
-        .join(Player, PlayerRegistration.player == Player.id)
-        .filter(
-            PlayerRegistration.event == tournament_url,
-            PlayerRegistration.status == RegistrationStatus.CONFIRMED,
-        )
-        .all()
-    )
+    team1_players = _regs_with_players(match.team1)
+    team2_players = _regs_with_players(match.team2)
+    all_players = _regs_with_players()
 
     from models import Injury
 
@@ -1021,10 +1015,18 @@ def run_match(tournament_url):
     from app.domain.enums import WinnerSide
     from app.services.dual_write import get_match_player_ids
 
+    from app.services.registration_resolver import player_registration_for_tournament
+
     def _registration_with_player(pid):
-        pr = PlayerRegistration.query.filter_by(
-            event=tournament_url, player=pid, status=RegistrationStatus.CONFIRMED
-        ).first()
+        pr = (
+            player_registration_for_tournament(
+                tournament,
+                pid,
+                statuses=[RegistrationStatus.CONFIRMED],
+            )
+            if tournament is not None
+            else None
+        )
         if not pr:
             return None
         player = Player.query.get(pid)

--- a/app/routes/tournaments/brackets.py
+++ b/app/routes/tournaments/brackets.py
@@ -12,16 +12,16 @@ from datetime import datetime, timezone
 from flask import current_app, g, jsonify, request
 from flask_login import current_user, login_required
 
-from app.domain.enums import MatchStatus, RegistrationStatus
+from app.domain.enums import MatchStatus
 from app.serializers.tournament_serializer import tournament_to_dict
 from app.services.permission_service import PermissionService
 from app.utils.decorators import require_json_body
+from app.services.registration_resolver import team_registration_for_tournament
 from app.utils.helpers import check_tournament_access
 from models import (
     Match,
     Tag,
     Team,
-    TeamRegistration,
     Tournament,
     db,
 )
@@ -33,6 +33,23 @@ def _check_to(tournament_url):
     if not current_user.is_authenticated:
         return False
     return PermissionService.is_tournament_organizer(tournament_url, current_user)
+
+
+def _team_info_payload(tournament, team_id: str) -> dict | None:
+    """Build display dict for a confirmed team registration (event or league)."""
+    if not team_id:
+        return None
+    team_reg = team_registration_for_tournament(tournament, team_id)
+    if not team_reg:
+        return None
+    team = Team.query.get(team_id)
+    return {
+        "id": team_id,
+        "pseudonym": team_reg.pseudonym,
+        "shortname": team_reg.shortname,
+        "profile_photo": team.profile_photo if team else None,
+        "display_text": team_reg.pseudonym,
+    }
 
 
 @bp.route("/tournaments/<tournament_url>/bracket-setup-data", methods=["GET"])
@@ -222,21 +239,8 @@ def tournament_bracket_api(tournament_url):
                 if tag_name:
                     tag = Tag.query.filter_by(event=tournament_url, name=tag_name).first()
                     if tag and tag.team:
-                        team_reg = TeamRegistration.query.filter_by(
-                            event=tournament_url,
-                            team=tag.team,
-                            status=RegistrationStatus.CONFIRMED,
-                        ).first()
-                        if team_reg:
-                            team = Team.query.get(tag.team)
-                            team_info = {
-                                "id": tag.team,
-                                "pseudonym": team_reg.pseudonym,
-                                "shortname": team_reg.shortname,
-                                "profile_photo": team.profile_photo if team else None,
-                                "display_text": team_reg.pseudonym,
-                            }
-                        else:
+                        team_info = _team_info_payload(tournament, tag.team)
+                        if not team_info:
                             team_info = {"display_text": f"tag::{tag_name}"}
                             is_tag = True
                     elif tag:
@@ -255,20 +259,8 @@ def tournament_bracket_api(tournament_url):
                     else:
                         team_id = None
                     if team_id:
-                        team_reg = TeamRegistration.query.filter_by(
-                            event=tournament_url,
-                            team=team_id,
-                            status=RegistrationStatus.CONFIRMED,
-                        ).first()
-                        if team_reg:
-                            team = Team.query.get(team_id)
-                            team_info = {
-                                "id": team_id,
-                                "pseudonym": team_reg.pseudonym,
-                                "shortname": team_reg.shortname,
-                                "profile_photo": team.profile_photo if team else None,
-                                "display_text": team_reg.pseudonym,
-                            }
+                        team_info = _team_info_payload(tournament, team_id)
+                        if team_info:
                             is_reference = True
                 elif match:
                     team_info = {"display_text": team_ref.replace("::", " ")}
@@ -277,38 +269,12 @@ def tournament_bracket_api(tournament_url):
                     team_info = {"display_text": team_ref.replace("::", " ")}
                     is_reference = True
             elif team_ref:
-                team_reg = TeamRegistration.query.filter_by(
-                    event=tournament_url,
-                    team=team_ref,
-                    status=RegistrationStatus.CONFIRMED,
-                ).first()
-                if team_reg:
-                    team = Team.query.get(team_ref)
-                    team_info = {
-                        "id": team_ref,
-                        "pseudonym": team_reg.pseudonym,
-                        "shortname": team_reg.shortname,
-                        "profile_photo": team.profile_photo if team else None,
-                        "display_text": team_reg.pseudonym,
-                    }
-                else:
+                team_info = _team_info_payload(tournament, team_ref)
+                if not team_info:
                     tag = Tag.query.filter_by(event=tournament_url, name=team_ref).first()
                     if tag and tag.team:
-                        team_reg = TeamRegistration.query.filter_by(
-                            event=tournament_url,
-                            team=tag.team,
-                            status=RegistrationStatus.CONFIRMED,
-                        ).first()
-                        if team_reg:
-                            team = Team.query.get(tag.team)
-                            team_info = {
-                                "id": tag.team,
-                                "pseudonym": team_reg.pseudonym,
-                                "shortname": team_reg.shortname,
-                                "profile_photo": team.profile_photo if team else None,
-                                "display_text": team_reg.pseudonym,
-                            }
-                        else:
+                        team_info = _team_info_payload(tournament, tag.team)
+                        if not team_info:
                             team_info = {"display_text": f"tag::{tag.name}"}
                             is_tag = True
                     elif tag:

--- a/app/routes/tournaments/read.py
+++ b/app/routes/tournaments/read.py
@@ -509,6 +509,18 @@ def tournament_invitations_api(tournament_url):
         return jsonify({"error": "Only teams can view invitations"}), 403
 
     tournament = Tournament.query.filter_by(url=tournament_url).first_or_404()
+    # League events register at the league scope — point teams there.
+    if tournament.league_id:
+        return (
+            jsonify(
+                {
+                    "error": "Registration management for league events is on the league page.",
+                    "league_url": tournament.league_id,
+                }
+            ),
+            403,
+        )
+
     team_registration = TeamRegistration.query.filter_by(
         event=tournament_url, team=current_user.id, status=RegistrationStatus.CONFIRMED
     ).first()
@@ -1034,15 +1046,20 @@ def tournament_match_detail(tournament_url):
     team2_selected = set(get_match_player_ids(match, WinnerSide.TEAM2))
 
     # Helper to add players from a team (registration). Skip any player whose id is in exclude_ids (e.g. playing for the other team).
+    from app.services.registration_resolver import (
+        player_registration_for_tournament,
+        player_registrations_for_tournament,
+    )
+
     def add_team_players(team_id, team_side, selected_ids, exclude_ids=None):
         exclude_ids = exclude_ids or set()
         if not team_id:
             return
-        regs = PlayerRegistration.query.filter_by(
-            event=tournament_url,
-            team=team_id,
-            status=RegistrationStatus.CONFIRMED,
-        ).all()
+        regs = player_registrations_for_tournament(
+            tournament,
+            team_id=team_id,
+            statuses=[RegistrationStatus.CONFIRMED],
+        )
 
         for pr in regs:
             if pr.player in exclude_ids:
@@ -1073,11 +1090,11 @@ def tournament_match_detail(tournament_url):
             continue
         player = Player.query.get(pid)
         if player:
-            pr = PlayerRegistration.query.filter_by(
-                event=tournament_url,
-                player=pid,
-                status=RegistrationStatus.CONFIRMED,
-            ).first()
+            pr = player_registration_for_tournament(
+                tournament,
+                pid,
+                statuses=[RegistrationStatus.CONFIRMED],
+            )
             display = get_player_display_from_registration(player, pr) if pr else (player.name or pid)
             match_players.append(
                 {
@@ -1096,11 +1113,11 @@ def tournament_match_detail(tournament_url):
             continue
         player = Player.query.get(pid)
         if player:
-            pr = PlayerRegistration.query.filter_by(
-                event=tournament_url,
-                player=pid,
-                status=RegistrationStatus.CONFIRMED,
-            ).first()
+            pr = player_registration_for_tournament(
+                tournament,
+                pid,
+                statuses=[RegistrationStatus.CONFIRMED],
+            )
             display = get_player_display_from_registration(player, pr) if pr else (player.name or pid)
             match_players.append(
                 {

--- a/app/services/match_start_eligibility.py
+++ b/app/services/match_start_eligibility.py
@@ -15,7 +15,7 @@ Why modal has three sections:
       If user is player not registered -> "you are not registered for this tournament."
       If user is player registered but unattached -> "you are registered as unattached"
       If user is player registered for a team -> "you are currently registered for [team name]"
-      If allow anyone -> "anyone registered for this tournament can head ref."
+      If allow anyone -> "anyone registered for this event (or its league) can head ref."
 """
 
 from __future__ import annotations
@@ -41,7 +41,7 @@ def get_who_allowed_explanation(tournament_url: str, match=None) -> List[str]:
     Based on tournament settings, who should be allowed to head ref?
     - If explicitly listed refs exist: "[list] are allowed"
     - If reffing teams allowed: "players registered for assigned ref teams [list of teams] are allowed."
-    - If allow anyone: "anyone registered for this tournament can head ref."
+    - If allow anyone: "anyone registered for this event (or its league) can head ref."
     """
     from app.error_values import Err, Ok
     from app.services._common import get_tournament_or_err
@@ -66,7 +66,7 @@ def get_who_allowed_explanation(tournament_url: str, match=None) -> List[str]:
             lines.append(f"Players registered for assigned ref teams ({', '.join(names)}) are allowed.")
 
     if tournament.head_refs_allow_anyone:
-        lines.append("Anyone registered for this tournament can head ref.")
+        lines.append("Anyone registered for this event (or its league) can head ref.")
 
     if not lines:
         lines.append("No head ref policy is configured for this tournament.")
@@ -84,7 +84,6 @@ def get_current_user_explanation(tournament_url: str, user) -> List[str]:
     - If player registered for a team: "you are currently registered for [team name]"
     """
     from app.utils.user_helpers import is_player, is_team
-    from models import PlayerRegistration
 
     lines: List[str] = []
 
@@ -106,13 +105,17 @@ def get_current_user_explanation(tournament_url: str, user) -> List[str]:
         lines.append("Could not determine your user.")
         return lines
 
+    from models import Tournament
+    from app.services.registration_resolver import player_registration_for_tournament
+
+    tournament = Tournament.query.get(tournament_url) if tournament_url else None
     reg = (
-        PlayerRegistration.query.filter_by(
-            event=tournament_url,
-            player=user_id,
-            status=RegistrationStatus.CONFIRMED,
-        ).first()
-        if tournament_url
+        player_registration_for_tournament(
+            tournament,
+            user_id,
+            statuses=[RegistrationStatus.CONFIRMED],
+        )
+        if tournament is not None
         else None
     )
 

--- a/app/services/registration_resolver.py
+++ b/app/services/registration_resolver.py
@@ -222,16 +222,21 @@ def is_team_registered(tournament, team_id: str) -> bool:
     )
 
 
-def player_registration_for_tournament(tournament, player_id: str):
-    """Single player registration for (tournament, player_id), or None."""
+def player_registration_for_tournament(tournament, player_id: str, *, statuses=None):
+    """Single player registration for (tournament, player_id), or None.
 
-    prs = player_registrations_for_tournament(
-        tournament,
-        statuses=[
+    Args:
+        tournament: Tournament instance (standalone or league event).
+        player_id: Player id to look up.
+        statuses: Optional list of :class:`~app.domain.enums.RegistrationStatus`
+            values. Defaults to pending + confirmed.
+    """
+    if statuses is None:
+        statuses = [
             RegistrationStatus.PENDING_TEAM_APPROVAL,
             RegistrationStatus.CONFIRMED,
-        ],
-    )
+        ]
+    prs = player_registrations_for_tournament(tournament, statuses=statuses)
     for pr in prs:
         if pr.player == player_id:
             return pr

--- a/app/services/schedule_import_export_service.py
+++ b/app/services/schedule_import_export_service.py
@@ -187,7 +187,7 @@ class ScheduleImportExportService:
             base, sep, suffix = tok.partition("::")
             if not sep:
                 # Plain explicit team id
-                # probably should check that theres a team with this name
+                # probably should check that there's a team with this name
                 # registered for the tournament,
                 # but in normal match creation there's no such constraint
                 # so we'll fail silently for now :thumbsup_all: lmao
@@ -249,8 +249,8 @@ class ScheduleImportExportService:
         Ensure every team referenced by ID (in tags or matches) is registered for the tournament.
         Returns a list of error messages; empty if all referenced teams are registered.
         """
-        from app.domain.enums import TeamRegistrationStatus
-        from models import TeamRegistration
+        from models import Tournament
+        from app.services.registration_resolver import team_registrations_for_tournament
 
         # Collect all team IDs referenced by ID (not tag:: or match::winner/loser)
         team_ids: set[str] = set()
@@ -275,11 +275,17 @@ class ScheduleImportExportService:
         if not team_ids:
             return []
 
+        tournament = Tournament.query.filter_by(url=tournament_url).first()
+        if tournament is None:
+            return [f"Tournament '{tournament_url}' not found"]
+
         registered_team_ids: set[str] = {
             reg.team
-            for reg in TeamRegistration.query.filter_by(event=tournament_url)
-            .filter(TeamRegistration.status != TeamRegistrationStatus.CANCELLED)
-            .all()
+            for reg in team_registrations_for_tournament(
+                tournament,
+                exclude_cancelled=True,
+            )
+            if reg.team
         }
 
         unregistered = team_ids - registered_team_ids

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -8,7 +8,7 @@ import re
 from flask_login import current_user
 from app.domain.enums import RegistrationStatus
 from app.services._common import current_user_type
-from models import Tournament, PlayerRegistration, TeamRegistration, Team
+from models import Tournament, Team
 
 
 def get_registrable_config(tournament):
@@ -108,8 +108,12 @@ def can_head_ref_match(tournament_url: str, player_id: str, match=None) -> bool:
 
     Returns:
         True if the player can head ref, False otherwise
+
+    Registration checks honour both standalone (event-scoped) and league
+    tournaments (league-scoped player registrations).
     """
     from app.services.dual_write import get_head_ref_allowlist_ids, get_match_ref_team_ids
+    from app.services.registration_resolver import player_registrations_for_tournament
 
     tournament = Tournament.query.get(tournament_url)
     if not tournament:
@@ -119,27 +123,26 @@ def can_head_ref_match(tournament_url: str, player_id: str, match=None) -> bool:
     if player_id in get_head_ref_allowlist_ids(tournament):
         return True
 
-    # If allow anyone is enabled, check if player is registered
+    # If allow anyone is enabled, check if player is registered for this
+    # tournament's registration scope (event or parent league).
     if tournament.head_refs_allow_anyone:
-        player_reg = PlayerRegistration.query.filter_by(
-            event=tournament_url,
-            player=player_id,
-            status=RegistrationStatus.CONFIRMED,
-        ).first()
-        return player_reg is not None
+        regs = player_registrations_for_tournament(
+            tournament,
+            statuses=[RegistrationStatus.CONFIRMED],
+        )
+        return any(pr.player == player_id for pr in regs)
 
     # Check reffing teams (requires match context)
     if tournament.head_refs_allow_reffing_teams and match:
         for team_id in get_match_ref_team_ids(match):
             if not team_id:
                 continue
-            player_reg = PlayerRegistration.query.filter_by(
-                event=tournament_url,
-                player=player_id,
-                team=team_id,
-                status=RegistrationStatus.CONFIRMED,
-            ).first()
-            if player_reg:
+            regs = player_registrations_for_tournament(
+                tournament,
+                team_id=team_id,
+                statuses=[RegistrationStatus.CONFIRMED],
+            )
+            if any(pr.player == player_id for pr in regs):
                 return True
 
     return False
@@ -188,7 +191,7 @@ def get_team_display_name_for_event(tournament_url: str, team_id: str) -> str:
     Priority:
 
     1. :class:`~app.models.registration.TeamRegistration` pseudonym (if
-       confirmed and non-empty).
+       confirmed and non-empty), including league-scoped registrations.
     2. :attr:`~app.models.user.Team.name`.
     3. *team_id* as a fallback.
 
@@ -201,11 +204,10 @@ def get_team_display_name_for_event(tournament_url: str, team_id: str) -> str:
     """
     if not team_id:
         return ""
-    from app.domain.enums import TeamRegistrationStatus
+    from app.services.registration_resolver import team_registration_for_tournament
 
-    reg = TeamRegistration.query.filter_by(
-        event=tournament_url, team=team_id, status=TeamRegistrationStatus.CONFIRMED
-    ).first()
+    tournament = Tournament.query.get(tournament_url)
+    reg = team_registration_for_tournament(tournament, team_id) if tournament else None
     if reg and getattr(reg, "pseudonym", None):
         return reg.pseudonym
     team = Team.query.get(team_id)

--- a/app/utils/player_helpers.py
+++ b/app/utils/player_helpers.py
@@ -87,7 +87,7 @@ def get_player_display_name(player_id: str, tournament_url: str) -> Tuple[Option
         return None, None
 
     # Local imports to avoid heavy import chains during app startup.
-    from models import Player, PlayerRegistration
+    from models import Player
 
     player = Player.query.get(player_id)
     if not player:
@@ -97,7 +97,11 @@ def get_player_display_name(player_id: str, tournament_url: str) -> Tuple[Option
     player_display: Optional[str] = None
 
     if tournament_url:
-        reg = PlayerRegistration.query.filter_by(event=tournament_url, player=player_id).first()
+        from models import Tournament
+        from app.services.registration_resolver import player_registration_for_tournament
+
+        tournament = Tournament.query.get(tournament_url)
+        reg = player_registration_for_tournament(tournament, player_id) if tournament is not None else None
         if reg:
             player_display = format_jersey_display(
                 jersey_name=getattr(reg, "jersey_name", None),

--- a/tests/unit/test_league_vs_standalone_registration.py
+++ b/tests/unit/test_league_vs_standalone_registration.py
@@ -1,0 +1,321 @@
+"""League-scoped and event-scoped registrations must behave the same.
+
+These paths historically filtered only on ``event=tournament_url`` and silently
+ignored league registrants (``league_id`` set, ``event`` NULL). Each test builds
+a standalone event and a league event with equivalent confirmed registrations
+and asserts identical outcomes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import pytest
+
+from app.domain.enums import MatchStatus, RegistrationStatus, ScheduleType, TeamRegistrationStatus
+from app.filters import team_by_pseudonym_for_tournament, team_registration_for_tournament as filter_team_reg
+from app.services.match_start_eligibility import get_current_user_explanation
+from app.services.registration_resolver import (
+    player_registration_for_tournament,
+    player_registrations_for_tournament,
+    team_registration_for_tournament,
+)
+from app.services.schedule_import_export_service import ScheduleImportExportService
+from app.utils.helpers import can_head_ref_match, get_team_display_name_for_event
+from app.utils.player_helpers import get_player_display_name
+from models import (
+    League,
+    Match,
+    Player,
+    PlayerRegistration,
+    Team,
+    TeamRegistration,
+    Tournament,
+    db,
+)
+from tests.utils import make_registrable_config
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def _make_standalone_event(prefix: str) -> Tournament:
+    cfg = make_registrable_config(team_registration_open=True, player_registration_open=True)
+    t = Tournament(
+        url=f"{prefix}-sa",
+        name=f"{prefix} standalone",
+        start_date=_now(),
+        end_date=_now() + timedelta(days=1),
+        location="L",
+        max_field_size=14,
+        published=True,
+        schedule_published=True,
+        registrable_config_id=cfg.id,
+        head_refs_allow_anyone=False,
+        head_refs_allow_reffing_teams=False,
+    )
+    db.session.add(t)
+    db.session.flush()
+    return t
+
+
+def _make_league_event(prefix: str) -> Tournament:
+    cfg = make_registrable_config(team_registration_open=True, player_registration_open=True)
+    league = League(url=f"{prefix}-lg", name=f"{prefix} league", registrable_config_id=cfg.id)
+    db.session.add(league)
+    db.session.flush()
+    t = Tournament(
+        url=f"{prefix}-evt",
+        name=f"{prefix} league event",
+        start_date=_now(),
+        end_date=_now() + timedelta(days=1),
+        location="L",
+        max_field_size=14,
+        published=True,
+        schedule_published=True,
+        league_id=league.url,
+        head_refs_allow_anyone=False,
+        head_refs_allow_reffing_teams=False,
+    )
+    db.session.add(t)
+    db.session.flush()
+    return t
+
+
+def _ensure_team(team_id: str, name: str | None = None) -> Team:
+    team = Team.query.get(team_id)
+    if team is None:
+        team = Team(id=team_id, name=name or team_id, pw_hash="x")
+        db.session.add(team)
+        db.session.flush()
+    return team
+
+
+def _ensure_player(player_id: str, name: str | None = None) -> Player:
+    player = Player.query.get(player_id)
+    if player is None:
+        player = Player(id=player_id, name=name or player_id, pw_hash="x")
+        db.session.add(player)
+        db.session.flush()
+    return player
+
+
+def _register_team(tournament: Tournament, team_id: str, *, pseudonym: str) -> None:
+    _ensure_team(team_id)
+    kwargs = {
+        "team": team_id,
+        "pseudonym": pseudonym,
+        "status": TeamRegistrationStatus.CONFIRMED,
+    }
+    if tournament.league_id:
+        kwargs["league_id"] = tournament.league_id
+    else:
+        kwargs["event"] = tournament.url
+    db.session.add(TeamRegistration(**kwargs))
+    db.session.flush()
+
+
+def _register_player(
+    tournament: Tournament,
+    player_id: str,
+    *,
+    team_id: str | None = None,
+    jersey_name: str | None = None,
+    jersey_number: str | None = None,
+) -> None:
+    _ensure_player(player_id)
+    if team_id:
+        _ensure_team(team_id)
+    kwargs = {
+        "player": player_id,
+        "team": team_id,
+        "status": RegistrationStatus.CONFIRMED,
+        "jersey_name": jersey_name,
+        "jersey_number": jersey_number,
+    }
+    if tournament.league_id:
+        kwargs["league_id"] = tournament.league_id
+    else:
+        kwargs["event"] = tournament.url
+    db.session.add(PlayerRegistration(**kwargs))
+    db.session.flush()
+
+
+def _pair(prefix: str) -> tuple[Tournament, Tournament]:
+    """Return (standalone_event, league_event) with distinct URL prefixes."""
+    return _make_standalone_event(f"{prefix}-s"), _make_league_event(f"{prefix}-l")
+
+
+@pytest.mark.unit
+def test_can_head_ref_allow_anyone_league_and_standalone(app, test_db):
+    with app.app_context():
+        sa, lg = _pair("href-any")
+        for t in (sa, lg):
+            t.head_refs_allow_anyone = True
+            _register_player(t, f"p-{t.url}", team_id=f"tm-{t.url}")
+        db.session.commit()
+
+        assert can_head_ref_match(sa.url, f"p-{sa.url}") is True
+        assert can_head_ref_match(lg.url, f"p-{lg.url}") is True
+        assert can_head_ref_match(sa.url, "stranger") is False
+        assert can_head_ref_match(lg.url, "stranger") is False
+
+
+@pytest.mark.unit
+def test_can_head_ref_reffing_teams_league_and_standalone(app, test_db):
+    with app.app_context():
+        sa, lg = _pair("href-ref")
+        for t in (sa, lg):
+            t.head_refs_allow_reffing_teams = True
+            team_id = f"refteam-{t.url}"
+            _register_player(t, f"refp-{t.url}", team_id=team_id)
+            # Match whose assigned ref team is the player's team.
+            _ensure_team("a")
+            _ensure_team("b")
+            m = Match(
+                name=f"M-{t.url}",
+                event=t.url,
+                schedule_type=ScheduleType.STATIC,
+                set_type="SETS",
+                status=MatchStatus.NOT_STARTED,
+                team1="a",
+                team2="b",
+                nominal_length=60,
+            )
+            db.session.add(m)
+            db.session.flush()
+            from app.services.dual_write import set_match_referees
+
+            set_match_referees(m, [team_id], [team_id])
+            db.session.commit()
+
+            assert can_head_ref_match(t.url, f"refp-{t.url}", match=m) is True
+            assert can_head_ref_match(t.url, "other-player", match=m) is False
+
+
+@pytest.mark.unit
+def test_team_display_name_league_and_standalone(app, test_db):
+    with app.app_context():
+        sa, lg = _pair("tdisp")
+        for t, pseudo in ((sa, "Standalone Pseudos"), (lg, "League Pseudos")):
+            _register_team(t, f"team-{t.url}", pseudonym=pseudo)
+        db.session.commit()
+
+        assert get_team_display_name_for_event(sa.url, f"team-{sa.url}") == "Standalone Pseudos"
+        assert get_team_display_name_for_event(lg.url, f"team-{lg.url}") == "League Pseudos"
+
+
+@pytest.mark.unit
+def test_team_registration_helpers_league_and_standalone(app, test_db):
+    with app.app_context():
+        sa, lg = _pair("treg")
+        for t, pseudo in ((sa, "SA Club"), (lg, "LG Club")):
+            _register_team(t, f"tid-{t.url}", pseudonym=pseudo)
+        db.session.commit()
+
+        for t, pseudo in ((sa, "SA Club"), (lg, "LG Club")):
+            tid = f"tid-{t.url}"
+            reg = team_registration_for_tournament(t, tid)
+            assert reg is not None
+            assert reg.pseudonym == pseudo
+            assert filter_team_reg(tid, t.url) is not None
+            assert filter_team_reg(tid, t.url).pseudonym == pseudo
+            by_pseudo = team_by_pseudonym_for_tournament(pseudo, t.url)
+            assert by_pseudo is not None
+            assert by_pseudo.team == tid
+
+
+@pytest.mark.unit
+def test_player_registration_and_roster_league_and_standalone(app, test_db):
+    with app.app_context():
+        sa, lg = _pair("preg")
+        for t in (sa, lg):
+            team_id = f"roster-{t.url}"
+            _register_team(t, team_id, pseudonym=team_id)
+            _register_player(
+                t,
+                f"pl-{t.url}-1",
+                team_id=team_id,
+                jersey_name="Ace",
+                jersey_number="7",
+            )
+            _register_player(
+                t,
+                f"pl-{t.url}-2",
+                team_id=team_id,
+                jersey_name="Bee",
+                jersey_number="11",
+            )
+        db.session.commit()
+
+        for t in (sa, lg):
+            team_id = f"roster-{t.url}"
+            pr = player_registration_for_tournament(t, f"pl-{t.url}-1", statuses=[RegistrationStatus.CONFIRMED])
+            assert pr is not None
+            assert pr.team == team_id
+            roster = player_registrations_for_tournament(t, team_id=team_id, statuses=[RegistrationStatus.CONFIRMED])
+            assert {r.player for r in roster} == {f"pl-{t.url}-1", f"pl-{t.url}-2"}
+
+
+@pytest.mark.unit
+def test_player_display_name_jersey_league_and_standalone(app, test_db):
+    with app.app_context():
+        sa, lg = _pair("jers")
+        for t in (sa, lg):
+            _register_player(
+                t,
+                f"jp-{t.url}",
+                team_id=f"jt-{t.url}",
+                jersey_name="Flash",
+                jersey_number="9",
+            )
+        db.session.commit()
+
+        for t in (sa, lg):
+            name, display = get_player_display_name(f"jp-{t.url}", t.url)
+            assert name  # real player name
+            assert display is not None
+            assert "Flash" in display or "9" in display
+
+
+@pytest.mark.unit
+def test_current_user_explanation_registered_league_and_standalone(app, test_db):
+    with app.app_context():
+        sa, lg = _pair("expl")
+        for t, pseudo in ((sa, "SA Squad"), (lg, "LG Squad")):
+            team_id = f"exteam-{t.url}"
+            _register_team(t, team_id, pseudonym=pseudo)
+            _register_player(t, f"exp-{t.url}", team_id=team_id)
+        db.session.commit()
+
+        for t, pseudo in ((sa, "SA Squad"), (lg, "LG Squad")):
+            player = Player.query.get(f"exp-{t.url}")
+            lines = get_current_user_explanation(t.url, player)
+            joined = " ".join(lines).lower()
+            assert "not registered" not in joined
+            assert pseudo.lower() in joined or "registered" in joined
+
+
+@pytest.mark.unit
+def test_schedule_import_registered_teams_league_and_standalone(app, test_db):
+    with app.app_context():
+        sa, lg = _pair("imp")
+        for t in (sa, lg):
+            _register_team(t, f"ok-{t.url}", pseudonym=f"ok-{t.url}")
+        db.session.commit()
+
+        for t in (sa, lg):
+            errors = ScheduleImportExportService._validate_teams_registered(
+                t.url,
+                tags_data=[{"team": f"ok-{t.url}"}],
+                matches_data=[
+                    {
+                        "team1_initial": f"ok-{t.url}",
+                        "team2_initial": "missing-team",
+                        "refs_initial": "",
+                    }
+                ],
+            )
+            # missing-team should error; registered ok-* should not
+            assert any("missing-team" in e for e in errors)
+            assert not any(f"ok-{t.url}" in e for e in errors)


### PR DESCRIPTION
## Summary

Event-only PlayerRegistration/TeamRegistration filters ignored league registrants, so head-ref eligibility, start-match rosters, scoreboard names, jersey display, bracket overlays, and schedule import validation failed for league events. Route those checks through registration_resolver and guard tournament invitations for league events.

ngl its embarrassing how much of this was broken

## Test plan

added `tests/unit/test_league_vs_standalone_registration.py` with more tests to catch things like this.

- [x] `just test` passes locally
- [x] `just coverage-check` passes locally, or CI coverage is sufficient
- [x] Manual verification:
  - checked that this works for a head ref perms at least

---

### Pre-review checklist

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [x] Targeting `dev`, not `main` (unless this is a release PR).
- [x] `just lint` and `just format` are clean.
- [x] Tests added or updated for the new behavior.
- ~~[ ] If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated.~~
- ~~[ ] If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.~~
- [x] No merge conflicts with the base branch.
