### PR TITLE
[Feature] upgrade break match type

### DIFF
--- a/app/domain/enums.py
+++ b/app/domain/enums.py
@@ -123,7 +123,11 @@ class ScheduleType(StrEnum):
             delays.
         FAST: Times are recalculated aggressively, scheduling matches as
             early as possible.
-        BREAK: A scheduled break (no match played).
+        BREAK: A scheduled break (no match played). Same-name breaks across
+            fields start together (their dependency edges are unioned).
+        STATBREAK: A statically scheduled break: the user supplies the start
+            time and the solver never moves it. Auto-completes once its
+            window (start + nominal_length) has elapsed.
         JOIN: A synchronisation point that waits for multiple preceding
             matches to complete before advancing.
     """
@@ -132,7 +136,24 @@ class ScheduleType(StrEnum):
     SAFE = "SAFE"
     FAST = "FAST"
     BREAK = "BREAK"
+    STATBREAK = "STATBREAK"
     JOIN = "JOIN"
+
+
+#: Break-like schedule types: no playing teams, may carry ref-slot team
+#: requirements ("these teams must attend the break").
+BREAK_SCHEDULE_TYPES: tuple[ScheduleType, ...] = (
+    ScheduleType.BREAK,
+    ScheduleType.STATBREAK,
+)
+
+#: Structural schedule types: not games (no team1/team2, no lifecycle chrome),
+#: unique per (name, event, field) rather than per (name, event).
+STRUCTURAL_SCHEDULE_TYPES: tuple[ScheduleType, ...] = (
+    ScheduleType.BREAK,
+    ScheduleType.STATBREAK,
+    ScheduleType.JOIN,
+)
 
 
 class SetType(StrEnum):

--- a/app/domain/enums.py
+++ b/app/domain/enums.py
@@ -126,8 +126,9 @@ class ScheduleType(StrEnum):
         BREAK: A scheduled break (no match played). Same-name breaks across
             fields start together (their dependency edges are unioned).
         STATBREAK: A statically scheduled break: the user supplies the start
-            time and the solver never moves it. Auto-completes once its
-            window (start + nominal_length) has elapsed.
+            time and the solver never moves it. Its status is derived from the
+            current time when read (COMPLETED once the start has passed),
+            never stored.
         JOIN: A synchronisation point that waits for multiple preceding
             matches to complete before advancing.
     """
@@ -139,13 +140,6 @@ class ScheduleType(StrEnum):
     STATBREAK = "STATBREAK"
     JOIN = "JOIN"
 
-
-#: Break-like schedule types: no playing teams, may carry ref-slot team
-#: requirements ("these teams must attend the break").
-BREAK_SCHEDULE_TYPES: tuple[ScheduleType, ...] = (
-    ScheduleType.BREAK,
-    ScheduleType.STATBREAK,
-)
 
 #: Structural schedule types: not games (no team1/team2, no lifecycle chrome),
 #: unique per (name, event, field) rather than per (name, event).

--- a/app/models/match.py
+++ b/app/models/match.py
@@ -91,14 +91,14 @@ class Match(db.Model):
             "event",
             "field",
             unique=True,
-            sqlite_where=sa.text("schedule_type IN ('BREAK', 'JOIN')"),
+            sqlite_where=sa.text("schedule_type IN ('BREAK', 'JOIN', 'STATBREAK')"),
         ),
         db.Index(
             "unique_without_field",
             "name",
             "event",
             unique=True,
-            sqlite_where=sa.text("schedule_type NOT IN ('BREAK', 'JOIN')"),
+            sqlite_where=sa.text("schedule_type NOT IN ('BREAK', 'JOIN', 'STATBREAK')"),
         ),
     )
 
@@ -115,7 +115,9 @@ class Match(db.Model):
     confirmed_start_time = db.Column(db.DateTime)
     completed_time = db.Column(db.DateTime)
     nominal_length = db.Column(db.Integer)  # minutes
-    schedule_type = db.Column(db.Enum(ScheduleType), default=ScheduleType.STATIC)  # STATIC, SAFE, FAST, BREAK, JOIN
+    schedule_type = db.Column(
+        db.Enum(ScheduleType), default=ScheduleType.STATIC
+    )  # STATIC, SAFE, FAST, BREAK, STATBREAK, JOIN
     set_type = db.Column(db.Enum(SetType), default=SetType.SETS)  # SETS, STONES (only for non-BREAK/JOIN matches)
     ribbon = db.Column(db.Boolean, default=False)  # True if this is a ribbon game (not counted in results)
     nsets = db.Column(db.Integer)
@@ -229,18 +231,20 @@ class Match(db.Model):
     def finalize(self) -> None:
         """Mark this match as finalised and set completion metadata.
 
-        Sets :attr:`finalized_at` to the current UTC time.  For ``JOIN``
-        and ``BREAK`` schedule types the method also transitions the match
-        to ``COMPLETED`` and calculates :attr:`completed_time`:
+        Sets :attr:`finalized_at` to the current UTC time.  For ``JOIN``,
+        ``BREAK``, and ``STATBREAK`` schedule types the method also
+        transitions the match to ``COMPLETED`` and calculates
+        :attr:`completed_time`:
 
         * ``JOIN``: completed at :attr:`nominal_start_time`.
-        * ``BREAK``: completed at ``nominal_start_time + nominal_length``.
+        * ``BREAK`` / ``STATBREAK``: completed at
+          ``nominal_start_time + nominal_length``.
 
         For all other schedule types the caller is responsible for setting
         :attr:`status` and :attr:`completed_time`.
         """
         self.finalized_at = now_utc_naive()
-        if self.schedule_type in (ScheduleType.JOIN, ScheduleType.BREAK):
+        if self.schedule_type in (ScheduleType.JOIN, ScheduleType.BREAK, ScheduleType.STATBREAK):
             self.confirmed_start_time = self.nominal_start_time
             self.status = MatchStatus.COMPLETED
             self.completed_time = (

--- a/app/models/match.py
+++ b/app/models/match.py
@@ -222,6 +222,22 @@ class Match(db.Model):
                 return None
 
     @property
+    def effective_status(self) -> MatchStatus:
+        """Lifecycle status as clients should see it.
+
+        For ``STATBREAK`` the status is a pure function of the current time —
+        ``COMPLETED`` once the scheduled start has passed, ``NOT_STARTED``
+        before that — and the stored :attr:`status` is ignored (the solver
+        never writes it). All other schedule types return the stored status.
+        """
+        if self.schedule_type == ScheduleType.STATBREAK:
+            start = self.nominal_start_time or self.scheduled_start_time
+            if start is not None and now_utc_naive() >= start:
+                return MatchStatus.COMPLETED
+            return MatchStatus.NOT_STARTED
+        return self.status
+
+    @property
     def is_time_finalized(self) -> bool:
         """True when start time is locked: status is TIME_FINALIZED or any later state (READY_TO_START, IN_PROGRESS, COMPLETED, SKIPPED)."""
         if self.status is None:

--- a/app/routes/matches.py
+++ b/app/routes/matches.py
@@ -145,7 +145,7 @@ def scoreboard():
         if (
             m.status in (MatchStatus.COMPLETED, MatchStatus.SKIPPED)
             and m.completed_time
-            and m.schedule_type not in (ScheduleType.BREAK, ScheduleType.JOIN)
+            and m.schedule_type not in (ScheduleType.BREAK, ScheduleType.STATBREAK, ScheduleType.JOIN)
         ):
             prev_match = m
             break
@@ -153,7 +153,7 @@ def scoreboard():
     # Find next match (not started or ready to start) - skip BREAK/JOIN matches
     next_match = None
     for m in all_field_matches:
-        if m.schedule_type not in (ScheduleType.BREAK, ScheduleType.JOIN) and (
+        if m.schedule_type not in (ScheduleType.BREAK, ScheduleType.STATBREAK, ScheduleType.JOIN) and (
             m.status in (MatchStatus.NOT_STARTED, MatchStatus.IN_PROGRESS)
             or (m.status in (MatchStatus.COMPLETED, MatchStatus.SKIPPED) and not m.completed_time)
         ):
@@ -373,7 +373,7 @@ def scoreboard_state():
         if (
             m.status in (MatchStatus.COMPLETED, MatchStatus.SKIPPED)
             and m.completed_time
-            and m.schedule_type not in (ScheduleType.BREAK, ScheduleType.JOIN)
+            and m.schedule_type not in (ScheduleType.BREAK, ScheduleType.STATBREAK, ScheduleType.JOIN)
         ):
             prev_match = m
             break
@@ -381,7 +381,7 @@ def scoreboard_state():
     # Find next match (not started or ready to start) - skip BREAK/JOIN matches
     next_match = None
     for m in all_field_matches:
-        if m.schedule_type not in (ScheduleType.BREAK, ScheduleType.JOIN) and (
+        if m.schedule_type not in (ScheduleType.BREAK, ScheduleType.STATBREAK, ScheduleType.JOIN) and (
             m.status in (MatchStatus.NOT_STARTED, MatchStatus.IN_PROGRESS)
             or (m.status in (MatchStatus.COMPLETED, MatchStatus.SKIPPED) and not m.completed_time)
         ):

--- a/app/routes/tournaments/brackets.py
+++ b/app/routes/tournaments/brackets.py
@@ -125,15 +125,15 @@ def _bracket_match_payload(tournament, match: Match) -> dict:
 
 
 def _playable_matches(tournament_url: str) -> list[Match]:
-    """Matches that can appear on a bracket (exclude BREAK/JOIN)."""
+    """Matches that can appear on a bracket (exclude BREAK/STATBREAK/JOIN)."""
     rows = Match.query.filter_by(event=tournament_url).order_by(Match.name).all()
     out = []
     for m in rows:
         st = m.schedule_type
-        if st in (ScheduleType.BREAK, ScheduleType.JOIN):
+        if st in (ScheduleType.BREAK, ScheduleType.STATBREAK, ScheduleType.JOIN):
             continue
         # Also skip stringy legacy values just in case
-        if isinstance(st, str) and st.upper() in ("BREAK", "JOIN"):
+        if isinstance(st, str) and st.upper() in ("BREAK", "JOIN", "STATBREAK"):
             continue
         out.append(m)
     return out
@@ -851,8 +851,8 @@ def tournament_bracket_placement_add_api(tournament_url):
     match = Match.query.filter_by(uuid=match_id, event=tournament_url).first()
     if match is None:
         return jsonify({"error": "Match not found"}), 404
-    if match.schedule_type in (ScheduleType.BREAK, ScheduleType.JOIN):
-        return jsonify({"error": "BREAK/JOIN matches cannot be placed on the bracket"}), 400
+    if match.schedule_type in (ScheduleType.BREAK, ScheduleType.STATBREAK, ScheduleType.JOIN):
+        return jsonify({"error": "BREAK/STATBREAK/JOIN matches cannot be placed on the bracket"}), 400
 
     existing_placed = {p.match: p for p in BracketPlacement.query.filter_by(event=tournament_url).all() if p.is_placed}
     # name → match for auto-wire decisions

--- a/app/routes/tournaments/matches_admin.py
+++ b/app/routes/tournaments/matches_admin.py
@@ -13,10 +13,18 @@ from flask import jsonify, request
 from flask_login import current_user, login_required
 from sqlalchemy.orm.attributes import flag_modified
 
-from app.domain.enums import MatchStatus, ScheduleType, SetType
+from app.domain.enums import (
+    BREAK_SCHEDULE_TYPES,
+    STRUCTURAL_SCHEDULE_TYPES,
+    MatchStatus,
+    ScheduleType,
+    SetType,
+)
 from app.services.dual_write import (
     clear_match_referees,
     get_match_ref_initials,
+    get_match_refs_csv,
+    get_match_refs_initial_csv,
     set_match_referees_from_csv,
 )
 from app.services.permission_service import PermissionService
@@ -124,7 +132,9 @@ def update_match_api(tournament_url, match_id):
         return jsonify({"error": "Forbidden"}), 403
 
     match = Match.query.filter_by(uuid=match_id, event=tournament_url).first_or_404()
-    if match.status in _LOCKED_STATUSES:
+    # STATBREAKs auto-complete on a timer (nobody "starts" them), so they stay
+    # editable even in COMPLETED state.
+    if match.status in _LOCKED_STATUSES and match.schedule_type != ScheduleType.STATBREAK:
         return (
             jsonify({"error": (f"Match cannot be edited once it has started (current status: {match.status.value}).")}),
             409,
@@ -142,7 +152,8 @@ def update_match_api(tournament_url, match_id):
         ),
         ScheduleType.SAFE: (ScheduleType.SAFE, ScheduleType.FAST),
         ScheduleType.FAST: (ScheduleType.FAST,),
-        ScheduleType.BREAK: (ScheduleType.BREAK,),
+        ScheduleType.BREAK: (ScheduleType.BREAK, ScheduleType.STATBREAK),
+        ScheduleType.STATBREAK: (ScheduleType.STATBREAK, ScheduleType.BREAK),
         ScheduleType.JOIN: (ScheduleType.JOIN,),
     }
 
@@ -186,20 +197,22 @@ def update_match_api(tournament_url, match_id):
     if field is not None:  # field can be empty string/null
         match.field = field
 
-    # Match-name uniqueness check (still useful when only `field` changes for BREAK/JOIN,
-    # since BREAK/JOIN match names are unique per field).
+    # Match-name uniqueness check (still useful when only `field` changes for
+    # structural matches, whose names are unique per field across BREAK/STATBREAK/JOIN).
     if field is not None:
         effective_name = (match.name or "").strip()
         effective_field = (match.field or "").strip()
-        if effective_name and match.schedule_type in (ScheduleType.BREAK, ScheduleType.JOIN):
+        if effective_name and match.schedule_type in STRUCTURAL_SCHEDULE_TYPES:
             existing_name = (
                 Match.query.filter_by(
                     event=tournament_url,
                     name=effective_name,
                     field=effective_field,
-                    schedule_type=match.schedule_type,
                 )
-                .filter(Match.uuid != match.uuid)
+                .filter(
+                    Match.schedule_type.in_(STRUCTURAL_SCHEDULE_TYPES),
+                    Match.uuid != match.uuid,
+                )
                 .first()
             )
             if existing_name:
@@ -210,13 +223,23 @@ def update_match_api(tournament_url, match_id):
                     400,
                 )
 
-    # Handle BREAK/JOIN clearing teams
-    if match.schedule_type in (ScheduleType.BREAK, ScheduleType.JOIN):
+    # Structural matches never have playing teams. JOINs also have no refs;
+    # BREAK/STATBREAK accept refs as team requirements ("these teams must
+    # attend the break").
+    if match.schedule_type in STRUCTURAL_SCHEDULE_TYPES:
         match.team1 = None
         match.team1_initial = None
         match.team2 = None
         match.team2_initial = None
-        clear_match_referees(match)
+        if match.schedule_type == ScheduleType.JOIN:
+            clear_match_referees(match)
+        elif refs is not None:
+            if isinstance(refs, list):
+                r_csv, i_csv = resolve_refs_slots(refs, tournament_url)
+            else:
+                toks = refs_string_to_tokens(refs)
+                r_csv, i_csv = resolve_refs_slots(toks, tournament_url)
+            set_match_referees_from_csv(match, r_csv, i_csv)
     else:
         # When _initial fields change, write through to the resolved team cache
         # (team1 / team2). _resolve_initial_to_cached_team returns None for
@@ -323,6 +346,22 @@ def update_match_api(tournament_url, match_id):
         detach_match_from_chain(match, tournament_url)
         flag_modified(match, "previous_match")
         flag_modified(match, "next_match")
+    elif match.schedule_type == ScheduleType.STATBREAK:
+        # Statically-scheduled break: user-supplied start time is written to both
+        # timelines and the solver never moves it. Unlike STATIC it may sit in a
+        # field chain (matches chained after it wait for its end), so we only
+        # touch chain links when the client explicitly supplies one.
+        if start_time_str:
+            try:
+                dt = datetime.fromisoformat(start_time_str.replace("Z", "+00:00"))
+                if dt.tzinfo:
+                    dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+                match.nominal_start_time = dt
+                match.scheduled_start_time = dt
+            except ValueError:
+                pass
+        if previous_match_id:
+            update_match_previous_link(match, previous_match_id, tournament_url)
     else:
         # Dynamic (BREAK, JOIN, FAST, SAFE)
         match.nominal_start_time = compute_dynamic_match_nominal_start_time(match, tournament_url)
@@ -522,18 +561,22 @@ def create_match_api(tournament_url):
             pass
     effective_field = (data.get("field") or "").strip()
 
-    # Name uniqueness: for BREAK/JOIN only within same field (and same type); for others globally in tournament
-    if schedule_type in (ScheduleType.BREAK, ScheduleType.JOIN):
-        existing = Match.query.filter_by(
-            event=tournament_url,
-            name=name.strip(),
-            field=effective_field,
-            schedule_type=schedule_type,
-        ).first()
+    # Name uniqueness: structural matches (BREAK/STATBREAK/JOIN) are unique per
+    # (name, event, field) across the structural group; others globally in tournament.
+    if schedule_type in STRUCTURAL_SCHEDULE_TYPES:
+        existing = (
+            Match.query.filter_by(
+                event=tournament_url,
+                name=name.strip(),
+                field=effective_field,
+            )
+            .filter(Match.schedule_type.in_(STRUCTURAL_SCHEDULE_TYPES))
+            .first()
+        )
     else:
         existing = Match.query.filter_by(event=tournament_url, name=name.strip()).first()
     if existing:
-        if schedule_type in (ScheduleType.BREAK, ScheduleType.JOIN):
+        if schedule_type in STRUCTURAL_SCHEDULE_TYPES:
             return (
                 jsonify({"error": f"A {schedule_type.value} match with this name already exists on this field."}),
                 400,
@@ -571,8 +614,10 @@ def create_match_api(tournament_url):
         if prev_field != effective_field:
             return jsonify({"error": "Previous match must be on the same field."}), 400
 
-    if match.schedule_type == ScheduleType.STATIC:
+    if match.schedule_type in (ScheduleType.STATIC, ScheduleType.STATBREAK):
         start_time_str = data.get("start_time")
+        if not start_time_str and match.schedule_type == ScheduleType.STATBREAK:
+            return jsonify({"error": "Start time is required for Static Break matches."}), 400
         if start_time_str:
             try:
                 dt = datetime.fromisoformat(start_time_str.replace("Z", "+00:00"))
@@ -581,12 +626,13 @@ def create_match_api(tournament_url):
                 match.nominal_start_time = dt
                 match.scheduled_start_time = dt
             except ValueError:
-                pass
+                if match.schedule_type == ScheduleType.STATBREAK:
+                    return jsonify({"error": "Invalid start time for Static Break match."}), 400
 
     # Team handling
     team1_input = data.get("team1") or ""
     team2_input = data.get("team2") or ""
-    if match.schedule_type not in (ScheduleType.BREAK, ScheduleType.JOIN):
+    if match.schedule_type not in STRUCTURAL_SCHEDULE_TYPES:
         team1_name = str(team1_input).strip()
         team2_name = str(team2_input).strip()
         match.team1_initial = team1_name or None
@@ -596,10 +642,11 @@ def create_match_api(tournament_url):
 
     # Refs: parallel refs / refs_initial (same slot count). Resolved here but
     # written below after the flush so the match has a uuid the join-table
-    # rows can reference.
+    # rows can reference. Allowed on BREAK/STATBREAK (team requirements for
+    # attending the break) but never on JOIN.
     refs = data.get("refs")
     refs_csv_pair: tuple[str, str] | None = None
-    if refs and isinstance(refs, list):
+    if refs and isinstance(refs, list) and match.schedule_type != ScheduleType.JOIN:
         refs_csv_pair = resolve_refs_slots(refs, tournament_url)
 
     # Format
@@ -626,7 +673,8 @@ def create_match_api(tournament_url):
     if refs_csv_pair is not None:
         set_match_referees_from_csv(match, refs_csv_pair[0], refs_csv_pair[1])
 
-    # Handle linked list insert
+    # Handle linked list insert (STATBREAK may optionally sit in a chain so
+    # downstream matches wait for its end).
     prev_match_id = (
         data.get("previous_match_id")
         if match.schedule_type
@@ -635,6 +683,7 @@ def create_match_api(tournament_url):
             ScheduleType.FAST,
             ScheduleType.STATIC,
             ScheduleType.BREAK,
+            ScheduleType.STATBREAK,
             ScheduleType.JOIN,
         )
         else None
@@ -642,8 +691,8 @@ def create_match_api(tournament_url):
     if prev_match_id:
         update_match_previous_link(match, prev_match_id, tournament_url, is_new=True)
 
-    # Dynamic time compute
-    if match.schedule_type != ScheduleType.STATIC:
+    # Dynamic time compute (STATIC and STATBREAK keep their user-supplied anchor)
+    if match.schedule_type not in (ScheduleType.STATIC, ScheduleType.STATBREAK):
         match.nominal_start_time = compute_dynamic_match_nominal_start_time(match, tournament_url)
         # Seed the scheduled anchor from the freshly-computed nominal so future
         # recomputations of nominal don't drag time-based dependency edges around.
@@ -677,6 +726,330 @@ def delete_match_api(tournament_url, match_id):
     db.session.flush()
 
     delete_matches_with_children([match_id])
+    db.session.commit()
+    recompute_scheduled_and_nominal_times(tournament_url)
+
+    return jsonify({"success": True})
+
+
+# ---------------------------------------------------------------------------
+# Break groups: same-name BREAK/STATBREAK rows across multiple fields, created
+# and edited as one unit (shared name / length / team requirements / start time).
+# ---------------------------------------------------------------------------
+
+
+def _parse_start_time_utc(start_time_str: str | None) -> datetime | None:
+    """Parse an ISO datetime (optionally with Z/offset) into naive UTC, or ``None``."""
+    if not start_time_str:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(start_time_str).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _break_group_rows(tournament_url: str, name: str) -> list[Match]:
+    """All BREAK/STATBREAK rows sharing *name* in this tournament."""
+    return (
+        Match.query.filter_by(event=tournament_url, name=name)
+        .filter(Match.schedule_type.in_(BREAK_SCHEDULE_TYPES))
+        .all()
+    )
+
+
+def _field_chain_tail(tournament_url: str, field_name: str, exclude_uuids: set[str] | None = None) -> Match | None:
+    """Last match in *field_name*'s doubly-linked chain (no next_match).
+
+    Detached matches (e.g. STATIC rows) also have no next_match; among all
+    candidates we pick the one with the latest planned/nominal anchor so a new
+    break appended "at the tail" lands after everything currently scheduled.
+    """
+    exclude_uuids = exclude_uuids or set()
+    candidates = [
+        m
+        for m in Match.query.filter_by(event=tournament_url, field=field_name).all()
+        if not m.next_match and m.uuid not in exclude_uuids
+    ]
+    if not candidates:
+        return None
+
+    def sort_key(m: Match):
+        anchor = m.scheduled_start_time or m.nominal_start_time
+        return (anchor is not None, anchor or datetime.min, m.uuid)
+
+    return max(candidates, key=sort_key)
+
+
+def _structural_name_collision(tournament_url: str, name: str, field_name: str) -> Match | None:
+    """Existing structural match blocking (name, event, field), or ``None``."""
+    return (
+        Match.query.filter_by(event=tournament_url, name=name, field=field_name)
+        .filter(Match.schedule_type.in_(STRUCTURAL_SCHEDULE_TYPES))
+        .first()
+    )
+
+
+@bp.route("/tournaments/<tournament_url>/break-groups", methods=["POST"])
+@login_required
+def create_break_group_api(tournament_url):
+    """Create one BREAK/STATBREAK row per field, sharing name/length/teams."""
+    if not _check_to(tournament_url):
+        return jsonify({"error": "Forbidden"}), 403
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid JSON"}), 400
+
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify({"error": "Break name is required"}), 400
+    mn_err = match_name_char_error(name)
+    if mn_err:
+        return jsonify({"error": mn_err}), 400
+
+    try:
+        schedule_type = ScheduleType(data.get("schedule_type") or "BREAK")
+    except ValueError:
+        schedule_type = None
+    if schedule_type not in BREAK_SCHEDULE_TYPES:
+        return jsonify({"error": "schedule_type must be BREAK or STATBREAK."}), 400
+
+    try:
+        length = int(data.get("length"))
+    except (TypeError, ValueError):
+        return jsonify({"error": "Length (minutes) is required."}), 400
+    if length < 0:
+        return jsonify({"error": "Length cannot be negative."}), 400
+
+    raw_fields = data.get("fields")
+    if not isinstance(raw_fields, list):
+        raw_fields = []
+    fields, seen = [], set()
+    for f in raw_fields:
+        f = str(f or "").strip()
+        if f and f not in seen:
+            seen.add(f)
+            fields.append(f)
+    if not fields:
+        return jsonify({"error": "At least one field is required."}), 400
+    known_fields = {f.name for f in Field.query.filter_by(event=tournament_url).all()}
+    unknown = [f for f in fields if f not in known_fields]
+    if unknown:
+        return jsonify({"error": f"Unknown field(s): {', '.join(unknown)}"}), 400
+
+    teams = data.get("teams") or []
+    if not isinstance(teams, list):
+        return jsonify({"error": "teams must be a list of team tokens."}), 400
+    refs_csv_pair = resolve_refs_slots(teams, tournament_url) if teams else None
+
+    start_dt = None
+    if schedule_type == ScheduleType.STATBREAK:
+        start_dt = _parse_start_time_utc(data.get("start_time"))
+        if start_dt is None:
+            return jsonify({"error": "Start time is required for Static Break groups."}), 400
+
+    previous_map = data.get("previous_match")
+    if not isinstance(previous_map, dict):
+        previous_map = {}
+
+    for f in fields:
+        if _structural_name_collision(tournament_url, name, f):
+            return (
+                jsonify({"error": f'A break or join named "{name}" already exists on field "{f}".'}),
+                400,
+            )
+
+    created: list[Match] = []
+    for f in fields:
+        match = Match(event=tournament_url, name=name)
+        match.field = f
+        match.schedule_type = schedule_type
+        match.nominal_length = length
+        match.skip_condition = None
+        if start_dt is not None:
+            match.nominal_start_time = start_dt
+            match.scheduled_start_time = start_dt
+        db.session.add(match)
+        db.session.flush()
+        if refs_csv_pair is not None:
+            set_match_referees_from_csv(match, refs_csv_pair[0], refs_csv_pair[1])
+        if schedule_type == ScheduleType.BREAK:
+            prev_id = str(previous_map.get(f) or "").strip()
+            if prev_id:
+                prev_match = Match.query.filter_by(uuid=prev_id, event=tournament_url).first()
+                if not prev_match:
+                    db.session.rollback()
+                    return jsonify({"error": f'Previous match not found for field "{f}".'}), 400
+                if (prev_match.field or "").strip() != f:
+                    db.session.rollback()
+                    return (
+                        jsonify({"error": f'Previous match for field "{f}" must be on that field.'}),
+                        400,
+                    )
+            else:
+                # Default: append at the tail of the field's chain.
+                tail = _field_chain_tail(tournament_url, f, exclude_uuids={match.uuid})
+                prev_match = tail
+            if prev_match is not None:
+                update_match_previous_link(match, prev_match.uuid, tournament_url, is_new=True)
+        created.append(match)
+
+    db.session.flush()
+    db.session.commit()
+    recompute_scheduled_and_nominal_times(tournament_url)
+
+    return jsonify({"success": True, "name": name, "uuids": [m.uuid for m in created]})
+
+
+@bp.route("/tournaments/<tournament_url>/break-groups/<name>", methods=["PUT"])
+@login_required
+def update_break_group_api(tournament_url, name):
+    """Edit every same-name break row at once (length/teams/start_time/fields)."""
+    if not _check_to(tournament_url):
+        return jsonify({"error": "Forbidden"}), 403
+
+    rows = _break_group_rows(tournament_url, name)
+    if not rows:
+        return jsonify({"error": "Break group not found"}), 404
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid JSON"}), 400
+
+    group_type = rows[0].schedule_type
+    # No started-lock here: break statuses are solver-derived (BREAK completes
+    # when its dependencies complete, STATBREAK when its window elapses), not
+    # user-started, and the recompute below re-derives them after any edit.
+
+    length = data.get("length")
+    if length is not None:
+        try:
+            length = int(length)
+        except (TypeError, ValueError):
+            return jsonify({"error": "Length must be a number of minutes."}), 400
+        if length < 0:
+            return jsonify({"error": "Length cannot be negative."}), 400
+
+    teams = data.get("teams")
+    if teams is not None and not isinstance(teams, list):
+        return jsonify({"error": "teams must be a list of team tokens."}), 400
+
+    start_dt = None
+    if data.get("start_time") is not None:
+        if group_type != ScheduleType.STATBREAK:
+            start_dt = None  # start_time only applies to STATBREAK groups
+        else:
+            start_dt = _parse_start_time_utc(data.get("start_time"))
+            if start_dt is None:
+                return jsonify({"error": "Invalid start time."}), 400
+
+    fields = data.get("fields")
+    if fields is not None:
+        if not isinstance(fields, list):
+            return jsonify({"error": "fields must be a list of field names."}), 400
+        normalized, seen = [], set()
+        for f in fields:
+            f = str(f or "").strip()
+            if f and f not in seen:
+                seen.add(f)
+                normalized.append(f)
+        fields = normalized
+        if not fields:
+            return (
+                jsonify({"error": "A break group needs at least one field. Use DELETE to remove the group."}),
+                400,
+            )
+        known_fields = {f.name for f in Field.query.filter_by(event=tournament_url).all()}
+        unknown = [f for f in fields if f not in known_fields]
+        if unknown:
+            return jsonify({"error": f"Unknown field(s): {', '.join(unknown)}"}), 400
+
+    refs_csv_pair = None
+    if teams is not None and teams:
+        refs_csv_pair = resolve_refs_slots(teams, tournament_url)
+
+    # Shared edits on existing rows.
+    for m in rows:
+        if length is not None:
+            m.nominal_length = length
+        if teams is not None:
+            if refs_csv_pair is not None:
+                set_match_referees_from_csv(m, refs_csv_pair[0], refs_csv_pair[1])
+            else:
+                clear_match_referees(m)
+        if start_dt is not None:
+            m.nominal_start_time = start_dt
+            m.scheduled_start_time = start_dt
+
+    # Field membership changes: create/delete rows.
+    if fields is not None:
+        current = {(m.field or "").strip(): m for m in rows}
+        template = rows[0]
+        to_add = [f for f in fields if f not in current]
+        to_remove = [m for f, m in current.items() if f not in fields]
+
+        for f in to_add:
+            if _structural_name_collision(tournament_url, name, f):
+                db.session.rollback()
+                return (
+                    jsonify({"error": f'A break or join named "{name}" already exists on field "{f}".'}),
+                    400,
+                )
+            match = Match(event=tournament_url, name=name)
+            match.field = f
+            match.schedule_type = group_type
+            match.nominal_length = template.nominal_length
+            match.skip_condition = None
+            if group_type == ScheduleType.STATBREAK:
+                match.nominal_start_time = template.nominal_start_time
+                match.scheduled_start_time = template.scheduled_start_time
+            db.session.add(match)
+            db.session.flush()
+            if refs_csv_pair is not None:
+                set_match_referees_from_csv(match, refs_csv_pair[0], refs_csv_pair[1])
+            elif teams is None:
+                # Copy the group's existing team requirements onto the new row.
+                set_match_referees_from_csv(
+                    match,
+                    get_match_refs_csv(template),
+                    get_match_refs_initial_csv(template),
+                )
+            if group_type == ScheduleType.BREAK:
+                tail = _field_chain_tail(tournament_url, f, exclude_uuids={match.uuid})
+                if tail is not None:
+                    update_match_previous_link(match, tail.uuid, tournament_url, is_new=True)
+
+        for m in to_remove:
+            detach_match_from_chain(m, tournament_url)
+        if to_remove:
+            db.session.flush()
+            delete_matches_with_children([m.uuid for m in to_remove])
+
+    db.session.flush()
+    db.session.commit()
+    recompute_scheduled_and_nominal_times(tournament_url)
+
+    return jsonify({"success": True})
+
+
+@bp.route("/tournaments/<tournament_url>/break-groups/<name>", methods=["DELETE"])
+@login_required
+def delete_break_group_api(tournament_url, name):
+    """Delete every same-name break row in the group."""
+    if not _check_to(tournament_url):
+        return jsonify({"error": "Forbidden"}), 403
+
+    rows = _break_group_rows(tournament_url, name)
+    if not rows:
+        return jsonify({"error": "Break group not found"}), 404
+
+    for m in rows:
+        detach_match_from_chain(m, tournament_url)
+    db.session.flush()
+    delete_matches_with_children([m.uuid for m in rows])
     db.session.commit()
     recompute_scheduled_and_nominal_times(tournament_url)
 

--- a/app/routes/tournaments/matches_admin.py
+++ b/app/routes/tournaments/matches_admin.py
@@ -129,10 +129,15 @@ def update_match_api(tournament_url, match_id):
         return jsonify({"error": "Forbidden"}), 403
 
     match = Match.query.filter_by(uuid=match_id, event=tournament_url).first_or_404()
-    # STATBREAK status is time-derived at read time (nobody "starts" them) and
-    # the stored status stays NOT_STARTED, but keep the exemption so legacy rows
-    # with a stored COMPLETED remain editable too.
-    if match.status in _LOCKED_STATUSES and match.schedule_type != ScheduleType.STATBREAK:
+    # STATBREAK status is time-derived (nobody "starts" them): locked once the
+    # effective status says the break has happened, editable before that.
+    if match.schedule_type == ScheduleType.STATBREAK:
+        if match.effective_status == MatchStatus.COMPLETED:
+            return (
+                jsonify({"error": "Static break cannot be edited once its start time has passed."}),
+                409,
+            )
+    elif match.status in _LOCKED_STATUSES:
         return (
             jsonify({"error": (f"Match cannot be edited once it has started (current status: {match.status.value}).")}),
             409,
@@ -150,9 +155,12 @@ def update_match_api(tournament_url, match_id):
         ),
         ScheduleType.SAFE: (ScheduleType.SAFE, ScheduleType.FAST),
         ScheduleType.FAST: (ScheduleType.FAST,),
-        ScheduleType.BREAK: (ScheduleType.BREAK, ScheduleType.STATBREAK),
+        # Breaks and joins interconvert (both are dynamic field reservations);
+        # nothing converts TO a STATBREAK — create one deliberately, with a
+        # start time, instead of mutating a dynamic break into a static one.
+        ScheduleType.BREAK: (ScheduleType.BREAK, ScheduleType.JOIN),
         ScheduleType.STATBREAK: (ScheduleType.STATBREAK, ScheduleType.BREAK),
-        ScheduleType.JOIN: (ScheduleType.JOIN,),
+        ScheduleType.JOIN: (ScheduleType.JOIN, ScheduleType.BREAK),
     }
 
     # Extract fields. `name` is intentionally not extracted — match names are immutable
@@ -182,7 +190,26 @@ def update_match_api(tournament_url, match_id):
                     jsonify(
                         {
                             "error": f"Match type cannot be changed from {current_schedule_type.value} to {new_schedule_type.value}. "
-                            "Allowed changes: Static→Safe/Fast, Safe→Fast only."
+                            "Allowed changes: Static→Safe/Fast, Safe→Fast, Break↔Join, Static Break→Break."
+                        }
+                    ),
+                    400,
+                )
+            # Structural rows sharing a name form one logical group; converting a
+            # single row of a multi-row group would leave it mixed-type. Convert
+            # the whole group at once via the break-groups endpoint instead.
+            if (
+                new_schedule_type != current_schedule_type
+                and current_schedule_type in STRUCTURAL_SCHEDULE_TYPES
+                and Match.query.filter_by(event=tournament_url, name=match.name)
+                .filter(Match.schedule_type.in_(STRUCTURAL_SCHEDULE_TYPES), Match.uuid != match.uuid)
+                .count()
+                > 0
+            ):
+                return (
+                    jsonify(
+                        {
+                            "error": "This break/join spans multiple fields; convert the whole group via the group editor."
                         }
                     ),
                     400,
@@ -904,7 +931,9 @@ def update_break_group_api(tournament_url, name):
     """Edit every same-name structural row at once (length/start_time/fields).
 
     JOIN groups only support field membership changes; length stays 0. Team
-    requirements are rejected for every structural type.
+    requirements are rejected for every structural type. The whole group can
+    be converted BREAK↔JOIN (JOIN→BREAK requires a length); nothing converts
+    to STATBREAK, and a STATBREAK group is locked once its start has passed.
     """
     if not _check_to(tournament_url):
         return jsonify({"error": "Forbidden"}), 403
@@ -918,26 +947,43 @@ def update_break_group_api(tournament_url, name):
         return jsonify({"error": "Invalid JSON"}), 400
 
     group_type = rows[0].schedule_type
-    is_join = group_type == ScheduleType.JOIN
-    # No started-lock here: structural statuses are never user-started (BREAK/JOIN
-    # complete when their dependencies complete; STATBREAK status is derived from
-    # the current time when read), and the recompute below re-derives them.
+    # A completed static break is history: its window has passed, so there is
+    # nothing meaningful left to edit. (BREAK/JOIN statuses are solver-derived
+    # and re-derived by the recompute below, so they carry no lock.)
+    if group_type == ScheduleType.STATBREAK and rows[0].effective_status == MatchStatus.COMPLETED:
+        return jsonify({"error": "Static break cannot be edited once its start time has passed."}), 409
 
-    # The group PUT never changes the group's type. BREAK↔STATBREAK conversion
-    # goes through the single-match PUT; JOIN converts to/from nothing.
+    # Whole-group type conversion: BREAK↔JOIN only (both are dynamic field
+    # reservations). Nothing converts TO a STATBREAK — create one deliberately
+    # with a start time instead.
+    convert_to: ScheduleType | None = None
     if data.get("schedule_type") is not None:
         try:
             requested_type = ScheduleType(data.get("schedule_type"))
         except ValueError:
             requested_type = None
-        if requested_type != group_type:
-            if is_join or requested_type == ScheduleType.JOIN:
-                return jsonify({"error": "Joins cannot be converted to or from breaks."}), 400
-            return jsonify({"error": "A group's schedule type cannot be changed here."}), 400
+        if requested_type is not None and requested_type != group_type:
+            if group_type in (ScheduleType.BREAK, ScheduleType.JOIN) and requested_type in (
+                ScheduleType.BREAK,
+                ScheduleType.JOIN,
+            ):
+                convert_to = requested_type
+            elif requested_type == ScheduleType.STATBREAK:
+                return jsonify(
+                    {"error": "Breaks cannot be converted to static breaks; create a new static break instead."}
+                ), 400
+            else:
+                return jsonify({"error": "A group's schedule type cannot be changed here."}), 400
+
+    effective_type = convert_to or group_type
+    is_join = effective_type == ScheduleType.JOIN
 
     length = data.get("length")
     if is_join:
-        length = None  # JOIN invariant: length stays 0.
+        length = 0 if convert_to is not None else None  # JOIN invariant: length is 0.
+    elif convert_to == ScheduleType.BREAK and length is None:
+        # JOIN rows carry length 0; a break needs a real duration.
+        return jsonify({"error": "Length (minutes) is required when converting a join to a break."}), 400
     elif length is not None:
         try:
             length = int(length)
@@ -981,6 +1027,8 @@ def update_break_group_api(tournament_url, name):
 
     # Shared edits on existing rows.
     for m in rows:
+        if convert_to is not None:
+            m.schedule_type = convert_to
         if length is not None:
             m.nominal_length = length
         if start_dt is not None:
@@ -1003,15 +1051,15 @@ def update_break_group_api(tournament_url, name):
                 )
             match = Match(event=tournament_url, name=name)
             match.field = f
-            match.schedule_type = group_type
-            match.nominal_length = template.nominal_length
+            match.schedule_type = effective_type
+            match.nominal_length = length if length is not None else template.nominal_length
             match.skip_condition = None
-            if group_type == ScheduleType.STATBREAK:
+            if effective_type == ScheduleType.STATBREAK:
                 match.nominal_start_time = template.nominal_start_time
                 match.scheduled_start_time = template.scheduled_start_time
             db.session.add(match)
             db.session.flush()
-            if group_type in (ScheduleType.BREAK, ScheduleType.JOIN):
+            if effective_type in (ScheduleType.BREAK, ScheduleType.JOIN):
                 tail = _field_chain_tail(tournament_url, f, exclude_uuids={match.uuid})
                 if tail is not None:
                     update_match_previous_link(match, tail.uuid, tournament_url, is_new=True)

--- a/app/routes/tournaments/matches_admin.py
+++ b/app/routes/tournaments/matches_admin.py
@@ -14,7 +14,6 @@ from flask_login import current_user, login_required
 from sqlalchemy.orm.attributes import flag_modified
 
 from app.domain.enums import (
-    BREAK_SCHEDULE_TYPES,
     STRUCTURAL_SCHEDULE_TYPES,
     MatchStatus,
     ScheduleType,
@@ -733,8 +732,10 @@ def delete_match_api(tournament_url, match_id):
 
 
 # ---------------------------------------------------------------------------
-# Break groups: same-name BREAK/STATBREAK rows across multiple fields, created
-# and edited as one unit (shared name / length / team requirements / start time).
+# Structural groups ("break-groups" API): same-name BREAK/STATBREAK/JOIN rows
+# across multiple fields, created and edited as one unit (shared name / length /
+# team requirements / start time; JOINs carry only a name — length is always 0
+# and they never have team requirements).
 # ---------------------------------------------------------------------------
 
 
@@ -752,10 +753,10 @@ def _parse_start_time_utc(start_time_str: str | None) -> datetime | None:
 
 
 def _break_group_rows(tournament_url: str, name: str) -> list[Match]:
-    """All BREAK/STATBREAK rows sharing *name* in this tournament."""
+    """All BREAK/STATBREAK/JOIN rows sharing *name* in this tournament."""
     return (
         Match.query.filter_by(event=tournament_url, name=name)
-        .filter(Match.schedule_type.in_(BREAK_SCHEDULE_TYPES))
+        .filter(Match.schedule_type.in_(STRUCTURAL_SCHEDULE_TYPES))
         .all()
     )
 
@@ -795,7 +796,10 @@ def _structural_name_collision(tournament_url: str, name: str, field_name: str) 
 @bp.route("/tournaments/<tournament_url>/break-groups", methods=["POST"])
 @login_required
 def create_break_group_api(tournament_url):
-    """Create one BREAK/STATBREAK row per field, sharing name/length/teams."""
+    """Create one BREAK/STATBREAK/JOIN row per field, sharing name/length/teams.
+
+    JOIN rows always have ``nominal_length`` 0 and never carry team requirements.
+    """
     if not _check_to(tournament_url):
         return jsonify({"error": "Forbidden"}), 403
 
@@ -805,7 +809,7 @@ def create_break_group_api(tournament_url):
 
     name = (data.get("name") or "").strip()
     if not name:
-        return jsonify({"error": "Break name is required"}), 400
+        return jsonify({"error": "Name is required"}), 400
     mn_err = match_name_char_error(name)
     if mn_err:
         return jsonify({"error": mn_err}), 400
@@ -814,15 +818,19 @@ def create_break_group_api(tournament_url):
         schedule_type = ScheduleType(data.get("schedule_type") or "BREAK")
     except ValueError:
         schedule_type = None
-    if schedule_type not in BREAK_SCHEDULE_TYPES:
-        return jsonify({"error": "schedule_type must be BREAK or STATBREAK."}), 400
+    if schedule_type not in STRUCTURAL_SCHEDULE_TYPES:
+        return jsonify({"error": "schedule_type must be BREAK, STATBREAK, or JOIN."}), 400
+    is_join = schedule_type == ScheduleType.JOIN
 
-    try:
-        length = int(data.get("length"))
-    except (TypeError, ValueError):
-        return jsonify({"error": "Length (minutes) is required."}), 400
-    if length < 0:
-        return jsonify({"error": "Length cannot be negative."}), 400
+    if is_join:
+        length = 0  # JOIN invariant: zero-length synchronisation point.
+    else:
+        try:
+            length = int(data.get("length"))
+        except (TypeError, ValueError):
+            return jsonify({"error": "Length (minutes) is required."}), 400
+        if length < 0:
+            return jsonify({"error": "Length cannot be negative."}), 400
 
     raw_fields = data.get("fields")
     if not isinstance(raw_fields, list):
@@ -843,6 +851,8 @@ def create_break_group_api(tournament_url):
     teams = data.get("teams") or []
     if not isinstance(teams, list):
         return jsonify({"error": "teams must be a list of team tokens."}), 400
+    if is_join and teams:
+        return jsonify({"error": "Joins cannot have team requirements."}), 400
     refs_csv_pair = resolve_refs_slots(teams, tournament_url) if teams else None
 
     start_dt = None
@@ -876,7 +886,7 @@ def create_break_group_api(tournament_url):
         db.session.flush()
         if refs_csv_pair is not None:
             set_match_referees_from_csv(match, refs_csv_pair[0], refs_csv_pair[1])
-        if schedule_type == ScheduleType.BREAK:
+        if schedule_type in (ScheduleType.BREAK, ScheduleType.JOIN):
             prev_id = str(previous_map.get(f) or "").strip()
             if prev_id:
                 prev_match = Match.query.filter_by(uuid=prev_id, event=tournament_url).first()
@@ -907,7 +917,11 @@ def create_break_group_api(tournament_url):
 @bp.route("/tournaments/<tournament_url>/break-groups/<name>", methods=["PUT"])
 @login_required
 def update_break_group_api(tournament_url, name):
-    """Edit every same-name break row at once (length/teams/start_time/fields)."""
+    """Edit every same-name structural row at once (length/teams/start_time/fields).
+
+    JOIN groups only support field membership changes; length stays 0 and team
+    requirements are rejected.
+    """
     if not _check_to(tournament_url):
         return jsonify({"error": "Forbidden"}), 403
 
@@ -920,12 +934,27 @@ def update_break_group_api(tournament_url, name):
         return jsonify({"error": "Invalid JSON"}), 400
 
     group_type = rows[0].schedule_type
-    # No started-lock here: break statuses are solver-derived (BREAK completes
-    # when its dependencies complete, STATBREAK when its window elapses), not
-    # user-started, and the recompute below re-derives them after any edit.
+    is_join = group_type == ScheduleType.JOIN
+    # No started-lock here: structural statuses are solver-derived (BREAK/JOIN
+    # complete when their dependencies complete, STATBREAK when its window
+    # elapses), not user-started, and the recompute below re-derives them.
+
+    # The group PUT never changes the group's type. BREAK↔STATBREAK conversion
+    # goes through the single-match PUT; JOIN converts to/from nothing.
+    if data.get("schedule_type") is not None:
+        try:
+            requested_type = ScheduleType(data.get("schedule_type"))
+        except ValueError:
+            requested_type = None
+        if requested_type != group_type:
+            if is_join or requested_type == ScheduleType.JOIN:
+                return jsonify({"error": "Joins cannot be converted to or from breaks."}), 400
+            return jsonify({"error": "A group's schedule type cannot be changed here."}), 400
 
     length = data.get("length")
-    if length is not None:
+    if is_join:
+        length = None  # JOIN invariant: length stays 0.
+    elif length is not None:
         try:
             length = int(length)
         except (TypeError, ValueError):
@@ -936,6 +965,8 @@ def update_break_group_api(tournament_url, name):
     teams = data.get("teams")
     if teams is not None and not isinstance(teams, list):
         return jsonify({"error": "teams must be a list of team tokens."}), 400
+    if is_join and teams:
+        return jsonify({"error": "Joins cannot have team requirements."}), 400
 
     start_dt = None
     if data.get("start_time") is not None:
@@ -1010,14 +1041,14 @@ def update_break_group_api(tournament_url, name):
             db.session.flush()
             if refs_csv_pair is not None:
                 set_match_referees_from_csv(match, refs_csv_pair[0], refs_csv_pair[1])
-            elif teams is None:
+            elif teams is None and not is_join:
                 # Copy the group's existing team requirements onto the new row.
                 set_match_referees_from_csv(
                     match,
                     get_match_refs_csv(template),
                     get_match_refs_initial_csv(template),
                 )
-            if group_type == ScheduleType.BREAK:
+            if group_type in (ScheduleType.BREAK, ScheduleType.JOIN):
                 tail = _field_chain_tail(tournament_url, f, exclude_uuids={match.uuid})
                 if tail is not None:
                     update_match_previous_link(match, tail.uuid, tournament_url, is_new=True)
@@ -1038,7 +1069,7 @@ def update_break_group_api(tournament_url, name):
 @bp.route("/tournaments/<tournament_url>/break-groups/<name>", methods=["DELETE"])
 @login_required
 def delete_break_group_api(tournament_url, name):
-    """Delete every same-name break row in the group."""
+    """Delete every same-name structural row in the group."""
     if not _check_to(tournament_url):
         return jsonify({"error": "Forbidden"}), 403
 

--- a/app/routes/tournaments/matches_admin.py
+++ b/app/routes/tournaments/matches_admin.py
@@ -22,8 +22,6 @@ from app.domain.enums import (
 from app.services.dual_write import (
     clear_match_referees,
     get_match_ref_initials,
-    get_match_refs_csv,
-    get_match_refs_initial_csv,
     set_match_referees_from_csv,
 )
 from app.services.permission_service import PermissionService
@@ -131,8 +129,9 @@ def update_match_api(tournament_url, match_id):
         return jsonify({"error": "Forbidden"}), 403
 
     match = Match.query.filter_by(uuid=match_id, event=tournament_url).first_or_404()
-    # STATBREAKs auto-complete on a timer (nobody "starts" them), so they stay
-    # editable even in COMPLETED state.
+    # STATBREAK status is time-derived at read time (nobody "starts" them) and
+    # the stored status stays NOT_STARTED, but keep the exemption so legacy rows
+    # with a stored COMPLETED remain editable too.
     if match.status in _LOCKED_STATUSES and match.schedule_type != ScheduleType.STATBREAK:
         return (
             jsonify({"error": (f"Match cannot be edited once it has started (current status: {match.status.value}).")}),
@@ -222,23 +221,14 @@ def update_match_api(tournament_url, match_id):
                     400,
                 )
 
-    # Structural matches never have playing teams. JOINs also have no refs;
-    # BREAK/STATBREAK accept refs as team requirements ("these teams must
-    # attend the break").
+    # Structural matches (BREAK/STATBREAK/JOIN) never have playing teams or
+    # refs — they only occupy fields.
     if match.schedule_type in STRUCTURAL_SCHEDULE_TYPES:
         match.team1 = None
         match.team1_initial = None
         match.team2 = None
         match.team2_initial = None
-        if match.schedule_type == ScheduleType.JOIN:
-            clear_match_referees(match)
-        elif refs is not None:
-            if isinstance(refs, list):
-                r_csv, i_csv = resolve_refs_slots(refs, tournament_url)
-            else:
-                toks = refs_string_to_tokens(refs)
-                r_csv, i_csv = resolve_refs_slots(toks, tournament_url)
-            set_match_referees_from_csv(match, r_csv, i_csv)
+        clear_match_referees(match)
     else:
         # When _initial fields change, write through to the resolved team cache
         # (team1 / team2). _resolve_initial_to_cached_team returns None for
@@ -641,11 +631,10 @@ def create_match_api(tournament_url):
 
     # Refs: parallel refs / refs_initial (same slot count). Resolved here but
     # written below after the flush so the match has a uuid the join-table
-    # rows can reference. Allowed on BREAK/STATBREAK (team requirements for
-    # attending the break) but never on JOIN.
+    # rows can reference. Never allowed on structural types (BREAK/STATBREAK/JOIN).
     refs = data.get("refs")
     refs_csv_pair: tuple[str, str] | None = None
-    if refs and isinstance(refs, list) and match.schedule_type != ScheduleType.JOIN:
+    if refs and isinstance(refs, list) and match.schedule_type not in STRUCTURAL_SCHEDULE_TYPES:
         refs_csv_pair = resolve_refs_slots(refs, tournament_url)
 
     # Format
@@ -734,8 +723,8 @@ def delete_match_api(tournament_url, match_id):
 # ---------------------------------------------------------------------------
 # Structural groups ("break-groups" API): same-name BREAK/STATBREAK/JOIN rows
 # across multiple fields, created and edited as one unit (shared name / length /
-# team requirements / start time; JOINs carry only a name — length is always 0
-# and they never have team requirements).
+# start time; JOINs carry only a name — length is always 0). Structural rows
+# only occupy fields; they never have teams or refs.
 # ---------------------------------------------------------------------------
 
 
@@ -796,9 +785,10 @@ def _structural_name_collision(tournament_url: str, name: str, field_name: str) 
 @bp.route("/tournaments/<tournament_url>/break-groups", methods=["POST"])
 @login_required
 def create_break_group_api(tournament_url):
-    """Create one BREAK/STATBREAK/JOIN row per field, sharing name/length/teams.
+    """Create one BREAK/STATBREAK/JOIN row per field, sharing name/length.
 
-    JOIN rows always have ``nominal_length`` 0 and never carry team requirements.
+    JOIN rows always have ``nominal_length`` 0. Structural rows never carry
+    teams — they only occupy fields.
     """
     if not _check_to(tournament_url):
         return jsonify({"error": "Forbidden"}), 403
@@ -848,12 +838,8 @@ def create_break_group_api(tournament_url):
     if unknown:
         return jsonify({"error": f"Unknown field(s): {', '.join(unknown)}"}), 400
 
-    teams = data.get("teams") or []
-    if not isinstance(teams, list):
-        return jsonify({"error": "teams must be a list of team tokens."}), 400
-    if is_join and teams:
-        return jsonify({"error": "Joins cannot have team requirements."}), 400
-    refs_csv_pair = resolve_refs_slots(teams, tournament_url) if teams else None
+    if data.get("teams"):
+        return jsonify({"error": "Breaks and joins cannot have team requirements; they only occupy fields."}), 400
 
     start_dt = None
     if schedule_type == ScheduleType.STATBREAK:
@@ -884,8 +870,6 @@ def create_break_group_api(tournament_url):
             match.scheduled_start_time = start_dt
         db.session.add(match)
         db.session.flush()
-        if refs_csv_pair is not None:
-            set_match_referees_from_csv(match, refs_csv_pair[0], refs_csv_pair[1])
         if schedule_type in (ScheduleType.BREAK, ScheduleType.JOIN):
             prev_id = str(previous_map.get(f) or "").strip()
             if prev_id:
@@ -917,10 +901,10 @@ def create_break_group_api(tournament_url):
 @bp.route("/tournaments/<tournament_url>/break-groups/<name>", methods=["PUT"])
 @login_required
 def update_break_group_api(tournament_url, name):
-    """Edit every same-name structural row at once (length/teams/start_time/fields).
+    """Edit every same-name structural row at once (length/start_time/fields).
 
-    JOIN groups only support field membership changes; length stays 0 and team
-    requirements are rejected.
+    JOIN groups only support field membership changes; length stays 0. Team
+    requirements are rejected for every structural type.
     """
     if not _check_to(tournament_url):
         return jsonify({"error": "Forbidden"}), 403
@@ -935,9 +919,9 @@ def update_break_group_api(tournament_url, name):
 
     group_type = rows[0].schedule_type
     is_join = group_type == ScheduleType.JOIN
-    # No started-lock here: structural statuses are solver-derived (BREAK/JOIN
-    # complete when their dependencies complete, STATBREAK when its window
-    # elapses), not user-started, and the recompute below re-derives them.
+    # No started-lock here: structural statuses are never user-started (BREAK/JOIN
+    # complete when their dependencies complete; STATBREAK status is derived from
+    # the current time when read), and the recompute below re-derives them.
 
     # The group PUT never changes the group's type. BREAK↔STATBREAK conversion
     # goes through the single-match PUT; JOIN converts to/from nothing.
@@ -962,11 +946,8 @@ def update_break_group_api(tournament_url, name):
         if length < 0:
             return jsonify({"error": "Length cannot be negative."}), 400
 
-    teams = data.get("teams")
-    if teams is not None and not isinstance(teams, list):
-        return jsonify({"error": "teams must be a list of team tokens."}), 400
-    if is_join and teams:
-        return jsonify({"error": "Joins cannot have team requirements."}), 400
+    if data.get("teams"):
+        return jsonify({"error": "Breaks and joins cannot have team requirements; they only occupy fields."}), 400
 
     start_dt = None
     if data.get("start_time") is not None:
@@ -998,19 +979,10 @@ def update_break_group_api(tournament_url, name):
         if unknown:
             return jsonify({"error": f"Unknown field(s): {', '.join(unknown)}"}), 400
 
-    refs_csv_pair = None
-    if teams is not None and teams:
-        refs_csv_pair = resolve_refs_slots(teams, tournament_url)
-
     # Shared edits on existing rows.
     for m in rows:
         if length is not None:
             m.nominal_length = length
-        if teams is not None:
-            if refs_csv_pair is not None:
-                set_match_referees_from_csv(m, refs_csv_pair[0], refs_csv_pair[1])
-            else:
-                clear_match_referees(m)
         if start_dt is not None:
             m.nominal_start_time = start_dt
             m.scheduled_start_time = start_dt
@@ -1039,15 +1011,6 @@ def update_break_group_api(tournament_url, name):
                 match.scheduled_start_time = template.scheduled_start_time
             db.session.add(match)
             db.session.flush()
-            if refs_csv_pair is not None:
-                set_match_referees_from_csv(match, refs_csv_pair[0], refs_csv_pair[1])
-            elif teams is None and not is_join:
-                # Copy the group's existing team requirements onto the new row.
-                set_match_referees_from_csv(
-                    match,
-                    get_match_refs_csv(template),
-                    get_match_refs_initial_csv(template),
-                )
             if group_type in (ScheduleType.BREAK, ScheduleType.JOIN):
                 tail = _field_chain_tail(tournament_url, f, exclude_uuids={match.uuid})
                 if tail is not None:

--- a/app/routes/tournaments/read.py
+++ b/app/routes/tournaments/read.py
@@ -645,7 +645,9 @@ def tournament_schedule(tournament_url):
                 "team2": m.team2,
                 "team1_initial": m.team1_initial,
                 "team2_initial": m.team2_initial,
-                "status": (m.status.value if hasattr(m.status, "value") else str(m.status)),
+                "status": (
+                    m.effective_status.value if hasattr(m.effective_status, "value") else str(m.effective_status)
+                ),
                 "scheduled_start_time": dt_iso(m.scheduled_start_time),
                 "nominal_start_time": dt_iso(m.nominal_start_time),
                 "confirmed_start_time": dt_iso(m.confirmed_start_time),
@@ -795,7 +797,9 @@ def tournament_schedule_setup(tournament_url):
                 "team2": m.team2,
                 "team1_initial": m.team1_initial,
                 "team2_initial": m.team2_initial,
-                "status": (m.status.value if hasattr(m.status, "value") else str(m.status)),
+                "status": (
+                    m.effective_status.value if hasattr(m.effective_status, "value") else str(m.effective_status)
+                ),
                 "scheduled_start_time": dt_iso(m.scheduled_start_time),
                 "nominal_start_time": dt_iso(m.nominal_start_time),
                 "confirmed_start_time": dt_iso(m.confirmed_start_time),
@@ -1231,7 +1235,11 @@ def tournament_match_detail(tournament_url):
                 "team2_shortname": team2_shortname,
                 "team1_initial": match.team1_initial,
                 "team2_initial": match.team2_initial,
-                "status": (match.status.value if hasattr(match.status, "value") else str(match.status)),
+                "status": (
+                    match.effective_status.value
+                    if hasattr(match.effective_status, "value")
+                    else str(match.effective_status)
+                ),
                 "scheduled_start_time": dt_iso(match.scheduled_start_time),
                 "nominal_start_time": dt_iso(match.nominal_start_time),
                 "confirmed_start_time": dt_iso(match.confirmed_start_time),
@@ -1317,7 +1325,11 @@ def tournament_match_state(tournament_url):
     return jsonify(
         {
             "match_id": match.uuid,
-            "status": (match.status.value if hasattr(match.status, "value") else str(match.status)),
+            "status": (
+                match.effective_status.value
+                if hasattr(match.effective_status, "value")
+                else str(match.effective_status)
+            ),
             "team1_score": team1_score,
             "team2_score": team2_score,
             "scores_by_set": scores_by_set,

--- a/app/routes/tournaments/scheduling.py
+++ b/app/routes/tournaments/scheduling.py
@@ -795,7 +795,7 @@ def tournament_autocomplete(tournament_url):
     # Exclude BREAK and JOIN matches entirely
     matches = (
         Match.query.filter_by(event=tournament_url)
-        .filter(Match.schedule_type.notin_([ScheduleType.BREAK, ScheduleType.JOIN]))
+        .filter(Match.schedule_type.notin_([ScheduleType.BREAK, ScheduleType.STATBREAK, ScheduleType.JOIN]))
         .all()
     )
     for m in matches:

--- a/app/services/team_stats_service.py
+++ b/app/services/team_stats_service.py
@@ -68,7 +68,7 @@ def compute_team_stats(matches: list, tournament, include_ribbon: bool = False) 
     count_matches = [
         m
         for m in matches
-        if getattr(m, "schedule_type", None) not in (ScheduleType.BREAK, ScheduleType.JOIN)
+        if getattr(m, "schedule_type", None) not in (ScheduleType.BREAK, ScheduleType.STATBREAK, ScheduleType.JOIN)
         and (include_ribbon or not getattr(m, "ribbon", False))
     ]
 

--- a/app/utils/MatchGraph.py
+++ b/app/utils/MatchGraph.py
@@ -509,7 +509,7 @@ def build_match_graph(
             confirmed_end_time=representative.finalized_at,
             schedule_type=representative.schedule_type,
             skip_condition=representative.skip_condition,
-            status=representative.status,
+            status=representative.effective_status,
             component_uuids=component_uuids,
             field="",
         )
@@ -527,9 +527,13 @@ def build_match_graph(
             nominal_length=match.nominal_length,
             confirmed_start_time=match.confirmed_start_time,
             confirmed_end_time=match.finalized_at,
+            # Effective status: for STATBREAK the lifecycle status is derived
+            # from the current time (COMPLETED once its start has passed), so
+            # solver-internal status checks see the derived value. The write-back
+            # step never persists STATBREAK status.
             schedule_type=match.schedule_type,
             skip_condition=match.skip_condition,
-            status=match.status,
+            status=match.effective_status,
             field=match.field or "",
         )
         graph.add_node(node)
@@ -617,13 +621,10 @@ def build_match_graph(
         if include_resource_conflict_edges and match.schedule_type in (ScheduleType.SAFE, ScheduleType.FAST):
             # Cross-field same-team serialization: a SAFE/FAST match depends on the
             # latest match on *another* field that shares a team and is scheduled
-            # before it, so the two don't run simultaneously. Candidates include
-            # BREAK/STATBREAK rows with team requirements (refs), so a SAFE/FAST
-            # match whose team must attend a break elsewhere waits for that break.
-            # Same-field ordering is already handled by the previous_match chain, so
-            # we skip the match's own field. The anchor is scheduled_start_time
-            # (computed in the planned pass without these edges), which is stable —
-            # so this ordering doesn't flip-flop.
+            # before it, so the two don't run simultaneously. Same-field ordering is
+            # already handled by the previous_match chain, so we skip the match's own
+            # field. The anchor is scheduled_start_time (computed in the planned pass
+            # without these edges), which is stable — so this ordering doesn't flip-flop.
             match_start = _scheduled_anchor(match)
             participants = _match_participant_team_ids(match, ref_ids_by_uuid)
             latest_shared_matches_by_field: Dict[str, Match] = {}

--- a/app/utils/MatchGraph.py
+++ b/app/utils/MatchGraph.py
@@ -372,13 +372,59 @@ def _csv_tokens(raw: Optional[str]) -> List[str]:
     return [part.strip() for part in str(raw).split(",") if part.strip()]
 
 
-def _match_participant_team_ids(match: Match) -> Set[str]:
-    """Return concrete team IDs currently assigned to team or ref slots."""
+def referee_team_ids_by_match_uuid(matches: List[Match]) -> Dict[str, Set[str]]:
+    """Bulk-load resolved referee team IDs from ``match_referees`` for many matches.
+
+    Returns a dict keyed by match uuid; matches without referee rows are
+    simply absent. One query total, so callers in O(n²) loops (e.g. the
+    resource-conflict edge builder) don't hit the DB per pair.
+    """
+    from app.models import MatchReferee
+
+    uuids = [m.uuid for m in matches if getattr(m, "uuid", None)]
+    result: Dict[str, Set[str]] = {}
+    if not uuids:
+        return result
+    for row in MatchReferee.query.filter(MatchReferee.match_uuid.in_(uuids)).all():
+        if row.team_id and str(row.team_id).strip():
+            result.setdefault(row.match_uuid, set()).add(str(row.team_id).strip())
+    return result
+
+
+def _match_participant_team_ids(
+    match: Match,
+    ref_team_ids_by_uuid: Optional[Dict[str, Set[str]]] = None,
+) -> Set[str]:
+    """Return concrete team IDs currently assigned to team or ref slots.
+
+    Referee team IDs come from the normalised ``match_referees`` table (via
+    *ref_team_ids_by_uuid* when the caller pre-fetched it, else a per-match
+    query), falling back to the legacy ``refs`` CSV attribute only when no
+    join-table rows exist.
+    """
     participants = set()
     for team_id in (getattr(match, "team1", None), getattr(match, "team2", None)):
         if team_id and str(team_id).strip():
             participants.add(str(team_id).strip())
-    participants.update(_csv_tokens(getattr(match, "refs", None)))
+
+    ref_ids: Set[str] = set()
+    if ref_team_ids_by_uuid is not None:
+        ref_ids = ref_team_ids_by_uuid.get(getattr(match, "uuid", None), set())
+    elif getattr(match, "uuid", None):
+        from app.services.dual_write import get_match_referee_rows
+
+        try:
+            rows = get_match_referee_rows(match)
+        except Exception:
+            rows = []
+        ref_ids = {str(r.team_id).strip() for r in rows if r.team_id and str(r.team_id).strip()}
+
+    if ref_ids:
+        participants.update(ref_ids)
+    else:
+        # Legacy fallback: dual-write no longer maintains the `refs` CSV column,
+        # but old in-memory objects/tests may still carry it.
+        participants.update(_csv_tokens(getattr(match, "refs", None)))
     return participants
 
 
@@ -418,6 +464,10 @@ def build_match_graph(
     """
     if all_matches is None:
         all_matches = Match.query.filter_by(event=tournament_url).all()
+
+    # Pre-fetch resolved referee team IDs once; the resource-conflict loop below
+    # is O(n²) over matches and must not hit the DB per candidate pair.
+    ref_ids_by_uuid = referee_team_ids_by_match_uuid(all_matches) if include_resource_conflict_edges else {}
 
     graph = MatchGraph()
 
@@ -567,12 +617,15 @@ def build_match_graph(
         if include_resource_conflict_edges and match.schedule_type in (ScheduleType.SAFE, ScheduleType.FAST):
             # Cross-field same-team serialization: a SAFE/FAST match depends on the
             # latest match on *another* field that shares a team and is scheduled
-            # before it, so the two don't run simultaneously. Same-field ordering is
-            # already handled by the previous_match chain, so we skip the match's own
-            # field. The anchor is scheduled_start_time (computed in the planned pass
-            # without these edges), which is stable — so this ordering doesn't flip-flop.
+            # before it, so the two don't run simultaneously. Candidates include
+            # BREAK/STATBREAK rows with team requirements (refs), so a SAFE/FAST
+            # match whose team must attend a break elsewhere waits for that break.
+            # Same-field ordering is already handled by the previous_match chain, so
+            # we skip the match's own field. The anchor is scheduled_start_time
+            # (computed in the planned pass without these edges), which is stable —
+            # so this ordering doesn't flip-flop.
             match_start = _scheduled_anchor(match)
-            participants = _match_participant_team_ids(match)
+            participants = _match_participant_team_ids(match, ref_ids_by_uuid)
             latest_shared_matches_by_field: Dict[str, Match] = {}
             if match_start and participants:
                 for field_name, field_matches in matches_by_field.items():
@@ -584,7 +637,7 @@ def build_match_graph(
                         candidate_start = _scheduled_anchor(candidate)
                         if candidate.uuid == match.uuid or candidate_start is None or candidate_start >= match_start:
                             continue
-                        if not (participants & _match_participant_team_ids(candidate)):
+                        if not (participants & _match_participant_team_ids(candidate, ref_ids_by_uuid)):
                             continue
                         if latest_shared_match is None or (
                             candidate_start,
@@ -625,4 +678,37 @@ def build_match_graph(
             if dep_key in graph.nodes_by_key:
                 graph.add_dependency(dependent_key, dep_key, is_skip_condition=True)
 
+    _sync_same_name_breaks(graph)
+
     return graph
+
+
+def _sync_same_name_breaks(graph: MatchGraph) -> None:
+    """Give same-name BREAK nodes the union of the group's dependency edges.
+
+    Breaks with the same name in the same event (across different fields) must
+    start at the same time: each member keeps its own (name, field) node — so
+    downstream per-field dependents still resolve — but every member depends on
+    every group member's predecessors, making each one compute the same start
+    (= latest predecessor end across the group) in both solver passes. These
+    are structural edges, present in the live and planned passes alike.
+
+    STATBREAKs are excluded: they're statically scheduled, so same-name
+    STATBREAKs are trivially synced by sharing a user-supplied start time.
+    """
+    breaks_by_name: Dict[str, List[MatchGraphNode]] = defaultdict(list)
+    for node in graph.get_all_nodes():
+        if node.schedule_type == ScheduleType.BREAK:
+            breaks_by_name[node.name].append(node)
+
+    for group in breaks_by_name.values():
+        if len(group) < 2:
+            continue
+        members = set(group)
+        union_deps: Set[Dependency] = set()
+        for member in group:
+            union_deps |= {dep for dep in member.dependencies if dep.node not in members}
+        for member in group:
+            member.dependencies |= union_deps
+            for dep in union_deps:
+                dep.node.dependents.add(member)

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -14,7 +14,6 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
 from app.domain.enums import (
-    BREAK_SCHEDULE_TYPES,
     STRUCTURAL_SCHEDULE_TYPES,
     MatchStatus,
     ScheduleType,
@@ -225,20 +224,12 @@ def _procedure_with_match(
     Mutates node (nominal_start_time, status). No callbacks.
     """
     if node.schedule_type == ScheduleType.STATBREAK:
-        # Statically-scheduled break: the solver never moves its time, and it
-        # is never startable (no READY_TO_START). Its status is purely
-        # time-derived — COMPLETED once its window (start + length) has
-        # elapsed, NOT_STARTED otherwise — so moving a completed STATBREAK
-        # into the future un-completes it. Downstream dependents then use its
-        # end (start + length) exactly like a BREAK's. Handled before the
-        # started/completed early-return below because that lock never applies
-        # to STATBREAKs.
-        anchor = node.nominal_start_time or node.scheduled_start_time
-        if anchor is not None and node.nominal_length is not None:
-            if _now_utc() >= anchor + timedelta(minutes=node.nominal_length):
-                node.status = MatchStatus.COMPLETED
-            elif node.status == MatchStatus.COMPLETED:
-                node.status = MatchStatus.NOT_STARTED
+        # Statically-scheduled break: the solver never moves its time and never
+        # writes its status. STATBREAK status is derived from the current time
+        # when read (Match.effective_status: COMPLETED once the start has
+        # passed), so the stored status stays NOT_STARTED. Downstream
+        # dependents still use its end (start + length) exactly like a
+        # BREAK's for time purposes.
         return
 
     if node.status in (
@@ -399,14 +390,20 @@ def _scheduled_procedure_for_cycle_node(
 
 
 def _write_graph_to_db(graph: MatchGraph, uuid_to_match: Dict[str, object]) -> None:
-    """Persist graph state to in-memory Match objects (no DB read). Caller commits once."""
+    """Persist graph state to in-memory Match objects (no DB read). Caller commits once.
+
+    STATBREAK statuses are never written: they're derived from the current time
+    at read time (``Match.effective_status``), and the graph node carries that
+    derived value, not the stored one.
+    """
     for node in graph.get_all_nodes():
         uuids_to_update = list(node.component_uuids) if node.component_uuids else [node.uuid]
         for uid in uuids_to_update:
             m = uuid_to_match.get(uid)
             if m is not None:
                 m.nominal_start_time = node.nominal_start_time
-                m.status = node.status
+                if node.schedule_type != ScheduleType.STATBREAK:
+                    m.status = node.status
 
 
 def _write_scheduled_to_db(graph: MatchGraph, uuid_to_match: Dict[str, object]) -> None:
@@ -709,8 +706,9 @@ def validate_match_warnings(tournament_url: str) -> List[dict]:
                 )
 
     # Duplicate-team within a single match (same id or same `_initial` token in 2+ slots).
+    # Structural matches have no team or ref slots, so skip them.
     for m in matches:
-        if m.schedule_type in (ScheduleType.JOIN,):
+        if m.schedule_type in STRUCTURAL_SCHEDULE_TYPES:
             continue
         slot_entries: list[tuple[str, str]] = []
         for slot, team_id, initial in (
@@ -783,17 +781,10 @@ def validate_match_warnings(tournament_url: str) -> List[dict]:
     # serializes cross-field same-team matches so they don't actually collide, which
     # means the conflict only shows up on the planned timeline — that's the timeline
     # we check here. Two matches sharing a team whose scheduled intervals overlap are
-    # double-booked, regardless of field or schedule type. Same-name break rows are
-    # one logical break spanning fields, so a shared team attending "both" is fine.
+    # double-booked, regardless of field or schedule type.
     ref_ids_by_uuid = referee_team_ids_by_match_uuid(matches)
     for i, m in enumerate(matches):
         for other in matches[i + 1 :]:
-            if (
-                m.name == other.name
-                and m.schedule_type in BREAK_SCHEDULE_TYPES
-                and other.schedule_type in BREAK_SCHEDULE_TYPES
-            ):
-                continue
             if not _matches_share_any_team(m, other, ref_ids_by_uuid):
                 continue
             if _intervals_overlap(

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -13,12 +13,19 @@ import threading
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
-from app.domain.enums import MatchStatus, ScheduleType
+from app.domain.enums import (
+    BREAK_SCHEDULE_TYPES,
+    STRUCTURAL_SCHEDULE_TYPES,
+    MatchStatus,
+    ScheduleType,
+)
 from app.models.base import db
 from app.utils.MatchGraph import (
     MatchGraph,
     MatchGraphNode,
+    _match_participant_team_ids,
     build_match_graph,
+    referee_team_ids_by_match_uuid,
 )
 from app.utils.name_validation import match_name_char_error
 from app.utils.datetime_helpers import now_utc_naive
@@ -50,50 +57,29 @@ def _now_utc() -> datetime:
     return now_utc_naive()
 
 
-def _csv_tokens(raw: Optional[str]) -> List[str]:
-    """Split a comma-separated string into a stripped, non-empty token list.
-
-    Args:
-        raw: Comma-separated string, or ``None``.
-
-    Returns:
-        List of non-empty stripped tokens.
-    """
-    if not raw:
-        return []
-    return [part.strip() for part in str(raw).split(",") if part.strip()]
-
-
-def _match_participant_team_ids(match: object) -> set[str]:
-    """Return the set of team IDs actively assigned to a match.
-
-    Includes ``team1``, ``team2``, and all non-empty ``refs`` tokens.
-
-    Args:
-        match: Any object with ``team1``, ``team2``, and ``refs`` attributes.
-
-    Returns:
-        Set of non-empty team ID strings.
-    """
-    participants = set()
-    for team_id in (getattr(match, "team1", None), getattr(match, "team2", None)):
-        if team_id and str(team_id).strip():
-            participants.add(str(team_id).strip())
-    participants.update(_csv_tokens(getattr(match, "refs", None)))
-    return participants
-
-
-def _matches_share_any_team(match_a: object, match_b: object) -> bool:
+def _matches_share_any_team(
+    match_a: object,
+    match_b: object,
+    ref_team_ids_by_uuid: Optional[Dict[str, set]] = None,
+) -> bool:
     """Return ``True`` if *match_a* and *match_b* share at least one team/ref.
+
+    Participant sets come from :func:`app.utils.MatchGraph._match_participant_team_ids`,
+    which reads referee assignments from the ``match_referees`` table (optionally
+    via a pre-fetched *ref_team_ids_by_uuid* map).
 
     Args:
         match_a: First match object.
         match_b: Second match object.
+        ref_team_ids_by_uuid: Optional pre-fetched uuid → referee-team-ids map.
 
     Returns:
         ``True`` if the participant team-ID sets intersect.
     """
-    return bool(_match_participant_team_ids(match_a) & _match_participant_team_ids(match_b))
+    return bool(
+        _match_participant_team_ids(match_a, ref_team_ids_by_uuid)
+        & _match_participant_team_ids(match_b, ref_team_ids_by_uuid)
+    )
 
 
 def _intervals_overlap(
@@ -194,10 +180,8 @@ def _all_participating_teams_resolved(
     each slot is either a concrete team ID, or a tag:: ref with the tag assigned to a team,
     or a MatchName::winner/loser ref whose match is completed.
     """
-    from app.domain.enums import ScheduleType
-
     schedule_type = getattr(match, "schedule_type", None)
-    if schedule_type in (ScheduleType.BREAK, ScheduleType.JOIN):
+    if schedule_type in STRUCTURAL_SCHEDULE_TYPES:
         return True
 
     if not _slot_resolved(
@@ -240,6 +224,23 @@ def _procedure_with_match(
 
     Mutates node (nominal_start_time, status). No callbacks.
     """
+    if node.schedule_type == ScheduleType.STATBREAK:
+        # Statically-scheduled break: the solver never moves its time, and it
+        # is never startable (no READY_TO_START). Its status is purely
+        # time-derived — COMPLETED once its window (start + length) has
+        # elapsed, NOT_STARTED otherwise — so moving a completed STATBREAK
+        # into the future un-completes it. Downstream dependents then use its
+        # end (start + length) exactly like a BREAK's. Handled before the
+        # started/completed early-return below because that lock never applies
+        # to STATBREAKs.
+        anchor = node.nominal_start_time or node.scheduled_start_time
+        if anchor is not None and node.nominal_length is not None:
+            if _now_utc() >= anchor + timedelta(minutes=node.nominal_length):
+                node.status = MatchStatus.COMPLETED
+            elif node.status == MatchStatus.COMPLETED:
+                node.status = MatchStatus.NOT_STARTED
+        return
+
     if node.status in (
         MatchStatus.COMPLETED,
         MatchStatus.IN_PROGRESS,
@@ -331,6 +332,9 @@ def _procedure_for_cycle_node(
         if node.status == MatchStatus.NOT_STARTED:
             node.status = MatchStatus.TIME_FINALIZED
         return
+    if node.schedule_type == ScheduleType.STATBREAK:
+        # Statically scheduled: keep the user-supplied time even inside a cycle.
+        return
 
     match_obj = uuid_to_match.get(node.uuid)
     prev_uuid = getattr(match_obj, "previous_match", None) if match_obj is not None else None
@@ -355,9 +359,9 @@ def _scheduled_procedure(node: MatchGraphNode) -> None:
     times and match status entirely. Never reads or writes status, and never
     touches nominal_start_time.
 
-    STATIC matches keep their user-set scheduled_start_time anchor.
+    STATIC and STATBREAK matches keep their user-set scheduled_start_time anchor.
     """
-    if node.schedule_type == ScheduleType.STATIC:
+    if node.schedule_type in (ScheduleType.STATIC, ScheduleType.STATBREAK):
         return
     latest = node.get_direct_deps_latest_scheduled_end_time()
     if latest is not None:
@@ -373,11 +377,11 @@ def _scheduled_procedure_for_cycle_node(
 
     Mirrors :func:`_procedure_for_cycle_node` but on the planned timeline: fall
     back to the doubly-linked-list previous match's scheduled end time. STATIC
-    matches keep their anchor. No status is read or written.
+    and STATBREAK matches keep their anchor. No status is read or written.
     """
     from app.utils.MatchGraph import _node_scheduled_end_time
 
-    if node.schedule_type == ScheduleType.STATIC:
+    if node.schedule_type in (ScheduleType.STATIC, ScheduleType.STATBREAK):
         return
     match_obj = uuid_to_match.get(node.uuid)
     prev_uuid = getattr(match_obj, "previous_match", None) if match_obj is not None else None
@@ -554,10 +558,15 @@ def validate_match_input(match, tournament_url: str) -> Tuple[bool, Optional[str
         event=tournament_url,
         name=match.name.strip(),
     )
-    # For BREAK/JOIN, only check uniqueness on the same field and same type
-    if schedule_type in (ScheduleType.BREAK, ScheduleType.JOIN):
+    # For BREAK/STATBREAK/JOIN, only check uniqueness on the same field within the
+    # structural group (mirrors the `unique_with_field` partial index, which spans
+    # all structural types).
+    if schedule_type in STRUCTURAL_SCHEDULE_TYPES:
         field = (getattr(match, "field", None) or "").strip()
-        existing = existing.filter(Match.field == field, Match.schedule_type == schedule_type)
+        existing = existing.filter(
+            Match.field == field,
+            Match.schedule_type.in_(STRUCTURAL_SCHEDULE_TYPES),
+        )
     if match.uuid:
         existing = existing.filter(Match.uuid != match.uuid)
     if existing.first():
@@ -686,7 +695,7 @@ def validate_match_warnings(tournament_url: str) -> List[dict]:
         return None
 
     for m in matches:
-        if m.schedule_type in (ScheduleType.BREAK, ScheduleType.JOIN):
+        if m.schedule_type in STRUCTURAL_SCHEDULE_TYPES:
             continue
         for slot, team_id, initial in (
             ("team1", m.team1, m.team1_initial),
@@ -701,7 +710,7 @@ def validate_match_warnings(tournament_url: str) -> List[dict]:
 
     # Duplicate-team within a single match (same id or same `_initial` token in 2+ slots).
     for m in matches:
-        if m.schedule_type in (ScheduleType.BREAK, ScheduleType.JOIN):
+        if m.schedule_type in (ScheduleType.JOIN,):
             continue
         slot_entries: list[tuple[str, str]] = []
         for slot, team_id, initial in (
@@ -774,10 +783,18 @@ def validate_match_warnings(tournament_url: str) -> List[dict]:
     # serializes cross-field same-team matches so they don't actually collide, which
     # means the conflict only shows up on the planned timeline — that's the timeline
     # we check here. Two matches sharing a team whose scheduled intervals overlap are
-    # double-booked, regardless of field or schedule type.
+    # double-booked, regardless of field or schedule type. Same-name break rows are
+    # one logical break spanning fields, so a shared team attending "both" is fine.
+    ref_ids_by_uuid = referee_team_ids_by_match_uuid(matches)
     for i, m in enumerate(matches):
         for other in matches[i + 1 :]:
-            if not _matches_share_any_team(m, other):
+            if (
+                m.name == other.name
+                and m.schedule_type in BREAK_SCHEDULE_TYPES
+                and other.schedule_type in BREAK_SCHEDULE_TYPES
+            ):
+                continue
+            if not _matches_share_any_team(m, other, ref_ids_by_uuid):
                 continue
             if _intervals_overlap(
                 m.scheduled_start_time,

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -3418,6 +3418,84 @@ pub async fn create_match(
     response_json(r).await
 }
 
+/// Create a break group: one BREAK/STATBREAK row per selected field, sharing
+/// name / length / team requirements (and start time for STATBREAK).
+pub async fn create_break_group(
+    tournament_url: &str,
+    req: &CreateBreakGroupRequest,
+) -> Result<CreateBreakGroupResponse, String> {
+    let c = client();
+    let r = with_credentials(
+        c.post(format!(
+            "{}/_api/tournaments/{}/break-groups",
+            base(),
+            tournament_url
+        ))
+        .json(req),
+    )
+    .send()
+    .await
+    .map_err(|e| e.to_string())?;
+    response_json(r).await
+}
+
+/// Edit every same-name break row at once (length / teams / start_time / fields).
+pub async fn update_break_group(
+    tournament_url: &str,
+    name: &str,
+    req: &UpdateBreakGroupRequest,
+) -> Result<(), String> {
+    let c = client();
+    let r = with_credentials(
+        c.put(format!(
+            "{}/_api/tournaments/{}/break-groups/{}",
+            base(),
+            tournament_url,
+            urlencoding::encode(name)
+        ))
+        .json(req),
+    )
+    .send()
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let data: Value = response_json(r).await?;
+    if data.get("success").and_then(|v| v.as_bool()) == Some(true) {
+        Ok(())
+    } else {
+        Err(data
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unknown error")
+            .to_string())
+    }
+}
+
+/// Delete every same-name break row in the group.
+pub async fn delete_break_group(tournament_url: &str, name: &str) -> Result<(), String> {
+    let c = client();
+    let r = with_credentials(c.delete(format!(
+        "{}/_api/tournaments/{}/break-groups/{}",
+        base(),
+        tournament_url,
+        urlencoding::encode(name)
+    )))
+    .send()
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let data: Value = response_json(r).await?;
+    if data.get("success").and_then(|v| v.as_bool()) == Some(true) {
+        Ok(())
+    } else {
+        Err(data
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unknown error")
+            .to_string())
+    }
+}
+
 /// Validate a DSL skip-condition expression. Uses the tournaments blueprint route.
 pub async fn validate_dsl(
     tournament_url: &str,

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -3418,8 +3418,8 @@ pub async fn create_match(
     response_json(r).await
 }
 
-/// Create a break group: one BREAK/STATBREAK row per selected field, sharing
-/// name / length / team requirements (and start time for STATBREAK).
+/// Create a break group: one BREAK/STATBREAK/JOIN row per selected field,
+/// sharing name / length (and start time for STATBREAK).
 pub async fn create_break_group(
     tournament_url: &str,
     req: &CreateBreakGroupRequest,
@@ -3439,7 +3439,7 @@ pub async fn create_break_group(
     response_json(r).await
 }
 
-/// Edit every same-name break row at once (length / teams / start_time / fields).
+/// Edit every same-name break row at once (length / start_time / fields).
 pub async fn update_break_group(
     tournament_url: &str,
     name: &str,

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -199,13 +199,27 @@ fn refs_tokens(m: &MatchSetupData) -> Vec<String> {
     out
 }
 
-/// True for BREAK / JOIN — structural schedule items, not games with lifecycle chrome.
+/// True for BREAK / STATBREAK / JOIN — structural schedule items, not games with lifecycle chrome.
 fn is_structural_match(m: &MatchSetupData) -> bool {
-    matches!(m.schedule_type.as_deref(), Some("BREAK") | Some("JOIN"))
+    is_structural_type(m.schedule_type.as_deref())
 }
 
 fn is_structural_type(schedule_type: Option<&str>) -> bool {
-    matches!(schedule_type, Some("BREAK") | Some("JOIN"))
+    matches!(
+        schedule_type,
+        Some("BREAK") | Some("STATBREAK") | Some("JOIN")
+    )
+}
+
+/// True for BREAK / STATBREAK — break-like blocks that may carry team
+/// requirements (refs = "these teams must attend") and are edited as a
+/// same-name group across fields.
+fn is_break_like_type(schedule_type: Option<&str>) -> bool {
+    matches!(schedule_type, Some("BREAK") | Some("STATBREAK"))
+}
+
+fn is_break_like_match(m: &MatchSetupData) -> bool {
+    is_break_like_type(m.schedule_type.as_deref())
 }
 
 /// True if a ref/team token refers to the given focus team id.
@@ -532,6 +546,9 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
 
     let mut active_modal = use_signal(|| "none".to_string());
     let mut selected_match_id = use_signal(|| "".to_string());
+    // Name of the break group being edited (BREAK/STATBREAK blocks open the
+    // group modal instead of the single-match edit modal).
+    let mut selected_break_group = use_signal(|| "".to_string());
     let mut key_nav = use_signal(|| None::<String>);
     let refresh_trigger = use_signal(|| 0u32);
     // Debug mode is opt-in via `localStorage.setItem("debug", "1")`. Read once at mount —
@@ -1160,9 +1177,20 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                                 String::new()
                             },
                             tournament_url: url.clone(),
-                            on_edit_match: move |id: String| {
-                                selected_match_id.set(id);
-                                active_modal.set("match_edit".to_string());
+                            on_edit_match: {
+                                let matches_for_edit = data.matches.clone();
+                                move |id: String| {
+                                    // Break-like blocks are edited as a same-name group.
+                                    if let Some(m) = matches_for_edit.iter().find(|m| m.uuid == id) {
+                                        if is_break_like_match(m) {
+                                            selected_break_group.set(m.name.clone());
+                                            active_modal.set("break_group".to_string());
+                                            return;
+                                        }
+                                    }
+                                    selected_match_id.set(id);
+                                    active_modal.set("match_edit".to_string());
+                                }
                             },
                             key_nav: key_nav,
                             on_key_nav_consumed: move |_| key_nav.set(None),
@@ -1176,9 +1204,19 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                             debug_mode: debug_mode(),
                             show_as_happened: edit_mode() && show_as_happened(),
                             tournament_url: url.clone(),
-                            on_edit_match: move |id: String| {
-                                selected_match_id.set(id);
-                                active_modal.set("match_edit".to_string());
+                            on_edit_match: {
+                                let matches_for_edit = data.matches.clone();
+                                move |id: String| {
+                                    if let Some(m) = matches_for_edit.iter().find(|m| m.uuid == id) {
+                                        if is_break_like_match(m) {
+                                            selected_break_group.set(m.name.clone());
+                                            active_modal.set("break_group".to_string());
+                                            return;
+                                        }
+                                    }
+                                    selected_match_id.set(id);
+                                    active_modal.set("match_edit".to_string());
+                                }
                             }
                         }
                     }
@@ -1206,6 +1244,20 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                             on_save: move |_| {
                                 active_modal.set("none".to_string());
                                 refresh();
+                            }
+                        }
+                    }
+                    if active_modal() == "break_group" {
+                        div { key: "{selected_break_group()}",
+                            BreakGroupModal {
+                                tournament_url: url.clone(),
+                                group_name: selected_break_group(),
+                                data: data.clone(),
+                                on_close: move |_| active_modal.set("none".to_string()),
+                                on_save: move |_| {
+                                    active_modal.set("none".to_string());
+                                    refresh();
+                                }
                             }
                         }
                     }
@@ -1349,6 +1401,8 @@ fn CreateMatchModal(
     let mut skip_condition = use_signal(|| "".to_string());
     let mut skip_condition_help_open = use_signal(|| false);
     let mut skip_condition_validity = use_signal(|| None::<Result<(), String>>);
+    // Break-group mode (type BREAK/STATBREAK): fields the break spans.
+    let mut break_fields = use_signal(Vec::<String>::new);
 
     let mut error = use_signal(|| None::<String>);
     let mut saving = use_signal(|| false);
@@ -1411,11 +1465,26 @@ fn CreateMatchModal(
     let validate_create_rc: Rc<RefCell<Box<dyn FnMut() -> bool>>> =
         Rc::new(RefCell::new(Box::new(move || {
             let st = schedule_type();
-            if st == "BREAK" || st == "JOIN" || st == "FAST" || st == "SAFE" {
+            if st == "BREAK" || st == "STATBREAK" {
+                // Break groups: one row per selected field; no previous match
+                // needed (each row appends at its field's chain tail).
+                if break_fields().is_empty() {
+                    error.set(Some("Select at least one field for the break.".to_string()));
+                    return false;
+                }
+                if st == "STATBREAK" && start_time().trim().is_empty() {
+                    error.set(Some(
+                        "Start time is required for a static break.".to_string(),
+                    ));
+                    return false;
+                }
+                return true;
+            }
+            if st == "JOIN" || st == "FAST" || st == "SAFE" {
                 let prev_id = previous_match_id().trim().to_string();
                 if prev_id.is_empty() {
                     error.set(Some(
-                        "Previous match is required for Break, Join, Fast, and Safe matches."
+                        "Previous match is required for Join, Fast, and Safe matches."
                             .to_string(),
                     ));
                     return false;
@@ -1455,6 +1524,36 @@ fn CreateMatchModal(
         spawn(async move {
             saving.set(true);
             error.set(None);
+            if schedule_type() == "BREAK" || schedule_type() == "STATBREAK" {
+                let teams_vec: Vec<String> = refs()
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                let req = CreateBreakGroupRequest {
+                    name: name(),
+                    schedule_type: schedule_type(),
+                    length: length(),
+                    fields: break_fields(),
+                    teams: teams_vec,
+                    start_time: if schedule_type() == "STATBREAK" {
+                        local_datetime_to_utc_iso(&start_time()).or_else(|| Some(start_time()))
+                    } else {
+                        None
+                    },
+                };
+                match api::create_break_group(&tournament_url, &req).await {
+                    Ok(_) => {
+                        saving.set(false);
+                        on_save.call(());
+                    }
+                    Err(e) => {
+                        error.set(Some(e));
+                        saving.set(false);
+                    }
+                }
+                return;
+            }
             if (schedule_type() == "SAFE" || schedule_type() == "FAST")
                 && !skip_condition().trim().is_empty()
             {
@@ -1562,6 +1661,36 @@ fn CreateMatchModal(
             spawn(async move {
                 saving.set(true);
                 error.set(None);
+                if schedule_type() == "BREAK" || schedule_type() == "STATBREAK" {
+                    let teams_vec: Vec<String> = refs()
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                    let req = CreateBreakGroupRequest {
+                        name: name(),
+                        schedule_type: schedule_type(),
+                        length: length(),
+                        fields: break_fields(),
+                        teams: teams_vec,
+                        start_time: if schedule_type() == "STATBREAK" {
+                            local_datetime_to_utc_iso(&start_time()).or_else(|| Some(start_time()))
+                        } else {
+                            None
+                        },
+                    };
+                    match api::create_break_group(&tournament_url, &req).await {
+                        Ok(_) => {
+                            saving.set(false);
+                            on_save.call(());
+                        }
+                        Err(e) => {
+                            error.set(Some(e));
+                            saving.set(false);
+                        }
+                    }
+                    return;
+                }
                 if (schedule_type() == "SAFE" || schedule_type() == "FAST")
                     && !skip_condition().trim().is_empty()
                 {
@@ -1710,16 +1839,18 @@ fn CreateMatchModal(
                                         }
                                     }
                                 }
-                                div { class: "col-md-6",
-                                    div { class: "mb-3",
-                                        label { class: "form-label", "Field" }
-                                        select {
-                                            class: "form-select",
-                                            value: "{field}",
-                                            onchange: move |e| on_field_change(e.value()),
-                                            option { value: "", "Select Field" }
-                                            for f in &data.fields {
-                                                option { value: "{f.name}", "{f.name}" }
+                                if !matches!(schedule_type().as_str(), "BREAK" | "STATBREAK") {
+                                    div { class: "col-md-6",
+                                        div { class: "mb-3",
+                                            label { class: "form-label", "Field" }
+                                            select {
+                                                class: "form-select",
+                                                value: "{field}",
+                                                onchange: move |e| on_field_change(e.value()),
+                                                option { value: "", "Select Field" }
+                                                for f in &data.fields {
+                                                    option { value: "{f.name}", "{f.name}" }
+                                                }
                                             }
                                         }
                                     }
@@ -1735,6 +1866,7 @@ fn CreateMatchModal(
                                             option { value: "SAFE", "Safe" }
                                             option { value: "FAST", "Fast" }
                                             option { value: "BREAK", "Break" }
+                                            option { value: "STATBREAK", "Static Break" }
                                             option { value: "JOIN", "Join" }
                                         }
                                     }
@@ -1749,12 +1881,12 @@ fn CreateMatchModal(
                                 }
                             }
 
-                            if schedule_type() == "STATIC" {
+                            if schedule_type() == "STATIC" || schedule_type() == "STATBREAK" {
                                 div { class: "mb-3",
                                     label { class: "form-label", "Start Time" }
                                     input { class: "form-control", "type": "datetime-local", value: "{start_time}", oninput: move |e| { let mut start_time = start_time; start_time.set(e.value()); } }
                                 }
-                            } else if schedule_type() == "SAFE" || schedule_type() == "FAST" || schedule_type() == "BREAK" || schedule_type() == "JOIN" {
+                            } else if schedule_type() == "SAFE" || schedule_type() == "FAST" || schedule_type() == "JOIN" {
                                 div { class: "mb-3",
                                     label { class: "form-label", "Previous Match" }
                                     select { class: "form-select", value: "{previous_match_id}", onchange: move |e| on_previous_match_change(e.value()),
@@ -1763,6 +1895,56 @@ fn CreateMatchModal(
                                             option { value: "{m.uuid}", "{m.name}" }
                                         }
                                     }
+                                }
+                            }
+
+                            if matches!(schedule_type().as_str(), "BREAK" | "STATBREAK") {
+                                div { class: "mb-3",
+                                    label { class: "form-label", "Fields" }
+                                    div { class: "form-text mb-1",
+                                        "One break is created per selected field. New breaks are appended at the end of each field's chain, and same-name breaks always start together."
+                                    }
+                                    div { class: "d-flex flex-wrap gap-3",
+                                        for f in &data.fields {
+                                            {
+                                                let fname = f.name.clone();
+                                                let checked = break_fields().contains(&fname);
+                                                rsx! {
+                                                    div { class: "form-check form-check-inline", key: "{f.id}",
+                                                        input {
+                                                            class: "form-check-input",
+                                                            "type": "checkbox",
+                                                            id: "create-break-field-{f.id}",
+                                                            checked: checked,
+                                                            onchange: move |e| {
+                                                                let mut v = break_fields();
+                                                                if e.value() == "true" {
+                                                                    if !v.contains(&fname) {
+                                                                        v.push(fname.clone());
+                                                                    }
+                                                                } else {
+                                                                    v.retain(|x| x != &fname);
+                                                                }
+                                                                break_fields.set(v);
+                                                            }
+                                                        }
+                                                        label { class: "form-check-label", "for": "create-break-field-{f.id}", "{f.name}" }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                TeamSelectionField {
+                                    label: "Teams required to attend".to_string(),
+                                    team_options: data.team_options.clone(),
+                                    tags: data.tags.clone(),
+                                    matches: data.matches.clone(),
+                                    value: refs(),
+                                    on_change: move |s| refs.set(s),
+                                    multiple: true,
+                                    placeholder: "(optional) teams that must attend this break".to_string(),
+                                    help_text: Some("These teams' matches on other fields will wait for the break.".to_string()),
                                 }
                             }
 
@@ -1882,6 +2064,244 @@ fn CreateMatchModal(
             }
             if skip_condition_help_open() {
                 SkipConditionHelpModal { on_close: move |_| skip_condition_help_open.set(false) }
+            }
+        }
+    }
+}
+
+/// Edit a break group: every same-name BREAK/STATBREAK row across fields at
+/// once. Members are derived from the already-loaded schedule data; edits go
+/// through the break-group endpoints (shared length / teams / start time,
+/// field add/remove, whole-group delete).
+#[component]
+fn BreakGroupModal(
+    tournament_url: String,
+    group_name: String,
+    data: ScheduleSetupResponse,
+    on_close: EventHandler<()>,
+    on_save: EventHandler<()>,
+) -> Element {
+    let members: Vec<MatchSetupData> = data
+        .matches
+        .iter()
+        .filter(|m| m.name == group_name && is_break_like_match(m))
+        .cloned()
+        .collect();
+
+    if members.is_empty() {
+        return rsx! { div { "Break group not found" } };
+    }
+    let first = members[0].clone();
+    let group_type = first
+        .schedule_type
+        .clone()
+        .unwrap_or_else(|| "BREAK".to_string());
+    let is_statbreak = group_type == "STATBREAK";
+    let type_label = if is_statbreak { "Static Break" } else { "Break" };
+
+    let mut length = use_signal(|| first.nominal_length.unwrap_or(30));
+    let mut teams = use_signal(|| {
+        first
+            .refs_initial
+            .clone()
+            .or(first.refs.clone())
+            .unwrap_or_default()
+    });
+    let mut start_time = use_signal(|| {
+        first
+            .nominal_start_time
+            .as_deref()
+            .and_then(utc_iso_to_local_datetime_input)
+            .unwrap_or_default()
+    });
+    let mut fields_sel = use_signal(|| {
+        members
+            .iter()
+            .filter_map(|m| m.field.clone())
+            .filter(|f| !f.is_empty())
+            .collect::<Vec<String>>()
+    });
+    let mut error = use_signal(|| None::<String>);
+    let mut saving = use_signal(|| false);
+
+    let url_save = tournament_url.clone();
+    let name_save = group_name.clone();
+    let do_save = move |_| {
+        if fields_sel().is_empty() {
+            error.set(Some(
+                "A break group needs at least one field. Use Delete to remove it entirely.".to_string(),
+            ));
+            return;
+        }
+        if is_statbreak && start_time().trim().is_empty() {
+            error.set(Some("Start time is required for a static break.".to_string()));
+            return;
+        }
+        let u = url_save.clone();
+        let n = name_save.clone();
+        let on_save = on_save.clone();
+        spawn(async move {
+            saving.set(true);
+            error.set(None);
+            let teams_vec: Vec<String> = teams()
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            let req = UpdateBreakGroupRequest {
+                length: Some(length()),
+                teams: Some(teams_vec),
+                start_time: if is_statbreak {
+                    local_datetime_to_utc_iso(&start_time()).or_else(|| Some(start_time()))
+                } else {
+                    None
+                },
+                fields: Some(fields_sel()),
+            };
+            match api::update_break_group(&u, &n, &req).await {
+                Ok(_) => {
+                    saving.set(false);
+                    on_save.call(());
+                }
+                Err(e) => {
+                    error.set(Some(e));
+                    saving.set(false);
+                }
+            }
+        });
+    };
+
+    let url_delete = tournament_url.clone();
+    let name_delete = group_name.clone();
+    let do_delete = move |_| {
+        let u = url_delete.clone();
+        let n = name_delete.clone();
+        let on_save = on_save.clone();
+        spawn(async move {
+            saving.set(true);
+            error.set(None);
+            match api::delete_break_group(&u, &n).await {
+                Ok(_) => {
+                    saving.set(false);
+                    on_save.call(());
+                }
+                Err(e) => {
+                    error.set(Some(e));
+                    saving.set(false);
+                }
+            }
+        });
+    };
+
+    let modal_keydown = move |ev: Event<KeyboardData>| {
+        if ev.key().to_string() == "Escape" {
+            ev.prevent_default();
+            on_close.call(());
+        }
+    };
+
+    rsx! {
+        div {
+            class: "modal d-block",
+            tabindex: -1,
+            style: "background: rgba(0,0,0,0.5)",
+            onkeydown: modal_keydown,
+            div { class: "modal-dialog modal-lg",
+                div { class: "modal-content",
+                    div { class: "modal-header",
+                        h5 { class: "modal-title", "Edit {type_label}: {group_name}" }
+                    }
+                    div { class: "modal-body",
+                        if let Some(err) = error() {
+                            div { class: "alert alert-danger", "{err}" }
+                        }
+                        div { class: "form-text mb-2",
+                            "Edits apply to every field's copy of this break. Same-name breaks always start together."
+                        }
+                        div { class: "row",
+                            div { class: "col-md-6",
+                                div { class: "mb-3",
+                                    label { class: "form-label", "Length (min)" }
+                                    input {
+                                        class: "form-control",
+                                        "type": "number",
+                                        min: "0",
+                                        value: "{length}",
+                                        oninput: move |e| length.set(e.value().parse().unwrap_or(30)),
+                                    }
+                                }
+                            }
+                            if is_statbreak {
+                                div { class: "col-md-6",
+                                    div { class: "mb-3",
+                                        label { class: "form-label", "Start Time" }
+                                        input {
+                                            class: "form-control",
+                                            "type": "datetime-local",
+                                            value: "{start_time}",
+                                            oninput: move |e| start_time.set(e.value()),
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        div { class: "mb-3",
+                            label { class: "form-label", "Fields" }
+                            div { class: "d-flex flex-wrap gap-3",
+                                for f in &data.fields {
+                                    {
+                                        let fname = f.name.clone();
+                                        let checked = fields_sel().contains(&fname);
+                                        rsx! {
+                                            div { class: "form-check form-check-inline", key: "{f.id}",
+                                                input {
+                                                    class: "form-check-input",
+                                                    "type": "checkbox",
+                                                    id: "break-group-field-{f.id}",
+                                                    checked: checked,
+                                                    onchange: move |e| {
+                                                        let mut v = fields_sel();
+                                                        if e.value() == "true" {
+                                                            if !v.contains(&fname) {
+                                                                v.push(fname.clone());
+                                                            }
+                                                        } else {
+                                                            v.retain(|x| x != &fname);
+                                                        }
+                                                        fields_sel.set(v);
+                                                    }
+                                                }
+                                                label { class: "form-check-label", "for": "break-group-field-{f.id}", "{f.name}" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            div { class: "form-text",
+                                "Checking a new field adds this break there; unchecking removes that field's copy."
+                            }
+                        }
+                        TeamSelectionField {
+                            label: "Teams required to attend".to_string(),
+                            team_options: data.team_options.clone(),
+                            tags: data.tags.clone(),
+                            matches: data.matches.clone(),
+                            value: teams(),
+                            on_change: move |s| teams.set(s),
+                            multiple: true,
+                            placeholder: "(optional) teams that must attend this break".to_string(),
+                            help_text: Some("These teams' matches on other fields will wait for the break.".to_string()),
+                        }
+                        div { class: "modal-footer",
+                            button { class: "btn btn-secondary", "type": "button", onclick: move |_| on_close.call(()), "Cancel (Esc)" }
+                            button { class: "btn btn-danger", "type": "button", disabled: "{saving}", onclick: do_delete, "Delete Group" }
+                            button { class: "btn btn-primary", "type": "button", disabled: "{saving}", onclick: do_save,
+                                if saving() { span { class: "spinner-border spinner-border-sm me-2" } }
+                                "Save"
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -3040,7 +3460,9 @@ fn TableView(
                                     td {
                                         // Editing is locked once a match has started — surface a
                                         // disabled pencil with a tooltip so the row layout doesn't shift.
-                                        if matches!(m.status.as_str(), "IN_PROGRESS" | "COMPLETED" | "SKIPPED") {
+                                        // Break-like rows stay editable (group modal); their status is
+                                        // solver-derived, never user-started.
+                                        if !is_break_like_match(m) && matches!(m.status.as_str(), "IN_PROGRESS" | "COMPLETED" | "SKIPPED") {
                                             button {
                                                 class: "btn btn-sm btn-link text-muted",
                                                 disabled: true,
@@ -3144,7 +3566,7 @@ fn TimelineEventCard(
     let navigator = use_navigator();
     let event_id_clone = event.id.clone();
     let (_, status_label) = status_color_and_label(&event.status);
-    let is_break = event.schedule_type.as_deref() == Some("BREAK");
+    let is_break = is_break_like_type(event.schedule_type.as_deref());
     let is_structural = is_structural_type(event.schedule_type.as_deref());
     let event_title = if is_break {
         event.name.clone()
@@ -3186,10 +3608,14 @@ fn TimelineEventCard(
             (d.clone(), p.clone(), k, l)
         })
         .collect();
-    let edit_locked = matches!(
-        event.status.as_str(),
-        "IN_PROGRESS" | "COMPLETED" | "SKIPPED"
-    );
+    // Break-like blocks stay clickable in edit mode even when COMPLETED: their
+    // status is solver-derived (never user-started) and the break-group modal
+    // handles what may actually change.
+    let edit_locked = !is_break
+        && matches!(
+            event.status.as_str(),
+            "IN_PROGRESS" | "COMPLETED" | "SKIPPED"
+        );
     let timeline_title = if edit_mode && edit_locked {
         format!("{event_title} — match has started, editing disabled")
     } else {
@@ -3353,8 +3779,16 @@ fn TimelineEventCard(
                     }
                 }
             } else {
-                div { class: "schedule-timeline-event-header",
+                div { class: "schedule-timeline-event-header d-flex align-items-center flex-wrap gap-1",
                     div { class: "schedule-timeline-event-name", "{event.name}" }
+                    if team_view {
+                        span { class: "schedule-role-badge schedule-role-badge--reffing", "Break" }
+                    }
+                }
+                if team_view {
+                    div { class: "schedule-timeline-event-teams text-muted small",
+                        "{field_label} · {start_time_label}"
+                    }
                 }
             }
             if event.ribbon {
@@ -3597,13 +4031,25 @@ fn ScheduleTimeline(
         .iter()
         .filter(|m| m.status != "SKIPPED")
         .filter(|m| m.schedule_type.as_deref() != Some("JOIN"))
-        .filter(|m| {
-            if !team_view {
-                return true;
+        .filter({
+            // Team view: play/ref matches for the focus team, plus breaks that
+            // require the team to attend (refs tokens). Same-name break rows
+            // are one logical break across fields — show it once.
+            let mut seen_break_names: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            let team_options = data.team_options.clone();
+            let focus_team_id = focus_team_id.clone();
+            move |m: &&MatchSetupData| {
+                if !team_view {
+                    return true;
+                }
+                if is_break_like_match(m) {
+                    return team_is_reffing(m, &focus_team_id, &team_options)
+                        && seen_break_names.insert(m.name.clone());
+                }
+                !is_structural_match(m)
+                    && match_involves_team(m, &focus_team_id, &team_options)
             }
-            // Team view: only play/ref matches for the focus team (no bare breaks).
-            !is_structural_match(m)
-                && match_involves_team(m, &focus_team_id, &data.team_options)
         })
         .filter_map(|m| {
             let (start_utc, end_utc) = display_interval_utc(m, show_as_happened)?;

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -211,15 +211,10 @@ fn is_structural_type(schedule_type: Option<&str>) -> bool {
     )
 }
 
-/// True for BREAK / STATBREAK — break-like blocks that may carry team
-/// requirements (refs = "these teams must attend") and are edited as a
+/// True for BREAK / STATBREAK — break-like blocks that are edited as a
 /// same-name group across fields.
 fn is_break_like_type(schedule_type: Option<&str>) -> bool {
     matches!(schedule_type, Some("BREAK") | Some("STATBREAK"))
-}
-
-fn is_break_like_match(m: &MatchSetupData) -> bool {
-    is_break_like_type(m.schedule_type.as_deref())
 }
 
 /// True if a ref/team token refers to the given focus team id.
@@ -1526,21 +1521,11 @@ fn CreateMatchModal(
             error.set(None);
             if matches!(schedule_type().as_str(), "BREAK" | "STATBREAK" | "JOIN") {
                 let is_join = schedule_type() == "JOIN";
-                let teams_vec: Vec<String> = if is_join {
-                    Vec::new() // Joins never carry team requirements.
-                } else {
-                    refs()
-                        .split(',')
-                        .map(|s| s.trim().to_string())
-                        .filter(|s| !s.is_empty())
-                        .collect()
-                };
                 let req = CreateBreakGroupRequest {
                     name: name(),
                     schedule_type: schedule_type(),
                     length: if is_join { 0 } else { length() },
                     fields: break_fields(),
-                    teams: teams_vec,
                     start_time: if schedule_type() == "STATBREAK" {
                         local_datetime_to_utc_iso(&start_time()).or_else(|| Some(start_time()))
                     } else {
@@ -1668,21 +1653,11 @@ fn CreateMatchModal(
                 error.set(None);
                 if matches!(schedule_type().as_str(), "BREAK" | "STATBREAK" | "JOIN") {
                     let is_join = schedule_type() == "JOIN";
-                    let teams_vec: Vec<String> = if is_join {
-                        Vec::new() // Joins never carry team requirements.
-                    } else {
-                        refs()
-                            .split(',')
-                            .map(|s| s.trim().to_string())
-                            .filter(|s| !s.is_empty())
-                            .collect()
-                    };
                     let req = CreateBreakGroupRequest {
                         name: name(),
                         schedule_type: schedule_type(),
                         length: if is_join { 0 } else { length() },
                         fields: break_fields(),
-                        teams: teams_vec,
                         start_time: if schedule_type() == "STATBREAK" {
                             local_datetime_to_utc_iso(&start_time()).or_else(|| Some(start_time()))
                         } else {
@@ -1966,16 +1941,6 @@ fn CreateMatchModal(
                                         }
                                     }
                                 }
-                                if schedule_type() != "JOIN" {
-                                    TeamChecklistField {
-                                        label: "Teams required to attend".to_string(),
-                                        id_prefix: "create-break".to_string(),
-                                        team_options: data.team_options.clone(),
-                                        value: refs(),
-                                        on_change: move |s| refs.set(s),
-                                        help_text: Some("These teams' matches on other fields will wait for the break.".to_string()),
-                                    }
-                                }
                             }
 
                             if schedule_type() == "STATIC" || schedule_type() == "SAFE" || schedule_type() == "FAST" {
@@ -2113,91 +2078,11 @@ fn SelectAllToggle(all_selected: bool, on_toggle: EventHandler<bool>) -> Element
     }
 }
 
-/// Checkbox list over the tournament's team options with a select-all toggle.
-/// The selection is stored as comma-separated ref tokens (team ids), exactly
-/// like the token input it replaces; non-team tokens already present in the
-/// value (tags, match refs) are preserved untouched.
-#[component]
-fn TeamChecklistField(
-    label: String,
-    id_prefix: String,
-    team_options: Vec<TeamOption>,
-    value: String,
-    on_change: EventHandler<String>,
-    #[props(optional)] help_text: Option<String>,
-) -> Element {
-    let tokens: Vec<String> = value
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect();
-    let all_ids: Vec<String> = team_options.iter().map(|o| o.id.clone()).collect();
-    let all_selected = !all_ids.is_empty() && all_ids.iter().all(|id| tokens.contains(id));
-    let toggle_tokens = tokens.clone();
-    let toggle_ids = all_ids.clone();
-
-    rsx! {
-        div { class: "mb-3",
-            label { class: "form-label", "{label}" }
-            SelectAllToggle {
-                all_selected: all_selected,
-                on_toggle: move |select: bool| {
-                    // Keep non-team tokens; replace the team-id part wholesale.
-                    let mut v: Vec<String> = toggle_tokens
-                        .iter()
-                        .filter(|t| !toggle_ids.contains(t))
-                        .cloned()
-                        .collect();
-                    if select {
-                        v.extend(toggle_ids.iter().cloned());
-                    }
-                    on_change.call(v.join(", "));
-                },
-            }
-            div { class: "d-flex flex-wrap gap-3",
-                for opt in &team_options {
-                    {
-                        let id = opt.id.clone();
-                        let display = opt.pseudonym.clone().unwrap_or_else(|| opt.id.clone());
-                        let checked = tokens.contains(&id);
-                        let toks = tokens.clone();
-                        rsx! {
-                            div { class: "form-check form-check-inline", key: "{opt.id}",
-                                input {
-                                    class: "form-check-input",
-                                    "type": "checkbox",
-                                    id: "{id_prefix}-team-{opt.id}",
-                                    checked: checked,
-                                    onchange: move |e| {
-                                        let mut v = toks.clone();
-                                        if e.value() == "true" {
-                                            if !v.contains(&id) {
-                                                v.push(id.clone());
-                                            }
-                                        } else {
-                                            v.retain(|x| x != &id);
-                                        }
-                                        on_change.call(v.join(", "));
-                                    }
-                                }
-                                label { class: "form-check-label", "for": "{id_prefix}-team-{opt.id}", "{display}" }
-                            }
-                        }
-                    }
-                }
-            }
-            if let Some(help) = &help_text {
-                div { class: "form-text", "{help}" }
-            }
-        }
-    }
-}
-
 /// Edit a structural group: every same-name BREAK/STATBREAK/JOIN row across
 /// fields at once. Members are derived from the already-loaded schedule data;
-/// edits go through the break-group endpoints (shared length / teams / start
-/// time, field add/remove, whole-group delete). JOIN groups expose only field
-/// membership: no length, teams, or start time.
+/// edits go through the break-group endpoints (shared length / start time,
+/// field add/remove, whole-group delete). JOIN groups expose only field
+/// membership: no length or start time.
 #[component]
 fn BreakGroupModal(
     tournament_url: String,
@@ -2233,13 +2118,6 @@ fn BreakGroupModal(
     let type_noun = if is_join { "join" } else { "break" };
 
     let mut length = use_signal(|| first.nominal_length.unwrap_or(30));
-    let mut teams = use_signal(|| {
-        first
-            .refs_initial
-            .clone()
-            .or(first.refs.clone())
-            .unwrap_or_default()
-    });
     let mut start_time = use_signal(|| {
         first
             .nominal_start_time
@@ -2276,15 +2154,9 @@ fn BreakGroupModal(
         spawn(async move {
             saving.set(true);
             error.set(None);
-            let teams_vec: Vec<String> = teams()
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-            // JOIN groups only edit field membership: no length/teams/start.
+            // JOIN groups only edit field membership: no length/start.
             let req = UpdateBreakGroupRequest {
                 length: if is_join { None } else { Some(length()) },
-                teams: if is_join { None } else { Some(teams_vec) },
                 start_time: if is_statbreak {
                     local_datetime_to_utc_iso(&start_time()).or_else(|| Some(start_time()))
                 } else {
@@ -2436,16 +2308,6 @@ fn BreakGroupModal(
                             }
                             div { class: "form-text",
                                 "Checking a new field adds this {type_noun} there; unchecking removes that field's copy."
-                            }
-                        }
-                        if !is_join {
-                            TeamChecklistField {
-                                label: "Teams required to attend".to_string(),
-                                id_prefix: "break-group".to_string(),
-                                team_options: data.team_options.clone(),
-                                value: teams(),
-                                on_change: move |s| teams.set(s),
-                                help_text: Some("These teams' matches on other fields will wait for the break.".to_string()),
                             }
                         }
                         div { class: "modal-footer",
@@ -3937,14 +3799,6 @@ fn TimelineEventCard(
             } else {
                 div { class: "schedule-timeline-event-header d-flex align-items-center flex-wrap gap-1",
                     div { class: "schedule-timeline-event-name", "{event.name}" }
-                    if team_view {
-                        span { class: "schedule-role-badge schedule-role-badge--reffing", "Break" }
-                    }
-                }
-                if team_view {
-                    div { class: "schedule-timeline-event-teams text-muted small",
-                        "{field_label} · {start_time_label}"
-                    }
                 }
             }
             if event.ribbon {
@@ -4188,20 +4042,13 @@ fn ScheduleTimeline(
         .filter(|m| m.status != "SKIPPED")
         .filter(|m| m.schedule_type.as_deref() != Some("JOIN"))
         .filter({
-            // Team view: play/ref matches for the focus team, plus breaks that
-            // require the team to attend (refs tokens). Same-name break rows
-            // are one logical break across fields — show it once.
-            let mut seen_break_names: std::collections::HashSet<String> =
-                std::collections::HashSet::new();
+            // Team view: only matches the focus team plays or refs. Structural
+            // rows (breaks/joins) have no participants, so they never appear.
             let team_options = data.team_options.clone();
             let focus_team_id = focus_team_id.clone();
             move |m: &&MatchSetupData| {
                 if !team_view {
                     return true;
-                }
-                if is_break_like_match(m) {
-                    return team_is_reffing(m, &focus_team_id, &team_options)
-                        && seen_break_names.insert(m.name.clone());
                 }
                 !is_structural_match(m)
                     && match_involves_team(m, &focus_team_id, &team_options)

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -1180,9 +1180,9 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                             on_edit_match: {
                                 let matches_for_edit = data.matches.clone();
                                 move |id: String| {
-                                    // Break-like blocks are edited as a same-name group.
+                                    // Structural blocks (breaks/joins) are edited as a same-name group.
                                     if let Some(m) = matches_for_edit.iter().find(|m| m.uuid == id) {
-                                        if is_break_like_match(m) {
+                                        if is_structural_match(m) {
                                             selected_break_group.set(m.name.clone());
                                             active_modal.set("break_group".to_string());
                                             return;
@@ -1208,7 +1208,7 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                                 let matches_for_edit = data.matches.clone();
                                 move |id: String| {
                                     if let Some(m) = matches_for_edit.iter().find(|m| m.uuid == id) {
-                                        if is_break_like_match(m) {
+                                        if is_structural_match(m) {
                                             selected_break_group.set(m.name.clone());
                                             active_modal.set("break_group".to_string());
                                             return;
@@ -1465,11 +1465,11 @@ fn CreateMatchModal(
     let validate_create_rc: Rc<RefCell<Box<dyn FnMut() -> bool>>> =
         Rc::new(RefCell::new(Box::new(move || {
             let st = schedule_type();
-            if st == "BREAK" || st == "STATBREAK" {
-                // Break groups: one row per selected field; no previous match
-                // needed (each row appends at its field's chain tail).
+            if st == "BREAK" || st == "STATBREAK" || st == "JOIN" {
+                // Structural groups: one row per selected field; no previous
+                // match needed (each row appends at its field's chain tail).
                 if break_fields().is_empty() {
-                    error.set(Some("Select at least one field for the break.".to_string()));
+                    error.set(Some("Select at least one field.".to_string()));
                     return false;
                 }
                 if st == "STATBREAK" && start_time().trim().is_empty() {
@@ -1480,11 +1480,11 @@ fn CreateMatchModal(
                 }
                 return true;
             }
-            if st == "JOIN" || st == "FAST" || st == "SAFE" {
+            if st == "FAST" || st == "SAFE" {
                 let prev_id = previous_match_id().trim().to_string();
                 if prev_id.is_empty() {
                     error.set(Some(
-                        "Previous match is required for Join, Fast, and Safe matches."
+                        "Previous match is required for Fast and Safe matches."
                             .to_string(),
                     ));
                     return false;
@@ -1524,16 +1524,21 @@ fn CreateMatchModal(
         spawn(async move {
             saving.set(true);
             error.set(None);
-            if schedule_type() == "BREAK" || schedule_type() == "STATBREAK" {
-                let teams_vec: Vec<String> = refs()
-                    .split(',')
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect();
+            if matches!(schedule_type().as_str(), "BREAK" | "STATBREAK" | "JOIN") {
+                let is_join = schedule_type() == "JOIN";
+                let teams_vec: Vec<String> = if is_join {
+                    Vec::new() // Joins never carry team requirements.
+                } else {
+                    refs()
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                };
                 let req = CreateBreakGroupRequest {
                     name: name(),
                     schedule_type: schedule_type(),
-                    length: length(),
+                    length: if is_join { 0 } else { length() },
                     fields: break_fields(),
                     teams: teams_vec,
                     start_time: if schedule_type() == "STATBREAK" {
@@ -1661,16 +1666,21 @@ fn CreateMatchModal(
             spawn(async move {
                 saving.set(true);
                 error.set(None);
-                if schedule_type() == "BREAK" || schedule_type() == "STATBREAK" {
-                    let teams_vec: Vec<String> = refs()
-                        .split(',')
-                        .map(|s| s.trim().to_string())
-                        .filter(|s| !s.is_empty())
-                        .collect();
+                if matches!(schedule_type().as_str(), "BREAK" | "STATBREAK" | "JOIN") {
+                    let is_join = schedule_type() == "JOIN";
+                    let teams_vec: Vec<String> = if is_join {
+                        Vec::new() // Joins never carry team requirements.
+                    } else {
+                        refs()
+                            .split(',')
+                            .map(|s| s.trim().to_string())
+                            .filter(|s| !s.is_empty())
+                            .collect()
+                    };
                     let req = CreateBreakGroupRequest {
                         name: name(),
                         schedule_type: schedule_type(),
-                        length: length(),
+                        length: if is_join { 0 } else { length() },
                         fields: break_fields(),
                         teams: teams_vec,
                         start_time: if schedule_type() == "STATBREAK" {
@@ -1839,7 +1849,7 @@ fn CreateMatchModal(
                                         }
                                     }
                                 }
-                                if !matches!(schedule_type().as_str(), "BREAK" | "STATBREAK") {
+                                if !matches!(schedule_type().as_str(), "BREAK" | "STATBREAK" | "JOIN") {
                                     div { class: "col-md-6",
                                         div { class: "mb-3",
                                             label { class: "form-label", "Field" }
@@ -1886,7 +1896,7 @@ fn CreateMatchModal(
                                     label { class: "form-label", "Start Time" }
                                     input { class: "form-control", "type": "datetime-local", value: "{start_time}", oninput: move |e| { let mut start_time = start_time; start_time.set(e.value()); } }
                                 }
-                            } else if schedule_type() == "SAFE" || schedule_type() == "FAST" || schedule_type() == "JOIN" {
+                            } else if schedule_type() == "SAFE" || schedule_type() == "FAST" {
                                 div { class: "mb-3",
                                     label { class: "form-label", "Previous Match" }
                                     select { class: "form-select", value: "{previous_match_id}", onchange: move |e| on_previous_match_change(e.value()),
@@ -1898,11 +1908,32 @@ fn CreateMatchModal(
                                 }
                             }
 
-                            if matches!(schedule_type().as_str(), "BREAK" | "STATBREAK") {
+                            if matches!(schedule_type().as_str(), "BREAK" | "STATBREAK" | "JOIN") {
                                 div { class: "mb-3",
                                     label { class: "form-label", "Fields" }
+                                    {
+                                        let all_field_names: Vec<String> = data.fields.iter().map(|f| f.name.clone()).collect();
+                                        let all_selected = !all_field_names.is_empty()
+                                            && all_field_names.iter().all(|f| break_fields().contains(f));
+                                        rsx! {
+                                            SelectAllToggle {
+                                                all_selected: all_selected,
+                                                on_toggle: move |select: bool| {
+                                                    if select {
+                                                        break_fields.set(all_field_names.clone());
+                                                    } else {
+                                                        break_fields.set(Vec::new());
+                                                    }
+                                                },
+                                            }
+                                        }
+                                    }
                                     div { class: "form-text mb-1",
-                                        "One break is created per selected field. New breaks are appended at the end of each field's chain, and same-name breaks always start together."
+                                        if schedule_type() == "JOIN" {
+                                            "One join is created per selected field, appended at the end of each field's chain. Each field's schedule continues only once all joined fields reach it."
+                                        } else {
+                                            "One break is created per selected field. New breaks are appended at the end of each field's chain, and same-name breaks always start together."
+                                        }
                                     }
                                     div { class: "d-flex flex-wrap gap-3",
                                         for f in &data.fields {
@@ -1935,16 +1966,15 @@ fn CreateMatchModal(
                                         }
                                     }
                                 }
-                                TeamSelectionField {
-                                    label: "Teams required to attend".to_string(),
-                                    team_options: data.team_options.clone(),
-                                    tags: data.tags.clone(),
-                                    matches: data.matches.clone(),
-                                    value: refs(),
-                                    on_change: move |s| refs.set(s),
-                                    multiple: true,
-                                    placeholder: "(optional) teams that must attend this break".to_string(),
-                                    help_text: Some("These teams' matches on other fields will wait for the break.".to_string()),
+                                if schedule_type() != "JOIN" {
+                                    TeamChecklistField {
+                                        label: "Teams required to attend".to_string(),
+                                        id_prefix: "create-break".to_string(),
+                                        team_options: data.team_options.clone(),
+                                        value: refs(),
+                                        on_change: move |s| refs.set(s),
+                                        help_text: Some("These teams' matches on other fields will wait for the break.".to_string()),
+                                    }
                                 }
                             }
 
@@ -2069,10 +2099,105 @@ fn CreateMatchModal(
     }
 }
 
-/// Edit a break group: every same-name BREAK/STATBREAK row across fields at
-/// once. Members are derived from the already-loaded schedule data; edits go
-/// through the break-group endpoints (shared length / teams / start time,
-/// field add/remove, whole-group delete).
+/// Small "Select all" / "Select none" toggle for a checkbox group, shown next
+/// to the group's label.
+#[component]
+fn SelectAllToggle(all_selected: bool, on_toggle: EventHandler<bool>) -> Element {
+    rsx! {
+        button {
+            class: "btn btn-sm btn-outline-secondary py-0 ms-2",
+            "type": "button",
+            onclick: move |_| on_toggle.call(!all_selected),
+            if all_selected { "Select none" } else { "Select all" }
+        }
+    }
+}
+
+/// Checkbox list over the tournament's team options with a select-all toggle.
+/// The selection is stored as comma-separated ref tokens (team ids), exactly
+/// like the token input it replaces; non-team tokens already present in the
+/// value (tags, match refs) are preserved untouched.
+#[component]
+fn TeamChecklistField(
+    label: String,
+    id_prefix: String,
+    team_options: Vec<TeamOption>,
+    value: String,
+    on_change: EventHandler<String>,
+    #[props(optional)] help_text: Option<String>,
+) -> Element {
+    let tokens: Vec<String> = value
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let all_ids: Vec<String> = team_options.iter().map(|o| o.id.clone()).collect();
+    let all_selected = !all_ids.is_empty() && all_ids.iter().all(|id| tokens.contains(id));
+    let toggle_tokens = tokens.clone();
+    let toggle_ids = all_ids.clone();
+
+    rsx! {
+        div { class: "mb-3",
+            label { class: "form-label", "{label}" }
+            SelectAllToggle {
+                all_selected: all_selected,
+                on_toggle: move |select: bool| {
+                    // Keep non-team tokens; replace the team-id part wholesale.
+                    let mut v: Vec<String> = toggle_tokens
+                        .iter()
+                        .filter(|t| !toggle_ids.contains(t))
+                        .cloned()
+                        .collect();
+                    if select {
+                        v.extend(toggle_ids.iter().cloned());
+                    }
+                    on_change.call(v.join(", "));
+                },
+            }
+            div { class: "d-flex flex-wrap gap-3",
+                for opt in &team_options {
+                    {
+                        let id = opt.id.clone();
+                        let display = opt.pseudonym.clone().unwrap_or_else(|| opt.id.clone());
+                        let checked = tokens.contains(&id);
+                        let toks = tokens.clone();
+                        rsx! {
+                            div { class: "form-check form-check-inline", key: "{opt.id}",
+                                input {
+                                    class: "form-check-input",
+                                    "type": "checkbox",
+                                    id: "{id_prefix}-team-{opt.id}",
+                                    checked: checked,
+                                    onchange: move |e| {
+                                        let mut v = toks.clone();
+                                        if e.value() == "true" {
+                                            if !v.contains(&id) {
+                                                v.push(id.clone());
+                                            }
+                                        } else {
+                                            v.retain(|x| x != &id);
+                                        }
+                                        on_change.call(v.join(", "));
+                                    }
+                                }
+                                label { class: "form-check-label", "for": "{id_prefix}-team-{opt.id}", "{display}" }
+                            }
+                        }
+                    }
+                }
+            }
+            if let Some(help) = &help_text {
+                div { class: "form-text", "{help}" }
+            }
+        }
+    }
+}
+
+/// Edit a structural group: every same-name BREAK/STATBREAK/JOIN row across
+/// fields at once. Members are derived from the already-loaded schedule data;
+/// edits go through the break-group endpoints (shared length / teams / start
+/// time, field add/remove, whole-group delete). JOIN groups expose only field
+/// membership: no length, teams, or start time.
 #[component]
 fn BreakGroupModal(
     tournament_url: String,
@@ -2084,7 +2209,7 @@ fn BreakGroupModal(
     let members: Vec<MatchSetupData> = data
         .matches
         .iter()
-        .filter(|m| m.name == group_name && is_break_like_match(m))
+        .filter(|m| m.name == group_name && is_structural_match(m))
         .cloned()
         .collect();
 
@@ -2097,7 +2222,15 @@ fn BreakGroupModal(
         .clone()
         .unwrap_or_else(|| "BREAK".to_string());
     let is_statbreak = group_type == "STATBREAK";
-    let type_label = if is_statbreak { "Static Break" } else { "Break" };
+    let is_join = group_type == "JOIN";
+    let type_label = if is_join {
+        "Join"
+    } else if is_statbreak {
+        "Static Break"
+    } else {
+        "Break"
+    };
+    let type_noun = if is_join { "join" } else { "break" };
 
     let mut length = use_signal(|| first.nominal_length.unwrap_or(30));
     let mut teams = use_signal(|| {
@@ -2128,9 +2261,9 @@ fn BreakGroupModal(
     let name_save = group_name.clone();
     let do_save = move |_| {
         if fields_sel().is_empty() {
-            error.set(Some(
-                "A break group needs at least one field. Use Delete to remove it entirely.".to_string(),
-            ));
+            error.set(Some(format!(
+                "A {type_noun} group needs at least one field. Use Delete to remove it entirely."
+            )));
             return;
         }
         if is_statbreak && start_time().trim().is_empty() {
@@ -2148,9 +2281,10 @@ fn BreakGroupModal(
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
                 .collect();
+            // JOIN groups only edit field membership: no length/teams/start.
             let req = UpdateBreakGroupRequest {
-                length: Some(length()),
-                teams: Some(teams_vec),
+                length: if is_join { None } else { Some(length()) },
+                teams: if is_join { None } else { Some(teams_vec) },
                 start_time: if is_statbreak {
                     local_datetime_to_utc_iso(&start_time()).or_else(|| Some(start_time()))
                 } else {
@@ -2216,30 +2350,36 @@ fn BreakGroupModal(
                             div { class: "alert alert-danger", "{err}" }
                         }
                         div { class: "form-text mb-2",
-                            "Edits apply to every field's copy of this break. Same-name breaks always start together."
-                        }
-                        div { class: "row",
-                            div { class: "col-md-6",
-                                div { class: "mb-3",
-                                    label { class: "form-label", "Length (min)" }
-                                    input {
-                                        class: "form-control",
-                                        "type": "number",
-                                        min: "0",
-                                        value: "{length}",
-                                        oninput: move |e| length.set(e.value().parse().unwrap_or(30)),
-                                    }
-                                }
+                            if is_join {
+                                "Edits apply to every field's copy of this join. Each field's schedule continues only once all joined fields reach it."
+                            } else {
+                                "Edits apply to every field's copy of this break. Same-name breaks always start together."
                             }
-                            if is_statbreak {
+                        }
+                        if !is_join {
+                            div { class: "row",
                                 div { class: "col-md-6",
                                     div { class: "mb-3",
-                                        label { class: "form-label", "Start Time" }
+                                        label { class: "form-label", "Length (min)" }
                                         input {
                                             class: "form-control",
-                                            "type": "datetime-local",
-                                            value: "{start_time}",
-                                            oninput: move |e| start_time.set(e.value()),
+                                            "type": "number",
+                                            min: "0",
+                                            value: "{length}",
+                                            oninput: move |e| length.set(e.value().parse().unwrap_or(30)),
+                                        }
+                                    }
+                                }
+                                if is_statbreak {
+                                    div { class: "col-md-6",
+                                        div { class: "mb-3",
+                                            label { class: "form-label", "Start Time" }
+                                            input {
+                                                class: "form-control",
+                                                "type": "datetime-local",
+                                                value: "{start_time}",
+                                                oninput: move |e| start_time.set(e.value()),
+                                            }
                                         }
                                     }
                                 }
@@ -2247,6 +2387,23 @@ fn BreakGroupModal(
                         }
                         div { class: "mb-3",
                             label { class: "form-label", "Fields" }
+                            {
+                                let all_field_names: Vec<String> = data.fields.iter().map(|f| f.name.clone()).collect();
+                                let all_selected = !all_field_names.is_empty()
+                                    && all_field_names.iter().all(|f| fields_sel().contains(f));
+                                rsx! {
+                                    SelectAllToggle {
+                                        all_selected: all_selected,
+                                        on_toggle: move |select: bool| {
+                                            if select {
+                                                fields_sel.set(all_field_names.clone());
+                                            } else {
+                                                fields_sel.set(Vec::new());
+                                            }
+                                        },
+                                    }
+                                }
+                            }
                             div { class: "d-flex flex-wrap gap-3",
                                 for f in &data.fields {
                                     {
@@ -2278,19 +2435,18 @@ fn BreakGroupModal(
                                 }
                             }
                             div { class: "form-text",
-                                "Checking a new field adds this break there; unchecking removes that field's copy."
+                                "Checking a new field adds this {type_noun} there; unchecking removes that field's copy."
                             }
                         }
-                        TeamSelectionField {
-                            label: "Teams required to attend".to_string(),
-                            team_options: data.team_options.clone(),
-                            tags: data.tags.clone(),
-                            matches: data.matches.clone(),
-                            value: teams(),
-                            on_change: move |s| teams.set(s),
-                            multiple: true,
-                            placeholder: "(optional) teams that must attend this break".to_string(),
-                            help_text: Some("These teams' matches on other fields will wait for the break.".to_string()),
+                        if !is_join {
+                            TeamChecklistField {
+                                label: "Teams required to attend".to_string(),
+                                id_prefix: "break-group".to_string(),
+                                team_options: data.team_options.clone(),
+                                value: teams(),
+                                on_change: move |s| teams.set(s),
+                                help_text: Some("These teams' matches on other fields will wait for the break.".to_string()),
+                            }
                         }
                         div { class: "modal-footer",
                             button { class: "btn btn-secondary", "type": "button", onclick: move |_| on_close.call(()), "Cancel (Esc)" }
@@ -3460,9 +3616,9 @@ fn TableView(
                                     td {
                                         // Editing is locked once a match has started — surface a
                                         // disabled pencil with a tooltip so the row layout doesn't shift.
-                                        // Break-like rows stay editable (group modal); their status is
-                                        // solver-derived, never user-started.
-                                        if !is_break_like_match(m) && matches!(m.status.as_str(), "IN_PROGRESS" | "COMPLETED" | "SKIPPED") {
+                                        // Structural rows (breaks/joins) stay editable (group modal);
+                                        // their status is solver-derived, never user-started.
+                                        if !is_structural_match(m) && matches!(m.status.as_str(), "IN_PROGRESS" | "COMPLETED" | "SKIPPED") {
                                             button {
                                                 class: "btn btn-sm btn-link text-muted",
                                                 disabled: true,

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -2118,6 +2118,8 @@ fn BreakGroupModal(
     let type_noun = if is_join { "join" } else { "break" };
 
     let mut length = use_signal(|| first.nominal_length.unwrap_or(30));
+    // Break↔Join whole-group conversion (STATBREAK groups don't convert).
+    let mut sel_type = use_signal(|| group_type.clone());
     let mut start_time = use_signal(|| {
         first
             .nominal_start_time
@@ -2137,6 +2139,7 @@ fn BreakGroupModal(
 
     let url_save = tournament_url.clone();
     let name_save = group_name.clone();
+    let group_type_save = group_type.clone();
     let do_save = move |_| {
         if fields_sel().is_empty() {
             error.set(Some(format!(
@@ -2151,12 +2154,16 @@ fn BreakGroupModal(
         let u = url_save.clone();
         let n = name_save.clone();
         let on_save = on_save.clone();
+        let group_type_now = group_type_save.clone();
         spawn(async move {
             saving.set(true);
             error.set(None);
+            let converting = sel_type() != group_type_now;
+            let now_join = sel_type() == "JOIN";
             // JOIN groups only edit field membership: no length/start.
             let req = UpdateBreakGroupRequest {
-                length: if is_join { None } else { Some(length()) },
+                schedule_type: if converting { Some(sel_type()) } else { None },
+                length: if now_join { None } else { Some(length()) },
                 start_time: if is_statbreak {
                     local_datetime_to_utc_iso(&start_time()).or_else(|| Some(start_time()))
                 } else {
@@ -2228,7 +2235,21 @@ fn BreakGroupModal(
                                 "Edits apply to every field's copy of this break. Same-name breaks always start together."
                             }
                         }
-                        if !is_join {
+                        // Whole-group Break↔Join conversion. Static breaks don't
+                        // convert (create one deliberately, with a start time).
+                        if !is_statbreak {
+                            div { class: "mb-3",
+                                label { class: "form-label", "Type" }
+                                select {
+                                    class: "form-select",
+                                    value: "{sel_type}",
+                                    onchange: move |e| sel_type.set(e.value()),
+                                    option { value: "BREAK", selected: sel_type() == "BREAK", "Break" }
+                                    option { value: "JOIN", selected: sel_type() == "JOIN", "Join" }
+                                }
+                            }
+                        }
+                        if sel_type() != "JOIN" {
                             div { class: "row",
                                 div { class: "col-md-6",
                                     div { class: "mb-3",

--- a/frontend/src/types.rs
+++ b/frontend/src/types.rs
@@ -1520,16 +1520,18 @@ pub struct CreateMatchResponse {
     pub uuid: String,
 }
 
-/// Create one BREAK/STATBREAK row per field, sharing name/length/teams.
+/// Create one BREAK/STATBREAK/JOIN row per field, sharing name/length/teams.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CreateBreakGroupRequest {
     pub name: String,
-    /// "BREAK" or "STATBREAK".
+    /// "BREAK", "STATBREAK", or "JOIN".
     pub schedule_type: String,
+    /// Minutes; must be 0 for JOIN.
     pub length: u32,
-    /// Field names to place the break on (one row per field).
+    /// Field names to place the break/join on (one row per field).
     pub fields: Vec<String>,
     /// Team requirement tokens (stored as ref slots on every row).
+    /// Must be empty for JOIN.
     pub teams: Vec<String>,
     /// Required for STATBREAK groups; ignored for BREAK.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/frontend/src/types.rs
+++ b/frontend/src/types.rs
@@ -1538,6 +1538,9 @@ pub struct CreateBreakGroupRequest {
 /// Edit every same-name break row at once. `None` fields are left unchanged.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UpdateBreakGroupRequest {
+    /// Whole-group conversion; only BREAK↔JOIN is accepted by the server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schedule_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub length: Option<u32>,
     /// STATBREAK groups only.

--- a/frontend/src/types.rs
+++ b/frontend/src/types.rs
@@ -1520,6 +1520,45 @@ pub struct CreateMatchResponse {
     pub uuid: String,
 }
 
+/// Create one BREAK/STATBREAK row per field, sharing name/length/teams.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreateBreakGroupRequest {
+    pub name: String,
+    /// "BREAK" or "STATBREAK".
+    pub schedule_type: String,
+    pub length: u32,
+    /// Field names to place the break on (one row per field).
+    pub fields: Vec<String>,
+    /// Team requirement tokens (stored as ref slots on every row).
+    pub teams: Vec<String>,
+    /// Required for STATBREAK groups; ignored for BREAK.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_time: Option<String>,
+}
+
+/// Edit every same-name break row at once. `None` fields are left unchanged.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UpdateBreakGroupRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub length: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub teams: Option<Vec<String>>,
+    /// STATBREAK groups only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_time: Option<String>,
+    /// New field membership: rows are created/deleted to match.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreateBreakGroupResponse {
+    pub success: bool,
+    pub name: String,
+    #[serde(default)]
+    pub uuids: Vec<String>,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ScheduleWarning {
     /// One of "unknown_team", "unknown_match_ref", "cycle", "double_booked".

--- a/frontend/src/types.rs
+++ b/frontend/src/types.rs
@@ -1520,7 +1520,7 @@ pub struct CreateMatchResponse {
     pub uuid: String,
 }
 
-/// Create one BREAK/STATBREAK/JOIN row per field, sharing name/length/teams.
+/// Create one BREAK/STATBREAK/JOIN row per field, sharing name/length.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CreateBreakGroupRequest {
     pub name: String,
@@ -1530,9 +1530,6 @@ pub struct CreateBreakGroupRequest {
     pub length: u32,
     /// Field names to place the break/join on (one row per field).
     pub fields: Vec<String>,
-    /// Team requirement tokens (stored as ref slots on every row).
-    /// Must be empty for JOIN.
-    pub teams: Vec<String>,
     /// Required for STATBREAK groups; ignored for BREAK.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start_time: Option<String>,
@@ -1543,8 +1540,6 @@ pub struct CreateBreakGroupRequest {
 pub struct UpdateBreakGroupRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub length: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub teams: Option<Vec<String>>,
     /// STATBREAK groups only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start_time: Option<String>,

--- a/migrations/versions/0012_statbreak.py
+++ b/migrations/versions/0012_statbreak.py
@@ -1,0 +1,72 @@
+"""Add STATBREAK to the schedule-type uniqueness groups.
+
+STATBREAK is a statically-scheduled break: user-supplied start time, never
+moved by the solver, auto-completed once its window elapses. Like BREAK and
+JOIN it is unique per (name, event, field) rather than per (name, event), so
+the two partial unique indexes on ``matches`` are recreated with STATBREAK
+included in the with-field predicate.
+
+No CHECK constraint rebuild is needed: SQLAlchemy's ``Enum`` did not create a
+constraint for ``matches.schedule_type`` on SQLite (the column is plain TEXT;
+``Enum(create_constraint=...)`` defaults to False), so only the indexes encode
+the type grouping.
+
+Revision ID: 0012_statbreak
+Revises: 0011_bracket_placements
+Create Date: 2026-08-12
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0012_statbreak"
+down_revision: Union[str, Sequence[str], None] = "0011_bracket_placements"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index("unique_with_field", table_name="matches")
+    op.drop_index("unique_without_field", table_name="matches")
+    op.create_index(
+        "unique_with_field",
+        "matches",
+        ["name", "event", "field"],
+        unique=True,
+        sqlite_where=sa.text("schedule_type IN ('BREAK', 'JOIN', 'STATBREAK')"),
+    )
+    op.create_index(
+        "unique_without_field",
+        "matches",
+        ["name", "event"],
+        unique=True,
+        sqlite_where=sa.text("schedule_type NOT IN ('BREAK', 'JOIN', 'STATBREAK')"),
+    )
+
+
+def downgrade() -> None:
+    # Demote any STATBREAK rows to plain BREAK first: the pre-0012 predicates
+    # would otherwise put STATBREAK rows into the without-field uniqueness
+    # group, where same-name per-field break rows collide.
+    op.execute("UPDATE matches SET schedule_type = 'BREAK' WHERE schedule_type = 'STATBREAK'")
+    op.drop_index("unique_with_field", table_name="matches")
+    op.drop_index("unique_without_field", table_name="matches")
+    op.create_index(
+        "unique_with_field",
+        "matches",
+        ["name", "event", "field"],
+        unique=True,
+        sqlite_where=sa.text("schedule_type IN ('BREAK', 'JOIN')"),
+    )
+    op.create_index(
+        "unique_without_field",
+        "matches",
+        ["name", "event"],
+        unique=True,
+        sqlite_where=sa.text("schedule_type NOT IN ('BREAK', 'JOIN')"),
+    )

--- a/tests/test_breaks.py
+++ b/tests/test_breaks.py
@@ -4,10 +4,11 @@ Tests for multi-field break groups and STATBREAK.
 Covers:
 - same-name BREAK rows across fields start together in both solver passes
   (their dependency edges are unioned in build_match_graph);
-- SAFE matches wait for breaks on other fields that require one of their teams
-  (cross-field resource-conflict edges now see referee team requirements);
-- STATBREAK: never moved by either pass, auto-completes once its window
-  elapses, chained matches respect its end, editable while COMPLETED;
+- breaks and joins only occupy fields: team requirements are rejected on every
+  structural type, and the single-match endpoints clear refs on them;
+- STATBREAK: never moved by either pass; its status is derived from the
+  current time when read (COMPLETED once its start passes) and never stored;
+  chained matches respect its end; always editable;
 - break-group JSON endpoints (create/update/delete).
 """
 
@@ -18,11 +19,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from app.domain.enums import MatchStatus, ScheduleType
-from app.services.dual_write import (
-    get_match_ref_initials,
-    get_match_ref_team_ids,
-    set_match_referees_from_csv,
-)
+from app.services.dual_write import get_match_ref_team_ids
 from app.utils.scheduling import recompute_scheduled_and_nominal_times
 from models import TO, Match, Player, db
 from tests.utils import login_as
@@ -158,103 +155,19 @@ class TestSameNameBreakSync:
             assert _close(brk.nominal_start_time, base + timedelta(minutes=75))
 
 
-class TestBreakTeamRequirements:
-    @pytest.mark.unit
-    def test_safe_match_waits_for_break_requiring_its_team(self, app, test_db, tournament, seeded_teams):
-        """A SAFE match with team X waits for a break on another field that
-        requires X to attend (cross-field resource-conflict edge, live pass)."""
-        url = tournament.url
-        with app.app_context():
-            base = datetime.now(timezone.utc).replace(tzinfo=None)
-
-            # Field 1: anchor runs 30 min late, then a break requiring team1.
-            a1 = _mk(url, "F1 Anchor", "Field 1", ScheduleType.STATIC, start=base, scheduled=base, length=60)
-            a1.status = MatchStatus.COMPLETED
-            a1.finalized_at = base + timedelta(minutes=90)
-            brk = _mk(url, "Team Break", "Field 1", ScheduleType.BREAK, length=30)
-            brk.previous_match = a1.uuid
-            a1.next_match = brk.uuid
-            set_match_referees_from_csv(brk, "team1", "team1")
-
-            # Field 2: anchor ends at base+80; team1's match is planned after the
-            # break's planned start (base+60), so the conflict edge applies.
-            a2 = _mk(
-                url,
-                "F2 Anchor",
-                "Field 2",
-                ScheduleType.STATIC,
-                start=base + timedelta(minutes=70),
-                scheduled=base + timedelta(minutes=70),
-                length=10,
-            )
-            a2.status = MatchStatus.COMPLETED
-            a2.finalized_at = base + timedelta(minutes=80)
-            m2 = _mk(url, "Team1 Game", "Field 2", ScheduleType.SAFE, length=60)
-            m2.previous_match = a2.uuid
-            a2.next_match = m2.uuid
-            m2.team1 = "team1"
-            m2.team1_initial = "team1"
-            m2.team2 = "team2"
-            m2.team2_initial = "team2"
-            db.session.commit()
-
-            recompute_scheduled_and_nominal_times(url)
-            db.session.refresh(m2)
-            db.session.refresh(brk)
-
-            # Break runs base+90 .. base+120 (anchor finished late). Without the
-            # conflict edge m2 would start at base+80; it must wait for the break.
-            assert _close(brk.nominal_start_time, base + timedelta(minutes=90))
-            assert _aware_utc(m2.nominal_start_time) >= _aware_utc(base + timedelta(minutes=120))
-
-    @pytest.mark.unit
-    def test_unrelated_team_not_delayed_by_break(self, app, test_db, tournament, seeded_teams):
-        """A SAFE match with no shared team ignores the other field's break."""
-        url = tournament.url
-        with app.app_context():
-            base = datetime.now(timezone.utc).replace(tzinfo=None)
-            a1 = _mk(url, "F1 Anchor", "Field 1", ScheduleType.STATIC, start=base, scheduled=base, length=60)
-            a1.status = MatchStatus.COMPLETED
-            a1.finalized_at = base + timedelta(minutes=90)
-            brk = _mk(url, "Team Break", "Field 1", ScheduleType.BREAK, length=30)
-            brk.previous_match = a1.uuid
-            a1.next_match = brk.uuid
-            set_match_referees_from_csv(brk, "team1", "team1")
-
-            a2 = _mk(
-                url,
-                "F2 Anchor",
-                "Field 2",
-                ScheduleType.STATIC,
-                start=base + timedelta(minutes=70),
-                scheduled=base + timedelta(minutes=70),
-                length=10,
-            )
-            a2.status = MatchStatus.COMPLETED
-            a2.finalized_at = base + timedelta(minutes=80)
-            m2 = _mk(url, "Other Game", "Field 2", ScheduleType.SAFE, length=60)
-            m2.previous_match = a2.uuid
-            a2.next_match = m2.uuid
-            m2.team1 = "team2"
-            m2.team1_initial = "team2"
-            m2.team2 = "team3"
-            m2.team2_initial = "team3"
-            db.session.commit()
-
-            recompute_scheduled_and_nominal_times(url)
-            db.session.refresh(m2)
-            assert _close(m2.nominal_start_time, base + timedelta(minutes=80))
-
-
 class TestStatBreak:
     @pytest.mark.unit
-    def test_statbreak_never_moves_and_autocompletes(self, app, test_db, tournament):
-        """A STATBREAK keeps its user-set times through both passes; once its
-        window has elapsed it auto-completes; a chained match respects its end."""
+    def test_statbreak_never_moves_and_completes_at_start(self, app, test_db, tournament):
+        """A STATBREAK keeps its user-set times through both passes; its
+        effective status is COMPLETED as soon as its START passes (not
+        start + length) while the stored status stays NOT_STARTED; a chained
+        match still respects its END (start + length)."""
         url = tournament.url
         with app.app_context():
             base = datetime.now(timezone.utc).replace(tzinfo=None)
-            past_start = base - timedelta(minutes=60)
+            # Start 10 min ago with a 30-min length: the window has NOT elapsed
+            # yet, but the start has passed — that's enough for completion.
+            past_start = base - timedelta(minutes=10)
 
             sb = _mk(
                 url,
@@ -276,8 +189,11 @@ class TestStatBreak:
 
             assert _close(sb.nominal_start_time, past_start)
             assert _close(sb.scheduled_start_time, past_start)
-            assert sb.status == MatchStatus.COMPLETED  # window elapsed
-            # Chained match starts no earlier than the STATBREAK's end.
+            # Effective status is time-derived; the solver never stores it.
+            assert sb.effective_status == MatchStatus.COMPLETED
+            assert sb.status == MatchStatus.NOT_STARTED
+            # Chained match starts no earlier than the STATBREAK's end
+            # (start + length — the dependency end time is unchanged).
             assert _close(after.nominal_start_time, past_start + timedelta(minutes=30))
             assert _close(after.scheduled_start_time, past_start + timedelta(minutes=30))
 
@@ -301,6 +217,7 @@ class TestStatBreak:
             recompute_scheduled_and_nominal_times(url)
             db.session.refresh(sb)
             assert sb.status == MatchStatus.NOT_STARTED
+            assert sb.effective_status == MatchStatus.NOT_STARTED
             assert _close(sb.nominal_start_time, future_start)
             assert _close(sb.scheduled_start_time, future_start)
 
@@ -314,7 +231,7 @@ class TestBreakGroupEndpoints:
             login_as(client, p)
         return t
 
-    def test_create_break_group_rows_per_field_with_refs(self, app, client, tournament, to_player, seeded_teams):
+    def test_create_break_group_rows_per_field(self, app, client, tournament, to_player):
         t = self._login(app, client, tournament, to_player)
         resp = client.post(
             f"/_api/tournaments/{t.url}/break-groups",
@@ -323,7 +240,6 @@ class TestBreakGroupEndpoints:
                 "schedule_type": "BREAK",
                 "length": 30,
                 "fields": ["Field 1", "Field 2"],
-                "teams": ["team1", "team2"],
             },
         )
         assert resp.status_code == 200, resp.get_json()
@@ -335,7 +251,7 @@ class TestBreakGroupEndpoints:
             assert m.schedule_type == ScheduleType.BREAK
             assert m.nominal_length == 30
             assert m.team1 is None and m.team2 is None
-            assert get_match_ref_team_ids(m) == ["team1", "team2"]
+            assert get_match_ref_team_ids(m) == []
 
         # Creating the same group again collides per (name, event, field).
         resp2 = client.post(
@@ -343,6 +259,44 @@ class TestBreakGroupEndpoints:
             json={"name": "Lunch", "schedule_type": "BREAK", "length": 30, "fields": ["Field 1"]},
         )
         assert resp2.status_code == 400
+
+    @pytest.mark.parametrize("schedule_type", ["BREAK", "STATBREAK", "JOIN"])
+    def test_structural_group_rejects_teams(self, app, client, tournament, to_player, seeded_teams, schedule_type):
+        """Breaks and joins only occupy fields: a non-empty `teams` list is
+        rejected on create for every structural type."""
+        t = self._login(app, client, tournament, to_player)
+        start = (datetime.now(timezone.utc) + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={
+                "name": "Blocked",
+                "schedule_type": schedule_type,
+                "length": 30,
+                "fields": ["Field 1"],
+                "teams": ["team1"],
+                "start_time": start,
+            },
+        )
+        assert resp.status_code == 400
+        assert "team requirements" in resp.get_json()["error"]
+        assert Match.query.filter_by(event=t.url, name="Blocked").count() == 0
+
+    def test_break_group_put_rejects_teams(self, app, client, tournament, to_player, seeded_teams):
+        t = self._login(app, client, tournament, to_player)
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Lunch", "schedule_type": "BREAK", "length": 30, "fields": ["Field 1"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Lunch",
+            json={"teams": ["team1"]},
+        )
+        assert resp.status_code == 400
+        assert "team requirements" in resp.get_json()["error"]
+        row = Match.query.filter_by(event=t.url, name="Lunch").one()
+        assert get_match_ref_team_ids(row) == []
 
     def test_create_break_group_appends_at_chain_tail(self, app, client, tournament, to_player):
         t = self._login(app, client, tournament, to_player)
@@ -362,7 +316,7 @@ class TestBreakGroupEndpoints:
         # Appended after the tail, so it inherits the chain's planned end.
         assert brk.scheduled_start_time is not None
 
-    def test_update_break_group_length_teams_and_fields(self, app, client, tournament, to_player, seeded_teams):
+    def test_update_break_group_length_and_fields(self, app, client, tournament, to_player):
         t = self._login(app, client, tournament, to_player)
         resp = client.post(
             f"/_api/tournaments/{t.url}/break-groups",
@@ -371,23 +325,21 @@ class TestBreakGroupEndpoints:
                 "schedule_type": "BREAK",
                 "length": 30,
                 "fields": ["Field 1"],
-                "teams": ["team1"],
             },
         )
         assert resp.status_code == 200, resp.get_json()
 
-        # Add Field 2, change length and teams in one PUT.
+        # Add Field 2 and change length in one PUT.
         resp = client.put(
             f"/_api/tournaments/{t.url}/break-groups/Lunch",
-            json={"length": 45, "teams": ["team2"], "fields": ["Field 1", "Field 2"]},
+            json={"length": 45, "fields": ["Field 1", "Field 2"]},
         )
         assert resp.status_code == 200, resp.get_json()
         rows = Match.query.filter_by(event=t.url, name="Lunch").all()
         assert {m.field for m in rows} == {"Field 1", "Field 2"}
         for m in rows:
             assert m.nominal_length == 45
-            assert get_match_ref_team_ids(m) == ["team2"]
-            assert get_match_ref_initials(m) == ["team2"]
+            assert get_match_ref_team_ids(m) == []
 
         # Remove Field 1 again.
         resp = client.put(
@@ -446,9 +398,9 @@ class TestBreakGroupEndpoints:
             assert _close(m.nominal_start_time, expected)
             assert _close(m.scheduled_start_time, expected)
 
-    def test_completed_statbreak_still_editable(self, app, client, tournament, to_player):
-        """STATBREAKs auto-complete on a timer, so COMPLETED must not lock edits
-        (group PUT and single-match PUT both work)."""
+    def test_past_start_statbreak_still_editable(self, app, client, tournament, to_player):
+        """STATBREAK status is time-derived at read time and never stored, so a
+        past-start STATBREAK stays editable (group PUT and single-match PUT)."""
         t = self._login(app, client, tournament, to_player)
         start = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
         resp = client.post(
@@ -463,7 +415,8 @@ class TestBreakGroupEndpoints:
         )
         assert resp.status_code == 200, resp.get_json()
         row = Match.query.filter_by(event=t.url, name="Dinner").one()
-        assert row.status == MatchStatus.COMPLETED  # window already elapsed
+        assert row.effective_status == MatchStatus.COMPLETED  # start passed
+        assert row.status == MatchStatus.NOT_STARTED  # never stored
 
         new_start = (datetime.now(timezone.utc) + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
         resp = client.put(
@@ -475,9 +428,9 @@ class TestBreakGroupEndpoints:
         expected = datetime.fromisoformat(new_start.replace("Z", "+00:00")).replace(tzinfo=None)
         assert row.nominal_length == 60
         assert _close(row.nominal_start_time, expected)
-        assert row.status == MatchStatus.NOT_STARTED  # window no longer elapsed
+        assert row.effective_status == MatchStatus.NOT_STARTED  # start now in the future
 
-        # Single-match update endpoint is also exempt from the started-lock.
+        # Single-match update endpoint also works.
         resp = client.put(
             f"/_api/tournaments/{t.url}/matches/{row.uuid}",
             json={"length": 90},
@@ -486,8 +439,40 @@ class TestBreakGroupEndpoints:
         row = Match.query.filter_by(event=t.url, name="Dinner").one()
         assert row.nominal_length == 90
 
-    def test_update_match_api_accepts_refs_on_break(self, app, client, tournament, to_player, seeded_teams):
-        """The single-match PUT stores refs on BREAK rows instead of clearing them."""
+    def test_statbreak_serialized_status_is_time_derived(self, app, client, tournament, to_player):
+        """The schedule payload reports the time-derived STATBREAK status, not
+        the stored one: COMPLETED once the start passes, NOT_STARTED before."""
+        t = self._login(app, client, tournament, to_player)
+        past = (datetime.now(timezone.utc) - timedelta(minutes=10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        future = (datetime.now(timezone.utc) + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        for name, start in (("Past Break", past), ("Future Break", future)):
+            resp = client.post(
+                f"/_api/tournaments/{t.url}/break-groups",
+                json={
+                    "name": name,
+                    "schedule_type": "STATBREAK",
+                    "length": 30,
+                    "fields": ["Field 1"],
+                    "start_time": start,
+                },
+            )
+            assert resp.status_code == 200, resp.get_json()
+
+        # Stored status is untouched either way.
+        for name in ("Past Break", "Future Break"):
+            assert Match.query.filter_by(event=t.url, name=name).one().status == MatchStatus.NOT_STARTED
+
+        resp = client.get(f"/_api/tournaments/{t.url}/schedule-setup")
+        assert resp.status_code == 200, resp.get_json()
+        by_name = {m["name"]: m for m in resp.get_json()["matches"]}
+        # Past-start STATBREAK reads COMPLETED (even though its window — start
+        # + length — has not elapsed yet); future one reads NOT_STARTED.
+        assert by_name["Past Break"]["status"] == "COMPLETED"
+        assert by_name["Future Break"]["status"] == "NOT_STARTED"
+
+    def test_update_match_api_clears_refs_on_break(self, app, client, tournament, to_player, seeded_teams):
+        """The single-match PUT clears refs on BREAK rows (like JOIN): breaks
+        only occupy fields and never carry team requirements."""
         t = self._login(app, client, tournament, to_player)
         with app.app_context():
             base = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -511,7 +496,7 @@ class TestBreakGroupEndpoints:
         )
         assert resp.status_code == 200, resp.get_json()
         brk = Match.query.filter_by(uuid=brk_uuid).one()
-        assert get_match_ref_team_ids(brk) == ["team1"]
+        assert get_match_ref_team_ids(brk) == []
         assert brk.team1 is None and brk.team2 is None
 
     def test_break_to_statbreak_conversion(self, app, client, tournament, to_player):
@@ -596,20 +581,11 @@ class TestJoinGroupEndpoints:
         )
         assert resp2.status_code == 400
 
-    def test_join_group_rejects_teams(self, app, client, tournament, to_player, seeded_teams):
+    def test_join_group_put_rejects_teams(self, app, client, tournament, to_player, seeded_teams):
+        """Group PUT rejects team requirements for JOIN groups too (create-time
+        rejection for every structural type is covered in
+        TestBreakGroupEndpoints.test_structural_group_rejects_teams)."""
         t = self._login(app, client, tournament, to_player)
-        resp = client.post(
-            f"/_api/tournaments/{t.url}/break-groups",
-            json={
-                "name": "Sync",
-                "schedule_type": "JOIN",
-                "fields": ["Field 1"],
-                "teams": ["team1"],
-            },
-        )
-        assert resp.status_code == 400
-        assert "team requirements" in resp.get_json()["error"]
-
         resp = client.post(
             f"/_api/tournaments/{t.url}/break-groups",
             json={"name": "Sync", "schedule_type": "JOIN", "fields": ["Field 1"]},

--- a/tests/test_breaks.py
+++ b/tests/test_breaks.py
@@ -1,0 +1,539 @@
+"""
+Tests for multi-field break groups and STATBREAK.
+
+Covers:
+- same-name BREAK rows across fields start together in both solver passes
+  (their dependency edges are unioned in build_match_graph);
+- SAFE matches wait for breaks on other fields that require one of their teams
+  (cross-field resource-conflict edges now see referee team requirements);
+- STATBREAK: never moved by either pass, auto-completes once its window
+  elapses, chained matches respect its end, editable while COMPLETED;
+- break-group JSON endpoints (create/update/delete).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.domain.enums import MatchStatus, ScheduleType
+from app.services.dual_write import (
+    get_match_ref_initials,
+    get_match_ref_team_ids,
+    set_match_referees_from_csv,
+)
+from app.utils.scheduling import recompute_scheduled_and_nominal_times
+from models import TO, Match, Player, db
+from tests.utils import login_as
+
+
+def _aware_utc(d: datetime) -> datetime:
+    if d is None:
+        return None
+    if d.tzinfo is None:
+        return d.replace(tzinfo=timezone.utc)
+    return d.astimezone(timezone.utc)
+
+
+def _close(a: datetime, b: datetime, seconds: float = 2.0) -> bool:
+    return abs((_aware_utc(a) - _aware_utc(b)).total_seconds()) < seconds
+
+
+@pytest.fixture
+def to_player(test_db, tournament):
+    """A player who is a Tournament Organiser for the test tournament."""
+    p = Player(id="test_to", name="Test TO", pw_hash="dummy_hash")
+    p.set_password("testpass")
+    db.session.add(p)
+    db.session.flush()
+    db.session.add(TO(user_id=p.id, user_type="player", event=tournament.url))
+    db.session.commit()
+    db.session.refresh(p)
+    return p
+
+
+def _mk(
+    tournament_url,
+    name,
+    field,
+    schedule_type,
+    *,
+    start=None,
+    scheduled=None,
+    length=60,
+    status=MatchStatus.NOT_STARTED,
+):
+    m = Match(
+        name=name,
+        event=tournament_url,
+        field=field,
+        nominal_start_time=start,
+        scheduled_start_time=scheduled,
+        schedule_type=schedule_type,
+        nominal_length=length,
+        status=status,
+    )
+    db.session.add(m)
+    db.session.flush()
+    return m
+
+
+class TestSameNameBreakSync:
+    @pytest.mark.unit
+    def test_same_name_breaks_start_together_both_passes(self, app, test_db, tournament):
+        """Same-name breaks on two fields share the latest predecessor end in both
+        timelines; each field's downstream match waits for shared start + its own
+        break's length."""
+        url = tournament.url
+        with app.app_context():
+            base = datetime.now(timezone.utc).replace(tzinfo=None)
+
+            # Field 1 anchor finishes on plan (base + 60); Field 2 anchor is
+            # planned later (ends base + 90) and actually finishes at base + 120.
+            a1 = _mk(url, "A1", "Field 1", ScheduleType.STATIC, start=base, scheduled=base, length=60)
+            a1.status = MatchStatus.COMPLETED
+            a1.finalized_at = base + timedelta(minutes=60)
+            b1 = _mk(
+                url,
+                "B1",
+                "Field 2",
+                ScheduleType.STATIC,
+                start=base + timedelta(minutes=30),
+                scheduled=base + timedelta(minutes=30),
+                length=60,
+            )
+            b1.status = MatchStatus.COMPLETED
+            b1.finalized_at = base + timedelta(minutes=120)
+
+            lunch1 = _mk(url, "Lunch", "Field 1", ScheduleType.BREAK, length=30)
+            lunch1.previous_match = a1.uuid
+            a1.next_match = lunch1.uuid
+            lunch2 = _mk(url, "Lunch", "Field 2", ScheduleType.BREAK, length=45)
+            lunch2.previous_match = b1.uuid
+            b1.next_match = lunch2.uuid
+
+            after1 = _mk(url, "After1", "Field 1", ScheduleType.SAFE, length=60)
+            after1.previous_match = lunch1.uuid
+            lunch1.next_match = after1.uuid
+            after2 = _mk(url, "After2", "Field 2", ScheduleType.SAFE, length=60)
+            after2.previous_match = lunch2.uuid
+            lunch2.next_match = after2.uuid
+            db.session.commit()
+
+            recompute_scheduled_and_nominal_times(url)
+
+            for m in (lunch1, lunch2, after1, after2):
+                db.session.refresh(m)
+
+            # Planned pass: shared start = latest planned predecessor end (base+90).
+            assert _close(lunch1.scheduled_start_time, base + timedelta(minutes=90))
+            assert _close(lunch2.scheduled_start_time, base + timedelta(minutes=90))
+            assert _close(after1.scheduled_start_time, base + timedelta(minutes=120))
+            assert _close(after2.scheduled_start_time, base + timedelta(minutes=135))
+
+            # Live pass: shared start = latest actual predecessor end (base+120).
+            assert _close(lunch1.nominal_start_time, base + timedelta(minutes=120))
+            assert _close(lunch2.nominal_start_time, base + timedelta(minutes=120))
+            assert _close(after1.nominal_start_time, base + timedelta(minutes=150))
+            assert _close(after2.nominal_start_time, base + timedelta(minutes=165))
+
+    @pytest.mark.unit
+    def test_single_field_break_unchanged(self, app, test_db, tournament):
+        """A lone break keeps today's behaviour: start = its own predecessor's end."""
+        url = tournament.url
+        with app.app_context():
+            base = datetime.now(timezone.utc).replace(tzinfo=None)
+            a1 = _mk(url, "A1", "Field 1", ScheduleType.STATIC, start=base, scheduled=base, length=60)
+            a1.status = MatchStatus.COMPLETED
+            a1.finalized_at = base + timedelta(minutes=75)
+            brk = _mk(url, "Solo Break", "Field 1", ScheduleType.BREAK, length=30)
+            brk.previous_match = a1.uuid
+            a1.next_match = brk.uuid
+            db.session.commit()
+
+            recompute_scheduled_and_nominal_times(url)
+            db.session.refresh(brk)
+            assert _close(brk.scheduled_start_time, base + timedelta(minutes=60))
+            assert _close(brk.nominal_start_time, base + timedelta(minutes=75))
+
+
+class TestBreakTeamRequirements:
+    @pytest.mark.unit
+    def test_safe_match_waits_for_break_requiring_its_team(self, app, test_db, tournament, seeded_teams):
+        """A SAFE match with team X waits for a break on another field that
+        requires X to attend (cross-field resource-conflict edge, live pass)."""
+        url = tournament.url
+        with app.app_context():
+            base = datetime.now(timezone.utc).replace(tzinfo=None)
+
+            # Field 1: anchor runs 30 min late, then a break requiring team1.
+            a1 = _mk(url, "F1 Anchor", "Field 1", ScheduleType.STATIC, start=base, scheduled=base, length=60)
+            a1.status = MatchStatus.COMPLETED
+            a1.finalized_at = base + timedelta(minutes=90)
+            brk = _mk(url, "Team Break", "Field 1", ScheduleType.BREAK, length=30)
+            brk.previous_match = a1.uuid
+            a1.next_match = brk.uuid
+            set_match_referees_from_csv(brk, "team1", "team1")
+
+            # Field 2: anchor ends at base+80; team1's match is planned after the
+            # break's planned start (base+60), so the conflict edge applies.
+            a2 = _mk(
+                url,
+                "F2 Anchor",
+                "Field 2",
+                ScheduleType.STATIC,
+                start=base + timedelta(minutes=70),
+                scheduled=base + timedelta(minutes=70),
+                length=10,
+            )
+            a2.status = MatchStatus.COMPLETED
+            a2.finalized_at = base + timedelta(minutes=80)
+            m2 = _mk(url, "Team1 Game", "Field 2", ScheduleType.SAFE, length=60)
+            m2.previous_match = a2.uuid
+            a2.next_match = m2.uuid
+            m2.team1 = "team1"
+            m2.team1_initial = "team1"
+            m2.team2 = "team2"
+            m2.team2_initial = "team2"
+            db.session.commit()
+
+            recompute_scheduled_and_nominal_times(url)
+            db.session.refresh(m2)
+            db.session.refresh(brk)
+
+            # Break runs base+90 .. base+120 (anchor finished late). Without the
+            # conflict edge m2 would start at base+80; it must wait for the break.
+            assert _close(brk.nominal_start_time, base + timedelta(minutes=90))
+            assert _aware_utc(m2.nominal_start_time) >= _aware_utc(base + timedelta(minutes=120))
+
+    @pytest.mark.unit
+    def test_unrelated_team_not_delayed_by_break(self, app, test_db, tournament, seeded_teams):
+        """A SAFE match with no shared team ignores the other field's break."""
+        url = tournament.url
+        with app.app_context():
+            base = datetime.now(timezone.utc).replace(tzinfo=None)
+            a1 = _mk(url, "F1 Anchor", "Field 1", ScheduleType.STATIC, start=base, scheduled=base, length=60)
+            a1.status = MatchStatus.COMPLETED
+            a1.finalized_at = base + timedelta(minutes=90)
+            brk = _mk(url, "Team Break", "Field 1", ScheduleType.BREAK, length=30)
+            brk.previous_match = a1.uuid
+            a1.next_match = brk.uuid
+            set_match_referees_from_csv(brk, "team1", "team1")
+
+            a2 = _mk(
+                url,
+                "F2 Anchor",
+                "Field 2",
+                ScheduleType.STATIC,
+                start=base + timedelta(minutes=70),
+                scheduled=base + timedelta(minutes=70),
+                length=10,
+            )
+            a2.status = MatchStatus.COMPLETED
+            a2.finalized_at = base + timedelta(minutes=80)
+            m2 = _mk(url, "Other Game", "Field 2", ScheduleType.SAFE, length=60)
+            m2.previous_match = a2.uuid
+            a2.next_match = m2.uuid
+            m2.team1 = "team2"
+            m2.team1_initial = "team2"
+            m2.team2 = "team3"
+            m2.team2_initial = "team3"
+            db.session.commit()
+
+            recompute_scheduled_and_nominal_times(url)
+            db.session.refresh(m2)
+            assert _close(m2.nominal_start_time, base + timedelta(minutes=80))
+
+
+class TestStatBreak:
+    @pytest.mark.unit
+    def test_statbreak_never_moves_and_autocompletes(self, app, test_db, tournament):
+        """A STATBREAK keeps its user-set times through both passes; once its
+        window has elapsed it auto-completes; a chained match respects its end."""
+        url = tournament.url
+        with app.app_context():
+            base = datetime.now(timezone.utc).replace(tzinfo=None)
+            past_start = base - timedelta(minutes=60)
+
+            sb = _mk(
+                url,
+                "Dinner",
+                "Field 1",
+                ScheduleType.STATBREAK,
+                start=past_start,
+                scheduled=past_start,
+                length=30,
+            )
+            after = _mk(url, "After Dinner", "Field 1", ScheduleType.SAFE, length=60)
+            after.previous_match = sb.uuid
+            sb.next_match = after.uuid
+            db.session.commit()
+
+            recompute_scheduled_and_nominal_times(url)
+            db.session.refresh(sb)
+            db.session.refresh(after)
+
+            assert _close(sb.nominal_start_time, past_start)
+            assert _close(sb.scheduled_start_time, past_start)
+            assert sb.status == MatchStatus.COMPLETED  # window elapsed
+            # Chained match starts no earlier than the STATBREAK's end.
+            assert _close(after.nominal_start_time, past_start + timedelta(minutes=30))
+            assert _close(after.scheduled_start_time, past_start + timedelta(minutes=30))
+
+    @pytest.mark.unit
+    def test_future_statbreak_not_completed(self, app, test_db, tournament):
+        url = tournament.url
+        with app.app_context():
+            base = datetime.now(timezone.utc).replace(tzinfo=None)
+            future_start = base + timedelta(hours=2)
+            sb = _mk(
+                url,
+                "Dinner",
+                "Field 1",
+                ScheduleType.STATBREAK,
+                start=future_start,
+                scheduled=future_start,
+                length=30,
+            )
+            db.session.commit()
+
+            recompute_scheduled_and_nominal_times(url)
+            db.session.refresh(sb)
+            assert sb.status == MatchStatus.NOT_STARTED
+            assert _close(sb.nominal_start_time, future_start)
+            assert _close(sb.scheduled_start_time, future_start)
+
+
+@pytest.mark.integration
+class TestBreakGroupEndpoints:
+    def _login(self, app, client, tournament, to_player):
+        with app.app_context():
+            t = db.session.merge(tournament)
+            p = db.session.merge(to_player)
+            login_as(client, p)
+        return t
+
+    def test_create_break_group_rows_per_field_with_refs(self, app, client, tournament, to_player, seeded_teams):
+        t = self._login(app, client, tournament, to_player)
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={
+                "name": "Lunch",
+                "schedule_type": "BREAK",
+                "length": 30,
+                "fields": ["Field 1", "Field 2"],
+                "teams": ["team1", "team2"],
+            },
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.get_json()["success"] is True
+
+        rows = Match.query.filter_by(event=t.url, name="Lunch").all()
+        assert {m.field for m in rows} == {"Field 1", "Field 2"}
+        for m in rows:
+            assert m.schedule_type == ScheduleType.BREAK
+            assert m.nominal_length == 30
+            assert m.team1 is None and m.team2 is None
+            assert get_match_ref_team_ids(m) == ["team1", "team2"]
+
+        # Creating the same group again collides per (name, event, field).
+        resp2 = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Lunch", "schedule_type": "BREAK", "length": 30, "fields": ["Field 1"]},
+        )
+        assert resp2.status_code == 400
+
+    def test_create_break_group_appends_at_chain_tail(self, app, client, tournament, to_player):
+        t = self._login(app, client, tournament, to_player)
+        with app.app_context():
+            base = datetime.now(timezone.utc).replace(tzinfo=None)
+            a1 = _mk(t.url, "G1", "Field 1", ScheduleType.STATIC, start=base, scheduled=base, length=60)
+            db.session.commit()
+            a1_uuid = a1.uuid
+
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Pause", "schedule_type": "BREAK", "length": 15, "fields": ["Field 1"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        brk = Match.query.filter_by(event=t.url, name="Pause").one()
+        assert brk.previous_match == a1_uuid
+        # Appended after the tail, so it inherits the chain's planned end.
+        assert brk.scheduled_start_time is not None
+
+    def test_update_break_group_length_teams_and_fields(self, app, client, tournament, to_player, seeded_teams):
+        t = self._login(app, client, tournament, to_player)
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={
+                "name": "Lunch",
+                "schedule_type": "BREAK",
+                "length": 30,
+                "fields": ["Field 1"],
+                "teams": ["team1"],
+            },
+        )
+        assert resp.status_code == 200, resp.get_json()
+
+        # Add Field 2, change length and teams in one PUT.
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Lunch",
+            json={"length": 45, "teams": ["team2"], "fields": ["Field 1", "Field 2"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        rows = Match.query.filter_by(event=t.url, name="Lunch").all()
+        assert {m.field for m in rows} == {"Field 1", "Field 2"}
+        for m in rows:
+            assert m.nominal_length == 45
+            assert get_match_ref_team_ids(m) == ["team2"]
+            assert get_match_ref_initials(m) == ["team2"]
+
+        # Remove Field 1 again.
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Lunch",
+            json={"fields": ["Field 2"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        rows = Match.query.filter_by(event=t.url, name="Lunch").all()
+        assert [m.field for m in rows] == ["Field 2"]
+
+        # Removing every field is rejected (use DELETE instead).
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Lunch",
+            json={"fields": []},
+        )
+        assert resp.status_code == 400
+
+    def test_delete_break_group(self, app, client, tournament, to_player):
+        t = self._login(app, client, tournament, to_player)
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Lunch", "schedule_type": "BREAK", "length": 30, "fields": ["Field 1", "Field 2"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        resp = client.delete(f"/_api/tournaments/{t.url}/break-groups/Lunch")
+        assert resp.status_code == 200
+        assert Match.query.filter_by(event=t.url, name="Lunch").count() == 0
+        resp = client.delete(f"/_api/tournaments/{t.url}/break-groups/Lunch")
+        assert resp.status_code == 404
+
+    def test_statbreak_group_requires_start_time_and_sets_both_timelines(self, app, client, tournament, to_player):
+        t = self._login(app, client, tournament, to_player)
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Dinner", "schedule_type": "STATBREAK", "length": 45, "fields": ["Field 1"]},
+        )
+        assert resp.status_code == 400  # start_time required
+
+        start = (datetime.now(timezone.utc) + timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={
+                "name": "Dinner",
+                "schedule_type": "STATBREAK",
+                "length": 45,
+                "fields": ["Field 1", "Field 2"],
+                "start_time": start,
+            },
+        )
+        assert resp.status_code == 200, resp.get_json()
+        rows = Match.query.filter_by(event=t.url, name="Dinner").all()
+        assert len(rows) == 2
+        expected = datetime.fromisoformat(start.replace("Z", "+00:00")).replace(tzinfo=None)
+        for m in rows:
+            assert m.schedule_type == ScheduleType.STATBREAK
+            assert _close(m.nominal_start_time, expected)
+            assert _close(m.scheduled_start_time, expected)
+
+    def test_completed_statbreak_still_editable(self, app, client, tournament, to_player):
+        """STATBREAKs auto-complete on a timer, so COMPLETED must not lock edits
+        (group PUT and single-match PUT both work)."""
+        t = self._login(app, client, tournament, to_player)
+        start = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={
+                "name": "Dinner",
+                "schedule_type": "STATBREAK",
+                "length": 30,
+                "fields": ["Field 1"],
+                "start_time": start,
+            },
+        )
+        assert resp.status_code == 200, resp.get_json()
+        row = Match.query.filter_by(event=t.url, name="Dinner").one()
+        assert row.status == MatchStatus.COMPLETED  # window already elapsed
+
+        new_start = (datetime.now(timezone.utc) + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Dinner",
+            json={"length": 60, "start_time": new_start},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        row = Match.query.filter_by(event=t.url, name="Dinner").one()
+        expected = datetime.fromisoformat(new_start.replace("Z", "+00:00")).replace(tzinfo=None)
+        assert row.nominal_length == 60
+        assert _close(row.nominal_start_time, expected)
+        assert row.status == MatchStatus.NOT_STARTED  # window no longer elapsed
+
+        # Single-match update endpoint is also exempt from the started-lock.
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/matches/{row.uuid}",
+            json={"length": 90},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        row = Match.query.filter_by(event=t.url, name="Dinner").one()
+        assert row.nominal_length == 90
+
+    def test_update_match_api_accepts_refs_on_break(self, app, client, tournament, to_player, seeded_teams):
+        """The single-match PUT stores refs on BREAK rows instead of clearing them."""
+        t = self._login(app, client, tournament, to_player)
+        with app.app_context():
+            base = datetime.now(timezone.utc).replace(tzinfo=None)
+            a1 = _mk(t.url, "G1", "Field 1", ScheduleType.STATIC, start=base, scheduled=base, length=60)
+            brk = _mk(t.url, "Break A", "Field 1", ScheduleType.BREAK, length=20)
+            brk.previous_match = a1.uuid
+            a1.next_match = brk.uuid
+            db.session.commit()
+            brk_uuid = brk.uuid
+            a1_uuid = a1.uuid
+
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/matches/{brk_uuid}",
+            json={
+                "schedule_type": "BREAK",
+                "length": 20,
+                "previous_match_id": a1_uuid,
+                "field": "Field 1",
+                "refs": ["team1"],
+            },
+        )
+        assert resp.status_code == 200, resp.get_json()
+        brk = Match.query.filter_by(uuid=brk_uuid).one()
+        assert get_match_ref_team_ids(brk) == ["team1"]
+        assert brk.team1 is None and brk.team2 is None
+
+    def test_break_to_statbreak_conversion(self, app, client, tournament, to_player):
+        """BREAK→STATBREAK conversion via the single-match PUT is allowed."""
+        t = self._login(app, client, tournament, to_player)
+        with app.app_context():
+            base = datetime.now(timezone.utc).replace(tzinfo=None)
+            a1 = _mk(t.url, "G1", "Field 1", ScheduleType.STATIC, start=base, scheduled=base, length=60)
+            brk = _mk(t.url, "Break A", "Field 1", ScheduleType.BREAK, length=20)
+            brk.previous_match = a1.uuid
+            a1.next_match = brk.uuid
+            db.session.commit()
+            brk_uuid = brk.uuid
+
+        start = (datetime.now(timezone.utc) + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/matches/{brk_uuid}",
+            json={"schedule_type": "STATBREAK", "length": 20, "start_time": start},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        brk = Match.query.filter_by(uuid=brk_uuid).one()
+        assert brk.schedule_type == ScheduleType.STATBREAK
+        expected = datetime.fromisoformat(start.replace("Z", "+00:00")).replace(tzinfo=None)
+        assert _close(brk.nominal_start_time, expected)
+        assert _close(brk.scheduled_start_time, expected)

--- a/tests/test_breaks.py
+++ b/tests/test_breaks.py
@@ -537,3 +537,213 @@ class TestBreakGroupEndpoints:
         expected = datetime.fromisoformat(start.replace("Z", "+00:00")).replace(tzinfo=None)
         assert _close(brk.nominal_start_time, expected)
         assert _close(brk.scheduled_start_time, expected)
+
+
+@pytest.mark.integration
+class TestJoinGroupEndpoints:
+    """JOIN groups through the structural-group ("break-groups") endpoints."""
+
+    def _login(self, app, client, tournament, to_player):
+        with app.app_context():
+            t = db.session.merge(tournament)
+            p = db.session.merge(to_player)
+            login_as(client, p)
+        return t
+
+    def _mk_anchors(self, app, t, fields=("Field 1", "Field 2")):
+        """One STATIC anchor per field; returns {field: uuid}."""
+        with app.app_context():
+            base = datetime.now(timezone.utc).replace(tzinfo=None)
+            uuids = {}
+            for i, f in enumerate(fields):
+                a = _mk(
+                    t.url,
+                    f"Anchor {f}",
+                    f,
+                    ScheduleType.STATIC,
+                    start=base + timedelta(minutes=10 * i),
+                    scheduled=base + timedelta(minutes=10 * i),
+                    length=60,
+                )
+                uuids[f] = a.uuid
+            db.session.commit()
+        return uuids
+
+    def test_create_join_group_rows_per_field_zero_length(self, app, client, tournament, to_player):
+        t = self._login(app, client, tournament, to_player)
+        anchors = self._mk_anchors(app, t)
+
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Sync", "schedule_type": "JOIN", "fields": ["Field 1", "Field 2"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+
+        rows = Match.query.filter_by(event=t.url, name="Sync").all()
+        assert {m.field for m in rows} == {"Field 1", "Field 2"}
+        for m in rows:
+            assert m.schedule_type == ScheduleType.JOIN
+            assert m.nominal_length == 0
+            assert m.team1 is None and m.team2 is None
+            assert get_match_ref_team_ids(m) == []
+            # Chain-tail default: appended after each field's anchor.
+            assert m.previous_match == anchors[m.field]
+
+        # Same-name-per-field uniqueness within the structural group.
+        resp2 = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Sync", "schedule_type": "JOIN", "fields": ["Field 1"]},
+        )
+        assert resp2.status_code == 400
+
+    def test_join_group_rejects_teams(self, app, client, tournament, to_player, seeded_teams):
+        t = self._login(app, client, tournament, to_player)
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={
+                "name": "Sync",
+                "schedule_type": "JOIN",
+                "fields": ["Field 1"],
+                "teams": ["team1"],
+            },
+        )
+        assert resp.status_code == 400
+        assert "team requirements" in resp.get_json()["error"]
+
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Sync", "schedule_type": "JOIN", "fields": ["Field 1"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Sync",
+            json={"teams": ["team1"]},
+        )
+        assert resp.status_code == 400
+        assert "team requirements" in resp.get_json()["error"]
+
+    def test_update_join_group_fields_with_chain_splicing(self, app, client, tournament, to_player):
+        t = self._login(app, client, tournament, to_player)
+        anchors = self._mk_anchors(app, t)
+
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Sync", "schedule_type": "JOIN", "fields": ["Field 1"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        join1 = Match.query.filter_by(event=t.url, name="Sync", field="Field 1").one()
+        assert Match.query.filter_by(uuid=anchors["Field 1"]).one().next_match == join1.uuid
+
+        # Add Field 2: new zero-length row appended at that field's chain tail.
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Sync",
+            json={"fields": ["Field 1", "Field 2"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        rows = Match.query.filter_by(event=t.url, name="Sync").all()
+        assert {m.field for m in rows} == {"Field 1", "Field 2"}
+        join2 = next(m for m in rows if m.field == "Field 2")
+        assert join2.nominal_length == 0
+        assert join2.previous_match == anchors["Field 2"]
+
+        # A group PUT length is ignored for JOIN: rows stay zero-length.
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Sync",
+            json={"length": 30},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert {m.nominal_length for m in Match.query.filter_by(event=t.url, name="Sync").all()} == {0}
+
+        # Remove Field 1: the row is deleted and its chain is spliced.
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Sync",
+            json={"fields": ["Field 2"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        rows = Match.query.filter_by(event=t.url, name="Sync").all()
+        assert [m.field for m in rows] == ["Field 2"]
+        assert Match.query.filter_by(uuid=anchors["Field 1"]).one().next_match is None
+
+    def test_delete_join_group(self, app, client, tournament, to_player):
+        t = self._login(app, client, tournament, to_player)
+        anchors = self._mk_anchors(app, t)
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Sync", "schedule_type": "JOIN", "fields": ["Field 1", "Field 2"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+
+        resp = client.delete(f"/_api/tournaments/{t.url}/break-groups/Sync")
+        assert resp.status_code == 200
+        assert Match.query.filter_by(event=t.url, name="Sync").count() == 0
+        # Chains are spliced: anchors are tails again.
+        for uuid in anchors.values():
+            assert Match.query.filter_by(uuid=uuid).one().next_match is None
+        resp = client.delete(f"/_api/tournaments/{t.url}/break-groups/Sync")
+        assert resp.status_code == 404
+
+    def test_join_break_conversion_rejected(self, app, client, tournament, to_player):
+        t = self._login(app, client, tournament, to_player)
+        self._mk_anchors(app, t)
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Sync", "schedule_type": "JOIN", "fields": ["Field 1"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Lunch", "schedule_type": "BREAK", "length": 30, "fields": ["Field 1"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        join_uuid = Match.query.filter_by(event=t.url, name="Sync").one().uuid
+        break_uuid = Match.query.filter_by(event=t.url, name="Lunch").one().uuid
+
+        # Single-match PUT: JOIN converts to/from nothing.
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/matches/{join_uuid}",
+            json={"schedule_type": "BREAK", "length": 30},
+        )
+        assert resp.status_code == 400
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/matches/{break_uuid}",
+            json={"schedule_type": "JOIN"},
+        )
+        assert resp.status_code == 400
+
+        # Group PUT: any type change involving JOIN is rejected.
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Sync",
+            json={"schedule_type": "BREAK"},
+        )
+        assert resp.status_code == 400
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Lunch",
+            json={"schedule_type": "JOIN"},
+        )
+        assert resp.status_code == 400
+
+        assert Match.query.filter_by(uuid=join_uuid).one().schedule_type == ScheduleType.JOIN
+        assert Match.query.filter_by(uuid=break_uuid).one().schedule_type == ScheduleType.BREAK
+
+    def test_same_name_join_rows_merge_in_solver(self, app, client, tournament, to_player):
+        """Rows created via the group endpoint still collapse into one JOIN node
+        (component_uuids fan-out) whose dependencies span both fields."""
+        from app.utils.MatchGraph import build_match_graph
+
+        t = self._login(app, client, tournament, to_player)
+        anchors = self._mk_anchors(app, t)
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Sync", "schedule_type": "JOIN", "fields": ["Field 1", "Field 2"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+
+        with app.app_context():
+            rows = Match.query.filter_by(event=t.url, name="Sync").all()
+            graph = build_match_graph(t.url)
+            node = graph.nodes_by_key.get(("Sync", ""))
+            assert node is not None
+            assert node.component_uuids == {m.uuid for m in rows}
+            dep_names = {dep.node.name for dep in node.dependencies}
+            assert {"Anchor Field 1", "Anchor Field 2"} <= dep_names

--- a/tests/test_breaks.py
+++ b/tests/test_breaks.py
@@ -398,11 +398,13 @@ class TestBreakGroupEndpoints:
             assert _close(m.nominal_start_time, expected)
             assert _close(m.scheduled_start_time, expected)
 
-    def test_past_start_statbreak_still_editable(self, app, client, tournament, to_player):
-        """STATBREAK status is time-derived at read time and never stored, so a
-        past-start STATBREAK stays editable (group PUT and single-match PUT)."""
+    def test_statbreak_locked_once_start_passes(self, app, client, tournament, to_player):
+        """A STATBREAK whose start has passed is history: both the group PUT and
+        the single-match PUT refuse to edit it. Before the start it's editable."""
         t = self._login(app, client, tournament, to_player)
-        start = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # Future STATBREAK: fully editable.
+        future = (datetime.now(timezone.utc) + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
         resp = client.post(
             f"/_api/tournaments/{t.url}/break-groups",
             json={
@@ -410,34 +412,47 @@ class TestBreakGroupEndpoints:
                 "schedule_type": "STATBREAK",
                 "length": 30,
                 "fields": ["Field 1"],
-                "start_time": start,
+                "start_time": future,
             },
         )
         assert resp.status_code == 200, resp.get_json()
         row = Match.query.filter_by(event=t.url, name="Dinner").one()
+        assert row.effective_status == MatchStatus.NOT_STARTED
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Dinner",
+            json={"length": 60},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert Match.query.filter_by(event=t.url, name="Dinner").one().nominal_length == 60
+
+        # Past-start STATBREAK: locked on both endpoints.
+        past = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={
+                "name": "Lunch",
+                "schedule_type": "STATBREAK",
+                "length": 30,
+                "fields": ["Field 1"],
+                "start_time": past,
+            },
+        )
+        assert resp.status_code == 200, resp.get_json()
+        row = Match.query.filter_by(event=t.url, name="Lunch").one()
         assert row.effective_status == MatchStatus.COMPLETED  # start passed
         assert row.status == MatchStatus.NOT_STARTED  # never stored
 
-        new_start = (datetime.now(timezone.utc) + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
         resp = client.put(
-            f"/_api/tournaments/{t.url}/break-groups/Dinner",
-            json={"length": 60, "start_time": new_start},
+            f"/_api/tournaments/{t.url}/break-groups/Lunch",
+            json={"length": 90},
         )
-        assert resp.status_code == 200, resp.get_json()
-        row = Match.query.filter_by(event=t.url, name="Dinner").one()
-        expected = datetime.fromisoformat(new_start.replace("Z", "+00:00")).replace(tzinfo=None)
-        assert row.nominal_length == 60
-        assert _close(row.nominal_start_time, expected)
-        assert row.effective_status == MatchStatus.NOT_STARTED  # start now in the future
-
-        # Single-match update endpoint also works.
+        assert resp.status_code == 409
         resp = client.put(
             f"/_api/tournaments/{t.url}/matches/{row.uuid}",
             json={"length": 90},
         )
-        assert resp.status_code == 200, resp.get_json()
-        row = Match.query.filter_by(event=t.url, name="Dinner").one()
-        assert row.nominal_length == 90
+        assert resp.status_code == 409
+        assert Match.query.filter_by(event=t.url, name="Lunch").one().nominal_length == 30
 
     def test_statbreak_serialized_status_is_time_derived(self, app, client, tournament, to_player):
         """The schedule payload reports the time-derived STATBREAK status, not
@@ -499,8 +514,8 @@ class TestBreakGroupEndpoints:
         assert get_match_ref_team_ids(brk) == []
         assert brk.team1 is None and brk.team2 is None
 
-    def test_break_to_statbreak_conversion(self, app, client, tournament, to_player):
-        """BREAK→STATBREAK conversion via the single-match PUT is allowed."""
+    def test_statbreak_conversion_rules(self, app, client, tournament, to_player):
+        """Nothing converts TO a STATBREAK; STATBREAK→BREAK is still allowed."""
         t = self._login(app, client, tournament, to_player)
         with app.app_context():
             base = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -510,18 +525,43 @@ class TestBreakGroupEndpoints:
             a1.next_match = brk.uuid
             db.session.commit()
             brk_uuid = brk.uuid
+            a1_uuid = a1.uuid
 
+        # BREAK → STATBREAK: rejected (create a static break deliberately instead).
         start = (datetime.now(timezone.utc) + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
         resp = client.put(
             f"/_api/tournaments/{t.url}/matches/{brk_uuid}",
             json={"schedule_type": "STATBREAK", "length": 20, "start_time": start},
         )
+        assert resp.status_code == 400
+        assert Match.query.filter_by(uuid=brk_uuid).one().schedule_type == ScheduleType.BREAK
+
+        # Group PUT rejects it too.
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Break A",
+            json={"schedule_type": "STATBREAK"},
+        )
+        assert resp.status_code == 400
+
+        # STATBREAK → BREAK (future-start, so not locked): still allowed.
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={
+                "name": "Pause",
+                "schedule_type": "STATBREAK",
+                "length": 15,
+                "fields": ["Field 1"],
+                "start_time": start,
+            },
+        )
         assert resp.status_code == 200, resp.get_json()
-        brk = Match.query.filter_by(uuid=brk_uuid).one()
-        assert brk.schedule_type == ScheduleType.STATBREAK
-        expected = datetime.fromisoformat(start.replace("Z", "+00:00")).replace(tzinfo=None)
-        assert _close(brk.nominal_start_time, expected)
-        assert _close(brk.scheduled_start_time, expected)
+        sb_uuid = Match.query.filter_by(event=t.url, name="Pause").one().uuid
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/matches/{sb_uuid}",
+            json={"schedule_type": "BREAK", "length": 15, "previous_match_id": a1_uuid},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert Match.query.filter_by(uuid=sb_uuid).one().schedule_type == ScheduleType.BREAK
 
 
 @pytest.mark.integration
@@ -659,48 +699,75 @@ class TestJoinGroupEndpoints:
         resp = client.delete(f"/_api/tournaments/{t.url}/break-groups/Sync")
         assert resp.status_code == 404
 
-    def test_join_break_conversion_rejected(self, app, client, tournament, to_player):
+    def test_join_break_group_conversion(self, app, client, tournament, to_player):
+        """Whole-group BREAK↔JOIN conversion via the group PUT."""
         t = self._login(app, client, tournament, to_player)
         self._mk_anchors(app, t)
         resp = client.post(
             f"/_api/tournaments/{t.url}/break-groups",
-            json={"name": "Sync", "schedule_type": "JOIN", "fields": ["Field 1"]},
+            json={"name": "Sync", "schedule_type": "JOIN", "fields": ["Field 1", "Field 2"]},
         )
         assert resp.status_code == 200, resp.get_json()
-        resp = client.post(
-            f"/_api/tournaments/{t.url}/break-groups",
-            json={"name": "Lunch", "schedule_type": "BREAK", "length": 30, "fields": ["Field 1"]},
-        )
-        assert resp.status_code == 200, resp.get_json()
-        join_uuid = Match.query.filter_by(event=t.url, name="Sync").one().uuid
-        break_uuid = Match.query.filter_by(event=t.url, name="Lunch").one().uuid
 
-        # Single-match PUT: JOIN converts to/from nothing.
-        resp = client.put(
-            f"/_api/tournaments/{t.url}/matches/{join_uuid}",
-            json={"schedule_type": "BREAK", "length": 30},
-        )
-        assert resp.status_code == 400
-        resp = client.put(
-            f"/_api/tournaments/{t.url}/matches/{break_uuid}",
-            json={"schedule_type": "JOIN"},
-        )
-        assert resp.status_code == 400
-
-        # Group PUT: any type change involving JOIN is rejected.
+        # JOIN → BREAK requires a length (JOIN rows carry 0).
         resp = client.put(
             f"/_api/tournaments/{t.url}/break-groups/Sync",
             json={"schedule_type": "BREAK"},
         )
         assert resp.status_code == 400
         resp = client.put(
-            f"/_api/tournaments/{t.url}/break-groups/Lunch",
+            f"/_api/tournaments/{t.url}/break-groups/Sync",
+            json={"schedule_type": "BREAK", "length": 45},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        rows = Match.query.filter_by(event=t.url, name="Sync").all()
+        assert len(rows) == 2
+        assert all(m.schedule_type == ScheduleType.BREAK for m in rows)
+        assert all(m.nominal_length == 45 for m in rows)
+
+        # And back: BREAK → JOIN forces length 0 on every row.
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/break-groups/Sync",
             json={"schedule_type": "JOIN"},
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 200, resp.get_json()
+        rows = Match.query.filter_by(event=t.url, name="Sync").all()
+        assert all(m.schedule_type == ScheduleType.JOIN for m in rows)
+        assert all(m.nominal_length == 0 for m in rows)
 
-        assert Match.query.filter_by(uuid=join_uuid).one().schedule_type == ScheduleType.JOIN
-        assert Match.query.filter_by(uuid=break_uuid).one().schedule_type == ScheduleType.BREAK
+    def test_single_row_conversion_rules(self, app, client, tournament, to_player):
+        """Single-match PUT: BREAK↔JOIN allowed for lone rows only; a row of a
+        multi-field group must convert through the group endpoint."""
+        t = self._login(app, client, tournament, to_player)
+        anchors = self._mk_anchors(app, t)
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Lunch", "schedule_type": "BREAK", "length": 30, "fields": ["Field 1"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        lone_uuid = Match.query.filter_by(event=t.url, name="Lunch").one().uuid
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/matches/{lone_uuid}",
+            json={"schedule_type": "JOIN", "previous_match_id": anchors["Field 1"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        m = Match.query.filter_by(uuid=lone_uuid).one()
+        assert m.schedule_type == ScheduleType.JOIN
+        assert m.nominal_length == 0
+
+        # Multi-field group: converting one row would leave the group mixed-type.
+        resp = client.post(
+            f"/_api/tournaments/{t.url}/break-groups",
+            json={"name": "Sync", "schedule_type": "JOIN", "fields": ["Field 1", "Field 2"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        row = Match.query.filter_by(event=t.url, name="Sync", field="Field 1").one()
+        resp = client.put(
+            f"/_api/tournaments/{t.url}/matches/{row.uuid}",
+            json={"schedule_type": "BREAK", "length": 30},
+        )
+        assert resp.status_code == 400
+        assert "group" in (resp.get_json().get("error") or "").lower()
 
     def test_same_name_join_rows_merge_in_solver(self, app, client, tournament, to_player):
         """Rows created via the group endpoint still collapse into one JOIN node


### PR DESCRIPTION
## Summary

- new static break match type so you can start the day with a break labeled "chain comp" or something without any issues
    - static breaks are marked completed when their start time passes. this is so that they aren't completed immediately on creation because you can't edit completed matches.
- breaks and joins are presented in the editing as a single match. you just select the fields you want.
- breaks act like joins now. if you want separate breaks, you need separate names. 
    - THIS IS NOT BACKWARDS COMPATIBLE. however all past tournaments are done so i think its fine
    - this is done so that we can in the future add team requirements to breaks. i think its better this way. plus now we don't need joins technically. perhaps we can deprecate them in the future or add a note in documentation about this.

note: because of the new schedule views where players just see by team or by field, their primary view (by team) won't show breaks, because breaks only exist in the context of a field. I debated making breaks also require teams (could use the ref table) but:
- it would be confusing to then still require a field to be selected? but we have to because the model requires it and the scheduling solver requires it unless we want a huge redesign there. and the whole edit process is very field-centric so it'd just be confusing to work with.
- the way we indicate priority for use of the "team" resource is by order of scheduled_start_time, which requires a field selection to determine. 
- if we don't have a field selected, we can't see the break anywhere on the schedule editor
- if we have multiple fields and multiple teams in a break, then all the matches across all fields need to have a matching set of entries for required teams. which feels sketchy.  
overall it just felt super scuffed, so im willing to just cope with the fact that the team schedule won't show breaks. at least for now.

really i think it is the correct model to allow any arbitrary selection of teams and/or fields based on what you're actually trying to say: are you giving people time to eat? then just teams. Are you doing bear pits on field 4? then you need all the teams and nothing happening on field 4. etc. but first we need to do a lot of architectural thinking about how to express schedules and how to make a UI that makes that easy to do correctly.

## What changed

Solver:

- same-name breaks across fields act as **one joined break**: every row in the group gets the union of the group's dependency edges, so they all start together (both solver passes), while keeping their own field, length, and chain position. joins already merged like this; now breaks match.
- **STATBREAK**: a break with a fixed start time. the solver never moves it, and its *status* is a pure function of the clock — `Match.effective_status` returns COMPLETED once the start passes, and the stored status is never written. 
- the participant lookup for cross-field conflict edges now reads the `match_referees` table instead of the legacy `refs` CSV column (which dual-write stopped maintaining a while ago — ref-based double-booking detection was quietly broken).

API:

- new structural-group endpoints: `POST/PUT/DELETE /_api/tournaments/<url>/break-groups[/<name>]`. create one row per selected field (chain-tail default, or explicit per-field previous match), edit the whole same-name group at once (length / start time / field membership with chain splicing), delete the group. JOIN groups force length 0.
- breaks and joins occupy *fields only* — team requirements on structural rows are rejected everywhere.

Frontend:

- picking Break/Static Break/Join in the create form switches to the group form: name + field checkboxes (+ length, + start time for STATBREAK), with select all/none. clicking any break or join in the editor opens the group editor for the whole group.

## Migration impact

- Alembic revisions added: `0012_statbreak`. recreates the two partial unique indexes so STATBREAK joins the per-field name-uniqueness group. index-only; downgrade demotes STATBREAK rows to BREAK first.
- Run `just db-backup && just db-migrate` before deploy.
- Backwards compatible: existing BREAK/JOIN rows untouched.

## Test plan

- [x] `just test` passes
- [x] `just lint` clean, `cargo check` clean
- [x] Manual verification:
  - [x] created a lunch break across 3 fields, dragged the morning around, all three stayed in lockstep
  - [x] STATBREAK at 12:00 sharp: morning running late flows around it, shows completed at 12:00 regardless

## Linked issues

Refs #199 
Refs #164

---

### Pre-review checklist

<!-- Strike through (~~item~~) anything that doesn't apply, rather than
     deleting, so reviewers can see you thought about it. -->

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [x] Targeting `dev`, not `main` (unless this is a release PR).
- [x] `just lint` and `just format` are clean.
- [x] Tests added or updated for the new behavior.
- ~~If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated.~~
- ~~If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.~~
- [x] No merge conflicts with the base branch.
