### PR TITLE
[Feature] toml update, solver fixes, and scheduling docs update

### DIFF
--- a/app/routes/tournaments/read.py
+++ b/app/routes/tournaments/read.py
@@ -1232,6 +1232,7 @@ def tournament_match_detail(tournament_url):
                 "team1_initial": match.team1_initial,
                 "team2_initial": match.team2_initial,
                 "status": (match.status.value if hasattr(match.status, "value") else str(match.status)),
+                "scheduled_start_time": dt_iso(match.scheduled_start_time),
                 "nominal_start_time": dt_iso(match.nominal_start_time),
                 "confirmed_start_time": dt_iso(match.confirmed_start_time),
                 "completed_time": dt_iso(match.completed_time),

--- a/app/routes/tournaments/scheduling.py
+++ b/app/routes/tournaments/scheduling.py
@@ -185,6 +185,7 @@ def import_schedule(tournament_url):
             "matches_created": import_result.matches_created,
             "matches_updated": import_result.matches_updated,
             "errors": import_result.errors,
+            "warnings": import_result.warnings,
         }
 
     return json_from_result(res, ok_to_payload=result_to_payload)
@@ -1427,9 +1428,9 @@ def import_schedule_api(tournament_url):
     from app.services.schedule_import_export_service import ScheduleImportExportService
     from app.utils.result_helpers import json_from_result
 
-    def _ok_payload(_):
+    def _ok_payload(import_result):
         recompute_scheduled_and_nominal_times(tournament_url)
-        return {}
+        return {"warnings": import_result.warnings}
 
     res = ScheduleImportExportService.import_schedule(tournament_url, toml_content)
     return json_from_result(res, ok_to_payload=_ok_payload)

--- a/app/routes/tournaments/scheduling.py
+++ b/app/routes/tournaments/scheduling.py
@@ -175,7 +175,8 @@ def import_schedule(tournament_url):
     res = ScheduleImportExportService.import_schedule(tournament_url, toml_content)
 
     def result_to_payload(import_result):
-        """Convert ImportResult to JSON payload."""
+        """Convert ImportResult to JSON payload, then re-solve plan + live timelines."""
+        recompute_scheduled_and_nominal_times(tournament_url)
         return {
             "tags_created": import_result.tags_created,
             "tags_updated": import_result.tags_updated,
@@ -1267,9 +1268,13 @@ def force_start_match_api(tournament_url, match_id):
     r_csv, i_csv = resolve_refs_slots(refs_list, tournament_url)
     set_match_referees_from_csv(match, r_csv, i_csv)
 
-    # Convert to static
+    # Convert to static. The new wall-clock "now" becomes both the plan anchor and
+    # the live estimate — otherwise the planned pass keeps a stale scheduled time
+    # while the board (plan mode) still shows the old slot.
     match.schedule_type = ScheduleType.STATIC
-    match.nominal_start_time = now_utc_naive()
+    now = now_utc_naive()
+    match.nominal_start_time = now
+    match.scheduled_start_time = now
     match.status = MatchStatus.READY_TO_START
 
     # The match is being converted to STATIC and started — fully splice it out of
@@ -1280,7 +1285,8 @@ def force_start_match_api(tournament_url, match_id):
 
     db.session.flush()
     db.session.commit()
-    recompute_all_match_times(tournament_url)
+    # Structural change to a STATIC anchor: re-solve plan then live.
+    recompute_scheduled_and_nominal_times(tournament_url)
 
     return jsonify({"success": True})
 
@@ -1330,12 +1336,25 @@ def push_back_matches_api(tournament_url):
     )
     from datetime import timedelta
 
+    # Push-back is a deliberate shift of the *plan* of the day (e.g. late first
+    # whistle). STATIC anchors must move scheduled_start_time as well as nominal;
+    # dynamic matches then re-derive both timelines from the new anchors.
+    delta = timedelta(minutes=minutes)
     for m in matches:
-        if m.schedule_type == ScheduleType.STATIC and m.nominal_start_time:
-            m.nominal_start_time += timedelta(minutes=minutes)
+        if m.schedule_type != ScheduleType.STATIC:
+            continue
+        if m.scheduled_start_time is not None:
+            m.scheduled_start_time = m.scheduled_start_time + delta
+        if m.nominal_start_time is not None:
+            m.nominal_start_time = m.nominal_start_time + delta
+        # Keep the two aligned if only one was populated.
+        if m.scheduled_start_time is None and m.nominal_start_time is not None:
+            m.scheduled_start_time = m.nominal_start_time
+        if m.nominal_start_time is None and m.scheduled_start_time is not None:
+            m.nominal_start_time = m.scheduled_start_time
 
     db.session.commit()
-    recompute_all_match_times(tournament_url)
+    recompute_scheduled_and_nominal_times(tournament_url)
     return jsonify({"success": True})
 
 

--- a/app/serializers/match_schedule_serializer.py
+++ b/app/serializers/match_schedule_serializer.py
@@ -143,7 +143,12 @@ class MatchScheduleSerializer:
         if match.ribbon:
             result["ribbon"] = True
 
-        # Datetime - only include if present
+        # Datetimes — export both timelines when present.
+        # scheduled_start_time is the plan anchor (STATIC user time / planned pass);
+        # nominal_start_time is the live estimate. On re-import, STATIC anchors need
+        # scheduled_start_time so the planned pass does not lose the published times.
+        if match.scheduled_start_time:
+            result["scheduled_start_time"] = match.scheduled_start_time
         if match.nominal_start_time:
             result["nominal_start_time"] = match.nominal_start_time
 
@@ -276,19 +281,41 @@ class MatchScheduleSerializer:
             "next_match": None,
         }
 
-        # Handle datetime
-        if "nominal_start_time" in data and data["nominal_start_time"]:
-            dt_value = data["nominal_start_time"]
+        # Handle datetimes (planned + live). Accept either field; seed the other when
+        # only one is present so STATIC anchors always land in scheduled_start_time.
+        def _parse_dt(field_name: str, dt_value: object) -> Result[datetime, ValidationError]:
             if isinstance(dt_value, datetime):
-                result["nominal_start_time"] = dt_value
-            elif isinstance(dt_value, str):
+                return Ok(dt_value)
+            if isinstance(dt_value, str):
                 try:
-                    # Try parsing ISO format
-                    result["nominal_start_time"] = datetime.fromisoformat(dt_value.replace("Z", "+00:00"))
+                    return Ok(datetime.fromisoformat(dt_value.replace("Z", "+00:00")))
                 except ValueError:
-                    return Err(ValidationError(f"Invalid datetime format: {dt_value}"))
-            else:
-                return Err(ValidationError(f"Invalid nominal_start_time type: {type(dt_value)}"))
+                    return Err(ValidationError(f"Invalid datetime format for {field_name}: {dt_value}"))
+            return Err(ValidationError(f"Invalid {field_name} type: {type(dt_value)}"))
+
+        scheduled_dt = None
+        nominal_dt = None
+        if data.get("scheduled_start_time"):
+            parsed = _parse_dt("scheduled_start_time", data["scheduled_start_time"])
+            if isinstance(parsed, Err):
+                return parsed
+            scheduled_dt = parsed.val
+        if data.get("nominal_start_time"):
+            parsed = _parse_dt("nominal_start_time", data["nominal_start_time"])
+            if isinstance(parsed, Err):
+                return parsed
+            nominal_dt = parsed.val
+
+        if scheduled_dt is None and nominal_dt is not None:
+            # Legacy TOML / exports that only had nominal: treat it as the plan anchor.
+            scheduled_dt = nominal_dt
+        if nominal_dt is None and scheduled_dt is not None:
+            nominal_dt = scheduled_dt
+
+        if scheduled_dt is not None:
+            result["scheduled_start_time"] = scheduled_dt
+        if nominal_dt is not None:
+            result["nominal_start_time"] = nominal_dt
 
         # Helper function to resolve match name to UUID
         def resolve_match_name(match_name: str, current_field: str | None) -> str | None:

--- a/app/services/schedule_import_export_service.py
+++ b/app/services/schedule_import_export_service.py
@@ -69,6 +69,11 @@ def _create_match_from_dict(match_dict: dict) -> "Match":
         k: v for k, v in match_dict.items() if k not in ("previous_match", "next_match", "refs", "refs_initial")
     }
     match = Match(**create_dict)
+    # Keep plan + live anchors aligned when the TOML only carried one of them.
+    if match.scheduled_start_time is None and match.nominal_start_time is not None:
+        match.scheduled_start_time = match.nominal_start_time
+    if match.nominal_start_time is None and match.scheduled_start_time is not None:
+        match.nominal_start_time = match.scheduled_start_time
     if not match.status:
         if match.schedule_type == ScheduleType.STATIC:
             match.status = MatchStatus.READY_TO_START
@@ -567,6 +572,12 @@ class ScheduleImportExportService:
                                 "refs_initial",
                             ):
                                 setattr(match, key, value)
+
+                        # Align plan/live anchors when the file only carried one of them.
+                        if match.scheduled_start_time is None and match.nominal_start_time is not None:
+                            match.scheduled_start_time = match.nominal_start_time
+                        if match.nominal_start_time is None and match.scheduled_start_time is not None:
+                            match.nominal_start_time = match.scheduled_start_time
 
                         # If _initial fields changed, refresh the corresponding resolved values.
                         if team1_initial_changed:

--- a/app/services/schedule_import_export_service.py
+++ b/app/services/schedule_import_export_service.py
@@ -8,6 +8,7 @@ conversion and with ``app.utils.toml_helpers`` for the parse / write.
 
 from __future__ import annotations
 
+import re
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -27,28 +28,80 @@ if TYPE_CHECKING:  # pragma: no cover
     pass
 
 
-def _is_explicit_team_id(token: str) -> bool:
-    """Return ``True`` if *token* is a direct team ID rather than a reference.
+# TEAM atoms in the ASS grammar are "[" /[^\]]+/ "]" (see app/utils/grammar.lark),
+# so a bracketed run without "]" inside is exactly one team literal.
+_ASS_TEAM_LITERAL_RE = re.compile(r"\[([^\]]+)\]")
 
-    Returns ``False`` for:
 
-    * ``tag::<name>`` — tag references
-    * Strings containing ``::winner`` or ``::loser`` — match references
+def _known_team_tokens(tournament) -> set[str]:
+    """Return the set of tokens that resolve to a registered team.
+
+    Mirrors the registration lookups used by
+    :mod:`app.utils.match_ref_resolution` (team ID or pseudonym of a
+    registration for this tournament / league scope). Non-cancelled
+    registrations count, matching the previous import-time check.
+    """
+    from app.services.registration_resolver import team_registrations_for_tournament
+
+    known: set[str] = set()
+    for reg in team_registrations_for_tournament(tournament, exclude_cancelled=True):
+        if reg.team:
+            known.add(reg.team)
+        if reg.pseudonym:
+            known.add(reg.pseudonym)
+    return known
+
+
+def rewrite_unknown_team_token(token: str, known_teams: set[str]) -> tuple[str, str | None]:
+    """Rewrite a team slot token to a ``tag::`` reference when the team is unknown.
+
+    Tokens that are empty, already symbolic (``tag::<name>``, or containing
+    ``::winner`` / ``::loser``), or that resolve to a registered team are
+    returned unchanged.
 
     Args:
-        token: A team slot string from the schedule.
+        token: A ``team1_initial`` / ``team2_initial`` / refs slot token.
+        known_teams: Team IDs and pseudonyms registered for the tournament.
 
     Returns:
-        ``True`` when *token* is an explicit team ID.
+        ``(new_token, warning)`` where *warning* is ``None`` when the token
+        was left unchanged.
     """
-    if not token or not str(token).strip():
-        return False
-    t = str(token).strip()
-    if t.lower().startswith("tag::"):
-        return False
-    if "::winner" in t.lower() or "::loser" in t.lower():
-        return False
-    return True
+    tok = (token or "").strip()
+    if not tok:
+        return tok, None
+    low = tok.lower()
+    if low.startswith("tag::") or "::winner" in low or "::loser" in low:
+        return tok, None
+    if tok in known_teams:
+        return tok, None
+    new_tok = f"tag::{tok}"
+    return new_tok, f"Team '{tok}' not found; imported as tag reference '{new_tok}'"
+
+
+def _rewrite_skip_condition(expression: str, known_teams: set[str]) -> tuple[str, list[str], list[str]]:
+    """Rewrite unknown team literals ``[Foo]`` in an ASS expression to ``[tag::Foo]``.
+
+    Literals containing ``::`` (match ``[X::winner]`` / ``[X::loser]`` refs and
+    ``[tag::X]`` refs) are left untouched, as are literals naming a registered
+    team. Works textually so expressions referencing not-yet-imported matches
+    stay valid.
+
+    Returns:
+        ``(new_expression, warnings, rewritten_tokens)``.
+    """
+    warnings: list[str] = []
+    rewritten: list[str] = []
+
+    def _repl(m: re.Match) -> str:
+        inner = m.group(1).strip()
+        if not inner or "::" in inner or inner in known_teams:
+            return m.group(0)
+        rewritten.append(inner)
+        warnings.append(f"Team '{inner}' not found; imported as tag reference 'tag::{inner}'")
+        return f"[tag::{inner}]"
+
+    return _ASS_TEAM_LITERAL_RE.sub(_repl, expression), warnings, rewritten
 
 
 def _create_match_from_dict(match_dict: dict) -> "Match":
@@ -102,6 +155,8 @@ class ImportResult:
         matches_updated: Number of existing match records updated.
         errors: List of human-readable error strings encountered during
             import.  Non-empty indicates a partial or failed import.
+        warnings: List of human-readable, non-fatal warnings (e.g. unknown
+            team references rewritten to ``tag::`` references).
     """
 
     tags_created: int = 0
@@ -111,11 +166,14 @@ class ImportResult:
     matches_created: int = 0
     matches_updated: int = 0
     errors: list[str] = None
+    warnings: list[str] = None
 
     def __post_init__(self) -> None:
-        """Initialise the mutable *errors* list on a frozen dataclass."""
+        """Initialise the mutable list fields on a frozen dataclass."""
         if self.errors is None:
             object.__setattr__(self, "errors", [])
+        if self.warnings is None:
+            object.__setattr__(self, "warnings", [])
 
 
 @dataclass(frozen=True)
@@ -131,6 +189,7 @@ class ScheduleImportExportService:
         tags_data: list[dict],
         fields_data: list[dict],
         matches_data: list[dict],
+        extra_tag_names: set[str] | None = None,
     ) -> list[str]:
         """
         Perform higher-level semantic validation on the uploaded schedule.
@@ -152,7 +211,7 @@ class ScheduleImportExportService:
             if name:
                 field_names.add(name)
 
-        tag_names: set[str] = set()
+        tag_names: set[str] = set(extra_tag_names or ())
         for t in tags_data:
             name = str(t.get("name", "")).strip()
             if name:
@@ -245,62 +304,84 @@ class ScheduleImportExportService:
         return errors
 
     @staticmethod
-    def _validate_teams_registered(
-        tournament_url: str,
+    def _rewrite_unknown_team_refs(
+        tournament,
         tags_data: list[dict],
         matches_data: list[dict],
-    ) -> list[str]:
-        """
-        Ensure every team referenced by ID (in tags or matches) is registered for the tournament.
-        Returns a list of error messages; empty if all referenced teams are registered.
-        """
-        from models import Tournament
-        from app.services.registration_resolver import team_registrations_for_tournament
+    ) -> tuple[list[dict], list[dict], list[str], set[str]]:
+        """Rewrite references to unknown teams into ``tag::`` references.
 
-        # Collect all team IDs referenced by ID (not tag:: or match::winner/loser)
-        team_ids: set[str] = set()
+        Applies :func:`rewrite_unknown_team_token` to ``team1_initial`` /
+        ``team2_initial`` / ``refs_initial`` slots and
+        :func:`_rewrite_skip_condition` to ``skip_condition`` expressions.
+        Tag rows assigning an unknown team ID are imported unassigned instead
+        of failing. Only the uploaded data is rewritten — existing DB rows are
+        never touched here.
 
+        Returns:
+            ``(tags_data, matches_data, warnings, auto_tag_names)`` where
+            *warnings* is deduplicated (one per rewritten token) and
+            *auto_tag_names* lists tag names that must exist for the rewritten
+            references to resolve (created idempotently during import).
+        """
+        known_teams = _known_team_tokens(tournament)
+
+        warnings: dict[str, str] = {}  # token -> warning (dedup, insertion-ordered)
+        auto_tag_names: set[str] = set()
+
+        new_tags: list[dict] = []
         for tag in tags_data:
             team_val = str(tag.get("team", "")).strip()
-            if team_val:
-                team_ids.add(team_val)
+            if team_val and team_val not in known_teams:
+                tag = {**tag, "team": ""}
+                tag_name = str(tag.get("name", "")).strip() or "<unnamed tag>"
+                warnings.setdefault(
+                    f"tag-team::{team_val}",
+                    f"Team '{team_val}' not found; tag '{tag_name}' imported unassigned",
+                )
+            new_tags.append(tag)
 
+        new_matches: list[dict] = []
         for m in matches_data:
+            m = dict(m)
+
             for field_name in ("team1_initial", "team2_initial"):
                 tok = str(m.get(field_name, "")).strip()
-                if tok and _is_explicit_team_id(tok):
-                    team_ids.add(tok)
+                if not tok:
+                    continue
+                new_tok, warning = rewrite_unknown_team_token(tok, known_teams)
+                if warning:
+                    m[field_name] = new_tok
+                    warnings.setdefault(tok, warning)
+                    auto_tag_names.add(tok)
+
             refs_raw = str(m.get("refs_initial", "")).strip()
             if refs_raw:
+                new_slots: list[str] = []
+                changed = False
                 for part in refs_raw.split(","):
                     tok = part.strip()
-                    if tok and _is_explicit_team_id(tok):
-                        team_ids.add(tok)
+                    new_tok, warning = rewrite_unknown_team_token(tok, known_teams)
+                    if warning:
+                        changed = True
+                        warnings.setdefault(tok, warning)
+                        auto_tag_names.add(tok)
+                    new_slots.append(new_tok)
+                if changed:
+                    m["refs_initial"] = ",".join(new_slots)
 
-        if not team_ids:
-            return []
+            skip_raw = str(m.get("skip_condition", "")).strip()
+            if skip_raw:
+                new_expr, skip_warnings, rewritten = _rewrite_skip_condition(skip_raw, known_teams)
+                if rewritten:
+                    m["skip_condition"] = new_expr
+                    for tok, warning in zip(rewritten, skip_warnings):
+                        warnings.setdefault(tok, warning)
+                        auto_tag_names.add(tok)
 
-        tournament = Tournament.query.filter_by(url=tournament_url).first()
-        if tournament is None:
-            return [f"Tournament '{tournament_url}' not found"]
+            new_matches.append(m)
 
-        registered_team_ids: set[str] = {
-            reg.team
-            for reg in team_registrations_for_tournament(
-                tournament,
-                exclude_cancelled=True,
-            )
-            if reg.team
-        }
-
-        unregistered = team_ids - registered_team_ids
-        if not unregistered:
-            return []
-
-        errors: list[str] = []
-        for tid in sorted(unregistered):
-            errors.append(f"Team '{tid}' is not registered for this tournament.")
-        return errors
+        return new_tags, new_matches, list(warnings.values()), auto_tag_names
 
     @staticmethod
     @allow_Q
@@ -341,7 +422,6 @@ class ScheduleImportExportService:
         }
 
         toml_content = write_toml_schedule(
-            event=tournament_url,
             tags=tag_dicts,
             fields=field_dicts,
             matches=match_dicts,
@@ -384,7 +464,18 @@ class ScheduleImportExportService:
 
         tournament = get_tournament_or_err(tournament_url).Q()
 
-        is_same_tournament = source_event == tournament_url
+        # `event` in the file is legacy/optional: when absent, treat the file as
+        # belonging to this tournament (exports no longer carry an event key).
+        is_same_tournament = source_event is None or source_event == tournament_url
+
+        # Rewrite references to unknown teams into tag:: references (with
+        # per-token warnings) before validation and the create/update path.
+        (
+            tags_data,
+            matches_data,
+            warnings,
+            auto_tag_names,
+        ) = ScheduleImportExportService._rewrite_unknown_team_refs(tournament, tags_data, matches_data)
 
         tags_created = 0
         tags_updated = 0
@@ -395,8 +486,10 @@ class ScheduleImportExportService:
         errors: list[str] = []
 
         # Perform all validation before making any database changes
-        # 1. High-level semantic validation
-        semantic_errors = ScheduleImportExportService._validate_semantics(tags_data, fields_data, matches_data)
+        # 1. High-level semantic validation (auto-created tag names count as known)
+        semantic_errors = ScheduleImportExportService._validate_semantics(
+            tags_data, fields_data, matches_data, extra_tag_names=auto_tag_names
+        )
         errors.extend(semantic_errors)
 
         # 2. Validate all tags
@@ -416,9 +509,6 @@ class ScheduleImportExportService:
             res = MatchScheduleSerializer.match_from_dict(match_data, tournament_url)
             if isinstance(res, Err):
                 errors.append(f"Match validation error: {res.value.message}")
-
-        # 5. Ensure all teams referenced by ID (tags and matches) are registered
-        errors.extend(ScheduleImportExportService._validate_teams_registered(tournament_url, tags_data, matches_data))
 
         # If any validation errors, abort before making any changes
         if errors:
@@ -481,6 +571,18 @@ class ScheduleImportExportService:
                     create_dict = {k: v for k, v in tag_dict.items() if k != "id"}
                     tag = Tag(**create_dict)
                     db.session.add(tag)
+                    tags_created += 1
+
+            # Auto-create unassigned tags backing rewritten unknown-team
+            # references. Idempotent: unique per (event, name), and re-imports
+            # of a rewritten file hit the tag:: fast path so no tag::tag::X.
+            for auto_name in sorted(auto_tag_names):
+                if auto_name in kept_tag_names:
+                    continue
+                kept_tag_names.add(auto_name)
+                existing_tag = Tag.query.filter_by(event=tournament_url, name=auto_name).first()
+                if existing_tag is None:
+                    db.session.add(Tag(event=tournament_url, name=auto_name))
                     tags_created += 1
 
             # Import fields
@@ -601,6 +703,13 @@ class ScheduleImportExportService:
                         kept_match_uuids.add(match.uuid)
                         matches_updated += 1
                     else:
+                        # UUID not in this tournament. If it exists elsewhere
+                        # (e.g. an event-less export from another tournament),
+                        # mint a fresh UUID instead of colliding on the PK.
+                        if Match.query.filter_by(uuid=match_dict["uuid"]).first() is not None:
+                            new_uuid = str(uuid.uuid4())
+                            match_uuid_map[match_dict["uuid"]] = new_uuid
+                            match_dict = {**match_dict, "uuid": new_uuid}
                         match = _create_match_from_dict(match_dict)
                         match_name_to_uuid[match_name] = match.uuid
                         match_field = match.field or ""
@@ -630,7 +739,8 @@ class ScheduleImportExportService:
                 # Find the match we just created/updated
                 # Use field to disambiguate if duplicates exist
                 if is_same_tournament and old_uuid:
-                    match = Match.query.filter_by(uuid=old_uuid, event=tournament_url).first()
+                    lookup_uuid = match_uuid_map.get(old_uuid, old_uuid)
+                    match = Match.query.filter_by(uuid=lookup_uuid, event=tournament_url).first()
                 else:
                     # Different tournament: use new UUID from map
                     if old_uuid and old_uuid in match_uuid_map:
@@ -719,6 +829,7 @@ class ScheduleImportExportService:
                 matches_created=matches_created,
                 matches_updated=matches_updated,
                 errors=errors,
+                warnings=warnings,
             )
 
             return Ok(result)

--- a/app/utils/toml_helpers.py
+++ b/app/utils/toml_helpers.py
@@ -18,7 +18,9 @@ def parse_toml_schedule(content: str) -> Result[dict[str, Any], ArctosError]:
 
     Expects a TOML document with:
 
-    * ``event`` (str, required) — tournament URL slug.
+    * ``event`` (str, optional, deprecated) — tournament URL slug. Accepted
+      for backward compatibility with older exports; the importing route
+      determines the target tournament.
     * ``tags`` (array of tables, optional).
     * ``fields`` (array of tables, optional).
     * ``matches`` (array of tables, optional).
@@ -28,8 +30,8 @@ def parse_toml_schedule(content: str) -> Result[dict[str, Any], ArctosError]:
 
     Returns:
         :class:`~app.error_values.Ok` wrapping a dict with keys
-        ``"event"``, ``"tags"``, ``"fields"``, ``"matches"``; or
-        :class:`~app.error_values.Err` wrapping a
+        ``"event"`` (str or ``None``), ``"tags"``, ``"fields"``,
+        ``"matches"``; or :class:`~app.error_values.Err` wrapping a
         :class:`~app.exceptions.ValidationError` on parse / structure error.
     """
     try:
@@ -41,10 +43,10 @@ def parse_toml_schedule(content: str) -> Result[dict[str, Any], ArctosError]:
     if not isinstance(data, dict):
         return Err(ValidationError("TOML root must be a table"))
 
-    # Extract event (required)
+    # Extract event (optional, legacy). Non-string values are ignored.
     event = data.get("event")
-    if not event or not isinstance(event, str):
-        return Err(ValidationError("Missing or invalid 'event' field in TOML"))
+    if not isinstance(event, str) or not event:
+        event = None
 
     # Extract tags (optional, defaults to empty list)
     tags = data.get("tags", [])
@@ -72,7 +74,6 @@ def parse_toml_schedule(content: str) -> Result[dict[str, Any], ArctosError]:
 
 
 def write_toml_schedule(
-    event: str,
     tags: list[dict[str, Any]],
     fields: list[dict[str, Any]],
     matches: list[dict[str, Any]],
@@ -83,10 +84,10 @@ def write_toml_schedule(
 
     Produces a human-readable TOML document suitable for download or
     re-import.  An optional metadata comment header is prepended when
-    *metadata* is provided.
+    *metadata* is provided.  The document intentionally carries no ``event``
+    key — the target tournament is determined by the importing route.
 
     Args:
-        event: Tournament URL slug written as the ``event`` key.
         tags: List of tag dicts with ``id``, ``name``, and optional
             ``team`` (team ID).
         fields: List of field dicts with ``id``, ``name``, and ``camera``.
@@ -105,10 +106,6 @@ def write_toml_schedule(
         for key, value in metadata.items():
             lines.append(f"# {key}: {value}")
         lines.append("")
-
-    # Event
-    lines.append(f'event = "{_escape_toml_string(event)}"')
-    lines.append("")
 
     # Tags
     if tags:

--- a/app/utils/toml_helpers.py
+++ b/app/utils/toml_helpers.py
@@ -162,14 +162,14 @@ def write_toml_schedule(
                 if field_name in match and match[field_name]:
                     lines.append(f'{field_name} = "{_escape_toml_string(str(match[field_name]))}"')
 
-            # Datetime
-            if "nominal_start_time" in match and match["nominal_start_time"]:
-                dt = match["nominal_start_time"]
-                if isinstance(dt, datetime):
-                    # Format as ISO 8601 string (TOML datetime format)
-                    lines.append(f'nominal_start_time = "{dt.isoformat()}"')
-                else:
-                    lines.append(f'nominal_start_time = "{dt}"')
+            # Datetimes: plan anchor first, then live estimate.
+            for field_name in ("scheduled_start_time", "nominal_start_time"):
+                if field_name in match and match[field_name]:
+                    dt = match[field_name]
+                    if isinstance(dt, datetime):
+                        lines.append(f'{field_name} = "{dt.isoformat()}"')
+                    else:
+                        lines.append(f'{field_name} = "{dt}"')
 
             # Integer fields
             for field_name in ["nominal_length", "nsets", "stones_per_set"]:

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,6 +1,54 @@
 # Scheduling Algorithm
 
-### `MatchGraph` class
+## Two timelines
+
+Every match has **two** start-time fields. They look similar and are easy to
+confuse; they are not interchangeable.
+
+| Field | Meaning | Who writes it | Moves when games run late? |
+|-------|---------|---------------|----------------------------|
+| **`scheduled_start_time`** | **Plan** — “if everything went as published” | Planned scheduling pass only | **No** |
+| **`nominal_start_time`** | **Live estimate** — when we currently expect the match to start | Live PROCEDURE pass | **Yes** |
+| `confirmed_start_time` | Wall-clock start once the match is started | Match start | N/A (history) |
+| `completed_time` | Wall-clock end | Match finalize | N/A (history) |
+
+### Why both exist
+
+Dynamic types (`SAFE` / `FAST` / `BREAK` / `JOIN`) recompute `nominal_start_time`
+from real dependency finish times. If the UI placed blocks on nominal alone,
+a delayed morning game would **slide the whole day** on the board. Players then
+treat the slipped time as the new plan, arrive a little late again, and lateness
+compounds.
+
+`scheduled_start_time` is the stable **contract of the day**:
+
+- STATIC anchors keep the user-chosen plan time.
+- Dynamic matches get plan times by walking dependencies with
+  `scheduled_start + nominal_length` only (no confirmed times, no status).
+- Match start / end runs the **live pass only**, so the plan does not move.
+
+UI rule (schedule display): a match is shown at its planned time **or
+earlier** — blocks are placed at `scheduled_start_time`, but pull earlier
+(and show real end times) when the day runs ahead of plan. They are never
+displayed later than plan; lateness shows via the now line instead. Edit
+mode has an option to display times exactly as they happened.
+
+### When each pass runs
+
+| Event | Pass |
+|-------|------|
+| Match start / end / finalize | Live only → `recompute_all_match_times` (= `run_scheduling(scheduled_pass=False)`) |
+| Match create / edit / delete | Both → `recompute_scheduled_and_nominal_times` |
+| TO “Recompute times” / TOML import (API) / app boot | Both |
+| Force-start convert to STATIC | Both (after writing the new STATIC anchor into **both** start fields) |
+
+`recompute_scheduled_and_nominal_times` always runs **planned first, then live**,
+so the live pass’s cross-field resource-conflict edges can anchor on fresh
+planned times.
+
+---
+
+## `MatchGraph` class
 
 represents the data in the Match model, but entirely in memory, and
 with relations as actual references like a graph. References are:
@@ -17,10 +65,11 @@ with relations as actual references like a graph. References are:
   direct dependencies should return an end time that is actually the
   start time of the match referenced in the `(skip-condition MATCH)`
   command.
-- the latest (by *scheduled* start time, which is just nominal start
-  time but it doesn't change when true match start/end times come in
-  to preserve ordering) match on each field whose nominal start time
-  is before this match's nominal start time.
+- cross-field **resource-conflict** edges (live pass only): a
+  SAFE/FAST match depends on the latest earlier (by
+  `scheduled_start_time`) match on another field that shares a
+  participating team. The planned pass **omits** these edges so the
+  plan cannot depend on itself through a shifting conflict edge.
 
 JOIN matches with the same name are stored as a single node, not
 multiple. They have the union of each one's dependencies.
@@ -36,16 +85,22 @@ it will search past any `BREAK`/`JOIN` matches).
 
 The `Dependency` abstract class wraps a pointer to a
 `MatchNode`. it hashes to the same thing as the node it points to, so it
-can be used in equality checks. It adds a `get_time()` method which gets
-the effective end time of that node. For most dependencies, this'll be
-the end time of the wrapped match. But for matches which are dependent
-through a `(skip-condition MATCH)` (as specified by the non-direct
-group of dependencies from `Match.get_skip_condition_dependencies()`),
-it should return the start time of the match.
+can be used in equality checks. It adds:
+
+- `get_time()` — **live** effective time (confirmed/nominal start or end)
+- `get_scheduled_time()` — **plan** effective time (`scheduled_start` or
+  `scheduled_start + nominal_length`)
 
 there are two subclasses of Dependency:
 - `startOfMatchDep`
 - `endOfMatchDep`
+
+---
+
+## Live PROCEDURE (writes `nominal_start_time` + status)
+
+Used by `run_scheduling(..., scheduled_pass=False)`.
+**Never writes `scheduled_start_time`.**
 
 ```
 PROCEDURE: WITH MATCH m {
@@ -108,18 +163,64 @@ PROCEDURE: WITH MATCH m {
 }
 ```
 
-### On Match Start/End
+`END_TIME(x)` uses confirmed end when present, else confirmed start + length,
+else nominal start + length (and for SKIPPED, nominal start alone in the live
+graph helpers — see `MatchGraph._node_end_time`).
+
+---
+
+## Planned PROCEDURE (writes `scheduled_start_time` only)
+
+Used by `run_scheduling(..., scheduled_pass=True)`.
+**Never reads status or confirmed times. Never writes `nominal_start_time`.**
+
+```
+SCHEDULED_PROCEDURE: WITH MATCH m {
+	IF m is STATIC {
+		// Keep user-set scheduled_start_time anchor; do nothing.
+		return
+	}
+	// SAFE / FAST / BREAK / JOIN
+	SET m.scheduled_start_time = latest(
+		SCHEDULED_END_TIMES m.get_direct_dependencies()
+	)
+	// where SCHEDULED_END(x) = x.scheduled_start_time + x.nominal_length
+	// and start-of-match deps use x.scheduled_start_time alone
+}
+```
+
+Notes:
+
+- Skipped matches still contribute full `nominal_length` on the plan (the plan
+  assumes the slot existed).
+- If a node is in a dependency cycle, fall back to the DLL previous match’s
+  scheduled end (same idea as the live cycle fallback).
+- After structural edits, always run planned **then** live.
+
+---
+
+## On Match Start/End
 
 0. acquire lock on matches
 1. set the match to COMPLETED or IN_PROGRESS as needed, and notate the relevant timestamps.
 2. load match graph from db
 3. topological sort.
-4. in order from root to leaf nodes, perform PROCEDURE.
-5. write data to db from graph
+4. in order from root to leaf nodes, perform **live** PROCEDURE.
+5. write **nominal_start_time + status** to db from graph
 6. release lock
 
+Do **not** run the planned pass here — that would let real delays rewrite the plan.
 
-### On Match Create/Edit
+---
 
-same as on match start/end, but first set time_finalized on any matches which
-should be finalized from the beginning.
+## On Match Create/Edit
+
+Same as on match start/end, but:
+
+1. For STATIC, user-supplied start time is written to **both**
+   `scheduled_start_time` and `nominal_start_time` (the plan anchor).
+2. For dynamic types, seed `scheduled_start_time` from the first computed
+   nominal if it is still null, then run **planned pass then live pass**
+   (`recompute_scheduled_and_nominal_times`).
+3. Finalize status on matches that should be finalized from the beginning
+   (live PROCEDURE).

--- a/tests/test_dynamic_scheduling.py
+++ b/tests/test_dynamic_scheduling.py
@@ -551,3 +551,102 @@ class TestScheduledVsNominalTimeline:
             # Planned timeline treats the skipped match as if it ran for its full 45 min.
             assert _aware_utc(skipped.scheduled_start_time) == _aware_utc(base + timedelta(minutes=60))
             assert _aware_utc(after.scheduled_start_time) == _aware_utc(base + timedelta(minutes=105))
+
+
+class TestPlanAnchorWritePaths:
+    """Write paths that intentionally shift the *plan* must touch scheduled_start_time."""
+
+    @pytest.mark.unit
+    def test_push_back_moves_scheduled_and_downstream_plan(self, app, test_db, tournament):
+        """STATIC push-back must move the plan anchor, then re-solve dynamic planned times."""
+        from app.domain.enums import ScheduleType
+
+        tournament_url = tournament.url
+        with app.app_context():
+            base = datetime.now(timezone.utc).replace(tzinfo=None)
+
+            anchor = Match(
+                name="Anchor",
+                event=tournament_url,
+                field="Field 1",
+                nominal_start_time=base,
+                scheduled_start_time=base,
+                schedule_type=ScheduleType.STATIC,
+                nominal_length=60,
+                status=MatchStatus.NOT_STARTED,
+            )
+            m2 = Match(
+                name="M2",
+                event=tournament_url,
+                field="Field 1",
+                nominal_start_time=base + timedelta(minutes=60),
+                scheduled_start_time=base + timedelta(minutes=60),
+                schedule_type=ScheduleType.SAFE,
+                nominal_length=60,
+                status=MatchStatus.NOT_STARTED,
+            )
+            db.session.add_all([anchor, m2])
+            db.session.flush()
+            _link_chain([anchor, m2])
+            db.session.commit()
+
+            # Mirror push_back_matches_api: shift STATIC plan anchors, then both passes.
+            delta = timedelta(minutes=30)
+            anchor.scheduled_start_time = anchor.scheduled_start_time + delta
+            anchor.nominal_start_time = anchor.nominal_start_time + delta
+            db.session.commit()
+            recompute_scheduled_and_nominal_times(tournament_url)
+
+            db.session.refresh(anchor)
+            db.session.refresh(m2)
+
+            assert _aware_utc(anchor.scheduled_start_time) == _aware_utc(base + delta)
+            assert _aware_utc(anchor.nominal_start_time) == _aware_utc(base + delta)
+            # Downstream plan follows the shifted STATIC anchor.
+            assert _aware_utc(m2.scheduled_start_time) == _aware_utc(base + delta + timedelta(minutes=60))
+            assert _aware_utc(m2.nominal_start_time) == _aware_utc(base + delta + timedelta(minutes=60))
+
+    @pytest.mark.unit
+    def test_live_pass_after_late_finish_does_not_move_plan(self, app, test_db, tournament):
+        """Regression: recompute_all_match_times after a late finish must leave scheduled alone."""
+        tournament_url = tournament.url
+        with app.app_context():
+            base = datetime.now(timezone.utc).replace(tzinfo=None)
+
+            anchor = Match(
+                name="Anchor",
+                event=tournament_url,
+                field="Field 1",
+                nominal_start_time=base,
+                scheduled_start_time=base,
+                schedule_type="STATIC",
+                nominal_length=60,
+                status=MatchStatus.COMPLETED,
+            )
+            # Finished 45 min late relative to plan end (plan end = base+60).
+            anchor.confirmed_start_time = base
+            anchor.completed_time = base + timedelta(minutes=105)
+            anchor.finalized_at = base + timedelta(minutes=105)
+            m2 = Match(
+                name="M2",
+                event=tournament_url,
+                field="Field 1",
+                nominal_start_time=base + timedelta(minutes=60),
+                scheduled_start_time=base + timedelta(minutes=60),
+                schedule_type="SAFE",
+                nominal_length=60,
+                status=MatchStatus.NOT_STARTED,
+            )
+            db.session.add_all([anchor, m2])
+            db.session.flush()
+            _link_chain([anchor, m2])
+            db.session.commit()
+
+            planned_m2 = m2.scheduled_start_time
+            recompute_all_match_times(tournament_url)
+            db.session.refresh(m2)
+
+            assert _aware_utc(m2.scheduled_start_time) == _aware_utc(planned_m2)
+            assert (
+                abs((_aware_utc(m2.nominal_start_time) - _aware_utc(base + timedelta(minutes=105))).total_seconds()) < 2
+            )

--- a/tests/unit/test_league_vs_standalone_registration.py
+++ b/tests/unit/test_league_vs_standalone_registration.py
@@ -305,9 +305,9 @@ def test_schedule_import_registered_teams_league_and_standalone(app, test_db):
         db.session.commit()
 
         for t in (sa, lg):
-            errors = ScheduleImportExportService._validate_teams_registered(
-                t.url,
-                tags_data=[{"team": f"ok-{t.url}"}],
+            tags_out, matches_out, warnings, auto_tag_names = ScheduleImportExportService._rewrite_unknown_team_refs(
+                t,
+                tags_data=[{"name": "T", "team": f"ok-{t.url}"}],
                 matches_data=[
                     {
                         "team1_initial": f"ok-{t.url}",
@@ -316,6 +316,11 @@ def test_schedule_import_registered_teams_league_and_standalone(app, test_db):
                     }
                 ],
             )
-            # missing-team should error; registered ok-* should not
-            assert any("missing-team" in e for e in errors)
-            assert not any(f"ok-{t.url}" in e for e in errors)
+            # missing-team should be rewritten to a tag reference with a warning;
+            # registered ok-* teams (event- or league-scoped) stay untouched.
+            assert matches_out[0]["team1_initial"] == f"ok-{t.url}"
+            assert matches_out[0]["team2_initial"] == "tag::missing-team"
+            assert auto_tag_names == {"missing-team"}
+            assert any("missing-team" in w for w in warnings)
+            assert not any(f"ok-{t.url}" in w for w in warnings)
+            assert tags_out[0]["team"] == f"ok-{t.url}"

--- a/tests/unit/test_schedule_import_export.py
+++ b/tests/unit/test_schedule_import_export.py
@@ -30,6 +30,7 @@ def test_export_schedule_includes_tags_fields_and_matches(test_db, tournament):
         event=tournament_url,
         field="Field 1",
         nominal_start_time=datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
+        scheduled_start_time=datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
         nominal_length=60,
         schedule_type="STATIC",
         set_type="SETS",
@@ -60,8 +61,36 @@ def test_export_schedule_includes_tags_fields_and_matches(test_db, tournament):
             assert 'field = "Field 1"' in toml_str
             assert 'team1_initial = "tag::Pool A"' in toml_str
             assert 'refs_initial = "tag::Pool A,tag::Pool B"' in toml_str
+            # Plan anchor must round-trip so re-import does not lose STATIC scheduled times.
+            assert "scheduled_start_time" in toml_str
         case Err(err):
             raise AssertionError(f"Expected Ok(TOML), got Err({err})")
+
+
+@pytest.mark.unit
+def test_import_seeds_scheduled_from_nominal_when_missing(test_db, tournament):
+    """Legacy TOML with only nominal_start_time must still populate the plan anchor."""
+    from app.serializers.match_schedule_serializer import MatchScheduleSerializer
+
+    tournament_url = tournament.url
+    # Unit-test the serializer seed path directly (avoids team-registration checks on full import).
+    res = MatchScheduleSerializer.match_from_dict(
+        {
+            "name": "LegacyStatic",
+            "field": "Field 1",
+            "schedule_type": "STATIC",
+            "nominal_length": 60,
+            "nominal_start_time": "2025-06-01T09:00:00",
+            "team1_initial": "tag::PoolA",
+            "team2_initial": "tag::PoolB",
+        },
+        tournament_url,
+    )
+    assert isinstance(res, Ok), getattr(res, "val", res)
+    d = res.val
+    assert d["nominal_start_time"] is not None
+    assert d["scheduled_start_time"] is not None
+    assert d["scheduled_start_time"] == d["nominal_start_time"]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_schedule_import_export.py
+++ b/tests/unit/test_schedule_import_export.py
@@ -1,5 +1,6 @@
 """Unit tests for ScheduleImportExportService (TOML import/export round-trips)."""
 
+import re
 import textwrap
 from datetime import datetime, timezone
 
@@ -47,8 +48,9 @@ def test_export_schedule_includes_tags_fields_and_matches(test_db, tournament):
     res = ScheduleImportExportService.export_schedule(tournament_url)
     match res:
         case Ok(toml_str):
-            # Basic sanity checks: event and table headers present
-            assert f'event = "{tournament_url}"' in toml_str
+            # Basic sanity checks: table headers present, no event key (the
+            # target tournament comes from the import route, not the file)
+            assert not re.search(r"^event\s*=", toml_str, re.MULTILINE)
             assert "[[tags]]" in toml_str
             assert "[[fields]]" in toml_str
             assert "[[matches]]" in toml_str
@@ -223,7 +225,7 @@ def test_import_schedule_replaces_existing_objects_and_deletes_missing(test_db, 
             "set_type": keep_match.set_type,
         }
     ]
-    toml_str = write_toml_schedule(event=tournament_url, tags=tags, fields=fields, matches=matches)
+    toml_str = write_toml_schedule(tags=tags, fields=fields, matches=matches)
 
     res = ScheduleImportExportService.import_schedule(tournament_url, toml_str)
     match res:
@@ -493,3 +495,232 @@ def test_tags_with_spaces_work_correctly(test_db, tournament):
     assert imported_match is not None
     assert imported_match.team1_initial == "tag::Pool A Teams"
     assert get_match_refs_initial_csv(imported_match) == "tag::Pool A Teams"
+
+
+def _register_team(tournament_url: str, team_id: str, pseudonym: str | None = None) -> None:
+    """Register (and create if needed) a team for a tournament."""
+    from app.domain.enums import TeamRegistrationStatus
+    from models import Team, TeamRegistration
+
+    if Team.query.get(team_id) is None:
+        db.session.add(Team(id=team_id, name=team_id, pw_hash="x"))
+        db.session.flush()
+    db.session.add(
+        TeamRegistration(
+            event=tournament_url,
+            team=team_id,
+            pseudonym=pseudonym or team_id,
+            status=TeamRegistrationStatus.CONFIRMED,
+        )
+    )
+    db.session.commit()
+
+
+@pytest.mark.unit
+def test_export_has_no_event_key_and_import_without_event_succeeds(test_db, tournament):
+    """Exports carry no 'event' key, and imports work without one (route decides)."""
+    tournament_url = tournament.url
+
+    toml_content = textwrap.dedent(
+        """
+        [[fields]]
+        name = "Field 1"
+
+        [[matches]]
+        name = "M1"
+        field = "Field 1"
+        schedule_type = "STATIC"
+        set_type = "SETS"
+        nominal_length = 60
+        """
+    ).strip()
+
+    res = ScheduleImportExportService.import_schedule(tournament_url, toml_content)
+    match res:
+        case Ok(result):
+            assert result.matches_created == 1
+            assert result.warnings == []
+        case Err(err):
+            raise AssertionError(f"Expected Ok(ImportResult), got Err({err})")
+
+    assert Match.query.filter_by(event=tournament_url, name="M1").first() is not None
+
+    export_res = ScheduleImportExportService.export_schedule(tournament_url)
+    match export_res:
+        case Ok(toml_str):
+            assert not re.search(r"^event\s*=", toml_str, re.MULTILINE)
+        case Err(err):
+            raise AssertionError(f"Expected Ok(TOML), got Err({err})")
+
+
+@pytest.mark.unit
+def test_import_rewrites_unknown_team_tokens_to_tag_references(test_db, tournament):
+    """Unknown team1/team2/refs tokens become tag:: references with warnings; known/symbolic tokens are untouched."""
+    tournament_url = tournament.url
+    _register_team(tournament_url, "known-team")
+
+    toml_content = textwrap.dedent(
+        """
+        [[tags]]
+        name = "Existing"
+
+        [[fields]]
+        name = "Field 1"
+
+        [[matches]]
+        name = "M1"
+        field = "Field 1"
+        schedule_type = "STATIC"
+        set_type = "SETS"
+        nominal_length = 60
+        team1_initial = "Mystery Team"
+        team2_initial = "known-team"
+        refs_initial = "Mystery Team,known-team"
+
+        [[matches]]
+        name = "M2"
+        field = "Field 1"
+        schedule_type = "STATIC"
+        set_type = "SETS"
+        nominal_length = 60
+        team1_initial = "M1::winner"
+        team2_initial = "tag::Existing"
+        """
+    ).strip()
+
+    res = ScheduleImportExportService.import_schedule(tournament_url, toml_content)
+    match res:
+        case Ok(result):
+            expected_warning = "Team 'Mystery Team' not found; imported as tag reference 'tag::Mystery Team'"
+            # Deduplicated by token: team1 + refs slot yield a single warning.
+            assert result.warnings == [expected_warning]
+        case Err(err):
+            raise AssertionError(f"Expected Ok(ImportResult), got Err({err})")
+
+    from app.services.dual_write import get_match_refs_initial_csv
+
+    m1 = Match.query.filter_by(event=tournament_url, name="M1").first()
+    assert m1.team1_initial == "tag::Mystery Team"
+    assert m1.team2_initial == "known-team"  # registered team untouched
+    assert get_match_refs_initial_csv(m1) == "tag::Mystery Team,known-team"
+
+    m2 = Match.query.filter_by(event=tournament_url, name="M2").first()
+    assert m2.team1_initial == "M1::winner"  # match reference untouched
+    assert m2.team2_initial == "tag::Existing"  # existing tag reference untouched
+
+    # Unassigned tag auto-created for the rewritten token
+    auto_tag = Tag.query.filter_by(event=tournament_url, name="Mystery Team").first()
+    assert auto_tag is not None
+    assert auto_tag.team is None
+
+
+@pytest.mark.unit
+def test_import_rewrites_unknown_team_literals_in_skip_condition(test_db, tournament):
+    """Unknown [Team] literals in skip_condition ASS expressions become [tag::Team]."""
+    tournament_url = tournament.url
+    _register_team(tournament_url, "known-team")
+
+    toml_content = textwrap.dedent(
+        """
+        [[tags]]
+        name = "Existing"
+
+        [[fields]]
+        name = "Field 1"
+
+        [[matches]]
+        name = "M1"
+        field = "Field 1"
+        schedule_type = "STATIC"
+        set_type = "SETS"
+        nominal_length = 60
+
+        [[matches]]
+        name = "M2"
+        field = "Field 1"
+        schedule_type = "SAFE"
+        set_type = "SETS"
+        nominal_length = 60
+        skip_condition = "[Ghost Team] == [M1::winner] or [tag::Existing] == [known-team]"
+        """
+    ).strip()
+
+    res = ScheduleImportExportService.import_schedule(tournament_url, toml_content)
+    match res:
+        case Ok(result):
+            assert any("Ghost Team" in w for w in result.warnings)
+        case Err(err):
+            raise AssertionError(f"Expected Ok(ImportResult), got Err({err})")
+
+    m2 = Match.query.filter_by(event=tournament_url, name="M2").first()
+    assert m2.skip_condition == "[tag::Ghost Team] == [M1::winner] or [tag::Existing] == [known-team]"
+
+    auto_tag = Tag.query.filter_by(event=tournament_url, name="Ghost Team").first()
+    assert auto_tag is not None
+    assert auto_tag.team is None
+
+
+@pytest.mark.unit
+def test_import_unknown_team_in_tags_section_imports_unassigned(test_db, tournament):
+    """A tag assigning an unknown team imports the tag unassigned with a warning instead of failing."""
+    tournament_url = tournament.url
+
+    toml_content = textwrap.dedent(
+        """
+        [[tags]]
+        name = "Pool X"
+        team = "no-such-team"
+        """
+    ).strip()
+
+    res = ScheduleImportExportService.import_schedule(tournament_url, toml_content)
+    match res:
+        case Ok(result):
+            assert any("no-such-team" in w and "Pool X" in w for w in result.warnings)
+        case Err(err):
+            raise AssertionError(f"Expected Ok(ImportResult), got Err({err})")
+
+    tag = Tag.query.filter_by(event=tournament_url, name="Pool X").first()
+    assert tag is not None
+    assert tag.team is None
+
+
+@pytest.mark.unit
+def test_reimport_of_rewritten_schedule_is_idempotent(test_db, tournament):
+    """Re-importing an export produced after a rewrite must not double-tag (no tag::tag::X)."""
+    tournament_url = tournament.url
+
+    toml_content = textwrap.dedent(
+        """
+        [[fields]]
+        name = "Field 1"
+
+        [[matches]]
+        name = "M1"
+        field = "Field 1"
+        schedule_type = "STATIC"
+        set_type = "SETS"
+        nominal_length = 60
+        team1_initial = "Mystery Team"
+        """
+    ).strip()
+
+    res = ScheduleImportExportService.import_schedule(tournament_url, toml_content)
+    assert isinstance(res, Ok)
+    assert len(res.val.warnings) == 1
+
+    export_res = ScheduleImportExportService.export_schedule(tournament_url)
+    assert isinstance(export_res, Ok)
+    exported = export_res.val
+    assert 'team1_initial = "tag::Mystery Team"' in exported
+    assert "tag::tag::" not in exported
+
+    # Re-import the rewritten file: no new warnings, no double-tagging, one tag row.
+    res2 = ScheduleImportExportService.import_schedule(tournament_url, exported)
+    assert isinstance(res2, Ok)
+    assert res2.val.warnings == []
+
+    m1 = Match.query.filter_by(event=tournament_url, name="M1").first()
+    assert m1.team1_initial == "tag::Mystery Team"
+    tags = Tag.query.filter_by(event=tournament_url, name="Mystery Team").all()
+    assert len(tags) == 1


### PR DESCRIPTION
## Summary

really should be a bugfix title and branch but im kinda lazy...

## What changed

Backend:

- push-back shifts `scheduled_start_time` together with nominal on STATIC anchors (it used to only move nominal, so the published plan silently kept the old times). backfills whichever field is missing so the two stay aligned, and re-solves plan-then-live instead of live-only.
- force-start-to-STATIC writes "now" into *both* start fields and re-solves both passes.
- the form-based TOML import now recomputes both passes after import, matching what the JSON import already did.
- match-detail API exposes `scheduled_start_time` (the frontend needs it later in the stack).

TOML:

- get rid of event key; just use whatever event we're uploading to.
- export includes `scheduled_start_time`; import seeds plan from nominal (and vice versa) for legacy files that only have one.
- unknown teams import as new tags. user still gets warned

Docs:

- `scheduling.md` includes two-pass solve and scheduled_start_time.

## Test plan

- [x] `just test` passes locally
- [x] `just lint` + `ruff format --check` clean
- [x] Manual verification:
  - [x] exported a schedule, wiped, re-imported: plan times survive
  - [x] imported a file referencing a fake team: match imports with `tag::` ref + warning

## Linked issues

Refs #196, #243 

---

### Pre-review checklist

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name`.
- [x] Targeting `dev`, not `main`.
- [x] `just lint` and `just format` are clean.
- [x] Tests added or updated for the new behavior.
- ~~ If a new module was added under `app/`~~
- ~~If developer workflow changes~~
- [x] No merge conflicts with the base branch.
