### PR TITLE
[Feature] schedule editing overhaul

### DIFF
--- a/app/routes/tournaments/__init__.py
+++ b/app/routes/tournaments/__init__.py
@@ -48,6 +48,34 @@ def _lookup_match_in(uid: str | None, tournament_url: str) -> Match | None:
     return Match.query.filter_by(uuid=uid, event=tournament_url).first()
 
 
+def _chain_successor(match: Match, tournament_url: str, exclude_uuid: str | None = None) -> Match | None:
+    """The match that sits after *match* in its per-field chain.
+
+    Trusts ``match.next_match`` when set. Otherwise falls back to the unique
+    match whose ``previous_match`` back-pointer aims at *match* — chains can be
+    "half-linked" (child points at parent, parent's ``next_match`` unset), e.g.
+    around STATIC matches (which are deliberately detached on edit) or after a
+    TOML import that only populates ``previous_match``. If several candidates
+    point back (already-degenerate state), returns ``None`` rather than guess.
+
+    Args:
+        match: Chain node whose successor we want.
+        tournament_url: Tournament scope.
+        exclude_uuid: Optional uuid to ignore among back-pointer candidates
+            (used to exclude the match currently being spliced).
+    """
+    if match.next_match:
+        nxt = _lookup_match_in(match.next_match, tournament_url)
+        if nxt is not None:
+            return nxt
+    candidates = [
+        m
+        for m in Match.query.filter_by(previous_match=match.uuid, event=tournament_url).all()
+        if m.uuid != exclude_uuid
+    ]
+    return candidates[0] if len(candidates) == 1 else None
+
+
 def detach_match_from_chain(match: Match, tournament_url: str) -> None:
     """Remove *match* from its per-field doubly-linked chain.
 
@@ -95,18 +123,19 @@ def update_match_previous_link(match: Match, prev_match_id: str, tournament_url:
     if not is_new:
         detach_match_from_chain(match, tournament_url)
 
-    # Splice *match* between prev_match and whatever currently sits after prev_match.
-    new_next_id = prev_match.next_match
-    if new_next_id == match.uuid:
-        # Stale back-pointer guard.
-        new_next_id = None
+    # Splice *match* between prev_match and whatever currently sits after
+    # prev_match. The successor is derived via _chain_successor rather than
+    # prev_match.next_match alone: half-linked chains (successor's
+    # previous_match set, prev's next_match unset — STATIC matches, TOML
+    # imports) would otherwise leave the old successor also pointing at
+    # prev_match, giving two matches the same dependency and thus the same
+    # solved start time.
+    new_next = _chain_successor(prev_match, tournament_url, exclude_uuid=match.uuid)
     match.previous_match = prev_match.uuid
-    match.next_match = new_next_id
+    match.next_match = new_next.uuid if new_next is not None else None
     prev_match.next_match = match.uuid
-    if new_next_id:
-        new_next = _lookup_match_in(new_next_id, tournament_url)
-        if new_next is not None:
-            new_next.previous_match = match.uuid
+    if new_next is not None:
+        new_next.previous_match = match.uuid
 
 
 def delete_matches_with_children(match_uuids: list[str]) -> None:

--- a/app/routes/tournaments/matches_admin.py
+++ b/app/routes/tournaments/matches_admin.py
@@ -747,6 +747,70 @@ def delete_match_api(tournament_url, match_id):
     return jsonify({"success": True})
 
 
+@bp.route("/tournaments/<tournament_url>/matches/bulk-length", methods=["POST"])
+@login_required
+def bulk_match_length_api(tournament_url):
+    """Set ``nominal_length`` on many matches at once.
+
+    Body: ``{"match_ids": [...], "length": <minutes>}``. Applies the shared
+    length to every editable match, skipping JOINs (structurally zero-length)
+    and matches locked by having started (same rule as single-match edit:
+    STATBREAKs stay editable even when COMPLETED). Single commit, one
+    recompute, per-match results in the response.
+    """
+    if not _check_to(tournament_url):
+        return jsonify({"error": "Forbidden"}), 403
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid JSON"}), 400
+
+    match_ids = data.get("match_ids")
+    if not isinstance(match_ids, list) or not match_ids:
+        return jsonify({"error": "match_ids must be a non-empty list."}), 400
+
+    try:
+        length = int(data.get("length"))
+    except (TypeError, ValueError):
+        return jsonify({"error": "Length must be a number of minutes."}), 400
+    if length <= 0:
+        return jsonify({"error": "Length must be greater than zero."}), 400
+
+    # Dedup while preserving order so results line up with the request.
+    seen: set[str] = set()
+    unique_ids: list[str] = []
+    for mid in match_ids:
+        mid = str(mid or "").strip()
+        if mid and mid not in seen:
+            seen.add(mid)
+            unique_ids.append(mid)
+    if not unique_ids:
+        return jsonify({"error": "match_ids must be a non-empty list."}), 400
+
+    results = []
+    updated = 0
+    for mid in unique_ids:
+        match = Match.query.filter_by(uuid=mid, event=tournament_url).first()
+        if not match:
+            results.append({"match_id": mid, "status": "not_found"})
+            continue
+        if match.schedule_type == ScheduleType.JOIN:
+            results.append({"match_id": mid, "status": "skipped_join"})
+            continue
+        if match.status in _LOCKED_STATUSES and match.schedule_type != ScheduleType.STATBREAK:
+            results.append({"match_id": mid, "status": "skipped_locked"})
+            continue
+        match.nominal_length = length
+        updated += 1
+        results.append({"match_id": mid, "status": "updated"})
+
+    db.session.commit()
+    if updated:
+        recompute_scheduled_and_nominal_times(tournament_url)
+
+    return jsonify({"success": True, "updated": updated, "results": results})
+
+
 # ---------------------------------------------------------------------------
 # Structural groups ("break-groups" API): same-name BREAK/STATBREAK/JOIN rows
 # across multiple fields, created and edited as one unit (shared name / length /

--- a/app/routes/tournaments/scheduling.py
+++ b/app/routes/tournaments/scheduling.py
@@ -109,20 +109,6 @@ def schedule_warnings(tournament_url):
         return jsonify({"success": False, "error": f"Schedule warnings failed: {e}"}), 500
 
 
-@bp.route("/<tournament_url>/recompute-schedule", methods=["POST"])
-@require_tournament_organizer("Only tournament organizers can access this page")
-def recompute_schedule(tournament_url):
-    """Force full recompute of match times as if a match were just edited (TO only)."""
-    try:
-        recompute_scheduled_and_nominal_times(tournament_url)
-        return (
-            jsonify({"success": True, "message": "Schedule recomputed successfully."}),
-            200,
-        )
-    except Exception as e:
-        return jsonify({"success": False, "error": f"Recompute failed: {e}"}), 500
-
-
 @bp.route("/<tournament_url>/export-schedule")
 @require_tournament_organizer("You must be a tournament organizer to export schedules")
 def export_schedule(tournament_url):
@@ -1289,16 +1275,6 @@ def force_start_match_api(tournament_url, match_id):
     # Structural change to a STATIC anchor: re-solve plan then live.
     recompute_scheduled_and_nominal_times(tournament_url)
 
-    return jsonify({"success": True})
-
-
-@bp.route("/tournaments/<tournament_url>/recompute-schedule", methods=["POST"])
-@login_required
-def recompute_schedule_api(tournament_url):
-    if not _check_to(tournament_url):
-        return jsonify({"error": "Forbidden"}), 403
-
-    recompute_scheduled_and_nominal_times(tournament_url)
     return jsonify({"success": True})
 
 

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -232,12 +232,50 @@ def _procedure_with_match(
         # BREAK's for time purposes.
         return
 
-    if node.status in (
+    # Real-world facts are never recomputed: a started/finished/skipped match
+    # stays that way. BREAK/JOIN are exempt from the COMPLETED early-return —
+    # their COMPLETED is solver-derived (nothing else can set it on structural
+    # rows), so it must be re-earned each pass like any other solver status.
+    if node.schedule_type not in (ScheduleType.BREAK, ScheduleType.JOIN) and node.status in (
         MatchStatus.COMPLETED,
         MatchStatus.IN_PROGRESS,
         MatchStatus.SKIPPED,
     ):
         return
+
+    # --- Downgrade pass -----------------------------------------------------
+    # Solver-earned statuses must be re-earned on every solve: schedule edits
+    # (reordering, retargeted previous-match links, new dependencies, tag
+    # unassignment) can invalidate a previously-correct TIME_FINALIZED /
+    # READY_TO_START / structural COMPLETED. Reset such nodes to their type's
+    # floor here; the earn logic below re-grants whatever still holds. This
+    # runs before the time computation so a downgraded SAFE/FAST node (now
+    # NOT_STARTED again) also gets its nominal recomputed this pass.
+    # Dependencies were already processed (topological order), so their
+    # downgraded statuses are visible and downgrades cascade down chains.
+    deps_started = _all_schedule_deps_in(node, (MatchStatus.IN_PROGRESS, MatchStatus.COMPLETED, MatchStatus.SKIPPED))
+    deps_complete = _all_schedule_deps_in(node, (MatchStatus.COMPLETED, MatchStatus.SKIPPED))
+    if node.status == MatchStatus.READY_TO_START:
+        ready_still_valid = deps_complete and _all_participating_teams_resolved(
+            name_to_match[node.name], tournament_url, name_to_match, tag_by_name
+        )
+        if not ready_still_valid:
+            if node.schedule_type == ScheduleType.STATIC:
+                # A STATIC match's time is finalized by definition.
+                node.status = MatchStatus.TIME_FINALIZED
+            elif node.schedule_type == ScheduleType.SAFE and deps_started:
+                node.status = MatchStatus.TIME_FINALIZED
+            else:
+                node.status = MatchStatus.NOT_STARTED
+    elif node.status == MatchStatus.TIME_FINALIZED:
+        if node.schedule_type == ScheduleType.SAFE and not deps_started:
+            node.status = MatchStatus.NOT_STARTED
+        # STATIC TIME_FINALIZED is the floor; FAST never earns TIME_FINALIZED.
+    elif node.status == MatchStatus.COMPLETED:
+        # Only reachable for BREAK/JOIN (see early-return above).
+        if not deps_complete:
+            node.status = MatchStatus.NOT_STARTED
+    # -------------------------------------------------------------------------
 
     nominal_start_if_skipped: Optional[datetime] = None
 

--- a/docs/schedule-display-vision.md
+++ b/docs/schedule-display-vision.md
@@ -72,7 +72,7 @@ Authoritative algorithm docs: [`docs/scheduling.md`](scheduling.md).
 
 | Pass | Writes | Trigger |
 |------|--------|---------|
-| Planned (`scheduled_pass=True`) | `scheduled_start_time` only | create/edit/delete, import, recompute button, push-back, boot |
+| Planned (`scheduled_pass=True`) | `scheduled_start_time` only | create/edit/delete, import, push-back, boot |
 | Live (`scheduled_pass=False`) | `nominal_start_time` + status | match start/end **and** after every planned pass |
 
 **Invariants:**

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -39,7 +39,7 @@ mode has an option to display times exactly as they happened.
 |-------|------|
 | Match start / end / finalize | Live only → `recompute_all_match_times` (= `run_scheduling(scheduled_pass=False)`) |
 | Match create / edit / delete | Both → `recompute_scheduled_and_nominal_times` |
-| TO “Recompute times” / TOML import (API) / app boot | Both |
+| Push-back / TOML import / app boot | Both |
 | Force-start convert to STATIC | Both (after writing the new STATIC anchor into **both** start fields) |
 
 `recompute_scheduled_and_nominal_times` always runs **planned first, then live**,

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -99,6 +99,15 @@ there are two subclasses of Dependency:
 
 ## Live PROCEDURE (writes `nominal_start_time` + status)
 
+Solver-earned statuses (`TIME_FINALIZED`, `READY_TO_START`, and BREAK/JOIN
+`COMPLETED`) are **re-earned on every solve**: a downgrade pass at the top of
+the procedure resets them to the type's floor (`NOT_STARTED`, or
+`TIME_FINALIZED` for STATIC) when their justification no longer holds — e.g.
+a reorder put an unfinished match in front, or a tag was unassigned. Only
+real-world facts (`IN_PROGRESS`, `COMPLETED` with a recorded result,
+`SKIPPED`) are never recomputed. Because nodes are processed in topological
+order, downgrades cascade down dependency chains in a single pass.
+
 Used by `run_scheduling(..., scheduled_pass=False)`.
 **Never writes `scheduled_start_time`.**
 

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -3439,6 +3439,33 @@ pub async fn create_break_group(
     response_json(r).await
 }
 
+pub async fn bulk_match_length(
+    tournament_url: &str,
+    req: &BulkMatchLengthRequest,
+) -> Result<BulkMatchLengthResponse, String> {
+    let c = client();
+    let r = with_credentials(
+        c.post(format!(
+            "{}/_api/tournaments/{}/matches/bulk-length",
+            base(),
+            tournament_url
+        ))
+        .json(req),
+    )
+    .send()
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let data: BulkMatchLengthResponse = response_json(r).await?;
+    if data.success {
+        Ok(data)
+    } else {
+        Err(data
+            .error
+            .unwrap_or_else(|| "Failed to update match lengths".to_string()))
+    }
+}
+
 /// Edit every same-name break row at once (length / start_time / fields).
 pub async fn update_break_group(
     tournament_url: &str,

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -3658,29 +3658,6 @@ pub async fn delete_tag(tournament_url: &str, tag_id: u32) -> Result<(), String>
     Err(err_msg)
 }
 
-pub async fn recompute_schedule(tournament_url: &str) -> Result<(), String> {
-    let c = client();
-    let r = with_credentials(c.post(format!(
-        "{}/_api/tournaments/{}/recompute-schedule",
-        base(),
-        tournament_url
-    )))
-    .send()
-    .await
-    .map_err(|e| e.to_string())?;
-
-    let data: Value = response_json(r).await?;
-    if data.get("success").and_then(|v| v.as_bool()) == Some(true) {
-        Ok(())
-    } else {
-        Err(data
-            .get("error")
-            .and_then(|v| v.as_str())
-            .unwrap_or("Unknown error")
-            .to_string())
-    }
-}
-
 #[allow(dead_code)]
 pub async fn update_all_references(tournament_url: &str) -> Result<(), String> {
     let c = client();

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -76,6 +76,9 @@ enum Route {
     #[route("/:url")]
     TournamentHome { url: String },
 
+    #[route("/:url/schedule/edit")]
+    ScheduleEdit { url: String },
+
     #[route("/:url/schedule?:view&:team&:field")]
     Schedule { url: String, view: String, team: String, field: String },
 

--- a/frontend/src/pages/layout.rs
+++ b/frontend/src/pages/layout.rs
@@ -19,6 +19,7 @@ fn page_title_for_route(route: &Route) -> String {
         Route::GoogleCompleteProfile { .. } => "Complete Profile".into(),
         Route::TournamentHome { url } | Route::TournamentHomeWithTab { url, .. } => format!("{url}"),
         Route::Schedule { url, .. } => format!("{url} Schedule"),
+        Route::ScheduleEdit { url } => format!("{url} Edit Schedule"),
         Route::Results { url } => format!("{url} Results"),
         Route::Bracket { url } => format!("{url} Bracket"),
         Route::LegacyBracket { url } => format!("{url} Legacy Bracket"),

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -91,7 +91,7 @@ pub use register::{Register, RegisterPlayer, RegisterTeam};
 pub use results::Results;
 pub use run_match::RunMatch;
 pub use crate::components::TeamSelectionField;
-pub use schedule::Schedule;
+pub use schedule::{Schedule, ScheduleEdit};
 pub use scoreboard::Scoreboard;
 pub use sidecomp_register_as_to::SideCompRegisterAsTo;
 pub use sidecomp_detail::SideCompDetail;

--- a/frontend/src/pages/run_match.rs
+++ b/frontend/src/pages/run_match.rs
@@ -935,6 +935,8 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let id_for_stones = id.clone();
                         let u_for_stones = u.clone();
                         spawn(async move {
+                            // Native (test) builds skip the wasm-only tick deferral.
+                            #[cfg(target_arch = "wasm32")]
                             gloo_timers::future::TimeoutFuture::new(0).await;
                             let mut final_stones_for_api: Option<u32> = None;
                             if let Some(Ok(ref state)) = prev.clone() {
@@ -1100,6 +1102,8 @@ pub fn RunMatch(url: String, match_id: String) -> Element {
                         let id_for_stones = id.clone();
                         let u_for_stones = u.clone();
                         spawn(async move {
+                            // Native (test) builds skip the wasm-only tick deferral.
+                            #[cfg(target_arch = "wasm32")]
                             gloo_timers::future::TimeoutFuture::new(0).await;
                             let mut final_stones_for_api: Option<u32> = None;
                             if let Some(Ok(ref state)) = prev.clone() {

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -464,8 +464,68 @@ fn read_debug_mode() -> bool {
     }
 }
 
+/// Payload emitted by the edit-page timeline when a drag-to-create gesture
+/// completes (or a plain click on empty grid space).
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct DragCreatePayload {
+    /// Field column the drag happened in.
+    field_name: String,
+    /// Snapped drag start, local time.
+    start_local: chrono::NaiveDateTime,
+    /// Drag extent in minutes (already min-clamped); None = plain click → default length.
+    length_min: Option<u32>,
+    /// Suggested previous match on that field (latest displayed start at-or-before the drag start).
+    prev_match_id: Option<String>,
+}
+
+/// Payload emitted by the edit-page timeline when a drag-to-move gesture commits.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct MoveCommitPayload {
+    match_id: String,
+    /// Schedule type of the dragged match (decides which API call to make).
+    schedule_type: String,
+    /// Match name (break groups are addressed by name).
+    group_name: String,
+    /// Target field name.
+    new_field: Option<String>,
+    /// New start time as UTC ISO (STATIC/STATBREAK).
+    new_start_utc: Option<String>,
+    /// New previous match id (dynamic types).
+    new_prev_id: Option<String>,
+}
+
+/// Public read-only schedule page. Edit affordances live on [`ScheduleEdit`].
 #[component]
 pub fn Schedule(url: String, view: String, team: String, field: String) -> Element {
+    rsx! {
+        SchedulePage {
+            url,
+            view,
+            team,
+            field,
+            editor: false,
+        }
+    }
+}
+
+/// Dedicated schedule-editing page (`/:url/schedule/edit`). TO-only; renders the
+/// all-fields timeline + table with edit capabilities permanently on. Non-TOs
+/// are redirected to the public schedule page.
+#[component]
+pub fn ScheduleEdit(url: String) -> Element {
+    rsx! {
+        SchedulePage {
+            url,
+            view: String::new(),
+            team: String::new(),
+            field: String::new(),
+            editor: true,
+        }
+    }
+}
+
+#[component]
+fn SchedulePage(url: String, view: String, team: String, field: String, editor: bool) -> Element {
     let url_data = url.clone();
     let mut setup_data = use_resource(move || {
         let u = url_data.clone();
@@ -476,6 +536,14 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
     // remembered location. Computed once so navigator().replace below (which
     // changes props) can't feed back into state.
     let initial_nav = use_hook(|| {
+        if editor {
+            // The edit page is always the all-fields grid (or table); no URL/query state.
+            return ScheduleNavState {
+                view: "timeline".to_string(),
+                team: String::new(),
+                field: "all".to_string(),
+            };
+        }
         let from_url = ScheduleNavState {
             view: view.clone(),
             team: team.clone(),
@@ -502,7 +570,9 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
         let v = initial_nav.view.clone();
         move || v
     });
-    let mut edit_mode = use_signal(|| false);
+    // Editing is a property of the page: permanently on for the edit page,
+    // permanently off on the public schedule page.
+    let edit_mode = editor;
     let mut selected_field = use_signal({
         let f = initial_nav.field.clone();
         move || f
@@ -549,6 +619,19 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
     // Debug mode is opt-in via `localStorage.setItem("debug", "1")`. Read once at mount —
     // toggling requires a refresh, which is fine for a developer-only switch.
     let debug_mode = use_signal(read_debug_mode);
+    let navigator = use_navigator();
+
+    // Edit-page-only state.
+    // Bulk match-length tool: click blocks to multi-select, then apply one length to all.
+    let mut bulk_mode = use_signal(|| false);
+    let mut bulk_selected = use_signal(Vec::<String>::new);
+    let mut bulk_length_input = use_signal(|| 30u32);
+    // Inline error affordance for drag-move / bulk failures (dismissible alert near the toolbar).
+    let mut edit_error = use_signal(|| None::<String>);
+    // Prefill for the create-match modal when opened from a drag-to-create gesture.
+    let mut create_prefill = use_signal(|| None::<DragCreatePayload>);
+    // Bumped per drag-create so the modal remounts with fresh prefill state.
+    let mut create_prefill_nonce = use_signal(|| 0u32);
 
     // Pull schedule warnings in parallel so we can surface a cycle banner at the top
     // of the page. Re-runs whenever refresh_trigger bumps so the banner stays in sync
@@ -562,10 +645,26 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
     #[cfg(target_arch = "wasm32")]
     let schedule_refresh_interval = use_signal(|| None as Option<Interval>);
 
+    let url_for_redirect = url.clone();
     use_effect(move || {
         if let Some(Ok(data)) = setup_data.value().read().as_ref() {
             is_to.set(data.is_to);
+            // The edit page is TO-only: bounce non-TOs to the public schedule.
+            if editor && !data.is_to {
+                navigator.replace(Route::Schedule {
+                    url: url_for_redirect.clone(),
+                    view: String::new(),
+                    team: String::new(),
+                    field: String::new(),
+                });
+                return;
+            }
             let v = view_mode();
+            // The edit page only has the all-fields grid and the table.
+            if editor && !matches!(v.as_str(), "timeline" | "table") {
+                view_mode.set("timeline".to_string());
+                return;
+            }
             // "All fields" and "Table" are TO-only; coerce stray values (e.g. from URL).
             if !data.is_to && matches!(v.as_str(), "timeline" | "table") {
                 view_mode.set("team".to_string());
@@ -595,6 +694,10 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
         let nav_handle = use_navigator();
         let mut last_nav_synced = use_signal(|| None::<ScheduleNavState>);
         use_effect(move || {
+            // The edit page has its own route with no query state; never rewrite its URL.
+            if editor {
+                return;
+            }
             let state = ScheduleNavState {
                 view: view_mode(),
                 team: focus_team_id(),
@@ -728,6 +831,7 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
             let url_for_recompute = url.clone();
             let url_for_export_key = url_for_export.clone();
             let url_for_recompute_key = url_for_recompute.clone();
+            let url_for_edit_link_key = url.clone();
             let handle_keydown = move |ev: Event<KeyboardData>| {
                 let key_str = ev.key().to_string();
                 let modal_open = active_modal() != "none";
@@ -741,7 +845,13 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                 }
                 if key_str == "Escape" {
                     ev.prevent_default();
-                    active_modal.set("none".to_string());
+                    // On the edit page Esc first exits the bulk-length tool.
+                    if bulk_mode() {
+                        bulk_mode.set(false);
+                        bulk_selected.set(Vec::new());
+                    } else {
+                        active_modal.set("none".to_string());
+                    }
                 } else {
                     match key_str.as_str() {
                         "n" | "N" => {
@@ -758,7 +868,7 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                         }
                         "t" | "T" => {
                             ev.prevent_default();
-                            if edit_mode() && is_to {
+                            if edit_mode && is_to {
                                 active_modal.set("tags".to_string());
                             } else if matches!(view_mode().as_str(), "team" | "field" | "timeline")
                             {
@@ -779,38 +889,38 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                         }
                         "y" | "Y" => {
                             ev.prevent_default();
-                            if !edit_mode() {
+                            if !edit_mode {
                                 view_mode.set("team".to_string());
                             }
                         }
                         "e" | "E" => {
                             ev.prevent_default();
-                            if is_to {
-                                let on = !edit_mode();
-                                edit_mode.set(on);
-                                // Team/field views are viewer-only; bounce to the grid.
-                                if on && matches!(view_mode().as_str(), "team" | "field") {
-                                    view_mode.set("timeline".to_string());
-                                }
+                            // Public page: jump a TO to the dedicated edit page.
+                            if !editor && is_to {
+                                navigator.push(Route::ScheduleEdit {
+                                    url: url_for_edit_link_key.clone(),
+                                });
                             }
                         }
                         "m" | "M" => {
-                            if edit_mode() && is_to {
+                            if edit_mode && is_to {
                                 ev.prevent_default();
+                                create_prefill.set(None);
+                                create_prefill_nonce.set(create_prefill_nonce().wrapping_add(1));
                                 active_modal.set("match_create".to_string());
                             }
                         }
                         "f" | "F" => {
-                            if edit_mode() && is_to {
+                            if edit_mode && is_to {
                                 ev.prevent_default();
                                 active_modal.set("fields".to_string());
-                            } else if !edit_mode() {
+                            } else if !edit_mode {
                                 ev.prevent_default();
                                 view_mode.set("field".to_string());
                             }
                         }
                         "x" | "X" => {
-                            if edit_mode() && is_to {
+                            if edit_mode && is_to {
                                 ev.prevent_default();
                                 let u = url_for_export_key.clone();
                                 spawn(async move {
@@ -852,13 +962,13 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                             }
                         }
                         "i" | "I" => {
-                            if edit_mode() && is_to {
+                            if edit_mode && is_to {
                                 ev.prevent_default();
                                 active_modal.set("toml_import".to_string());
                             }
                         }
                         "r" | "R" => {
-                            if edit_mode() && is_to {
+                            if edit_mode && is_to {
                                 ev.prevent_default();
                                 let u = url_for_recompute_key.clone();
                                 let mut trigger = refresh_trigger;
@@ -895,7 +1005,14 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                                     li { class: "breadcrumb-item",
                                         Link { to: Route::TournamentHome { url: url.clone() }, "{data.tournament.name}" }
                                     }
-                                    li { class: "breadcrumb-item active", "Schedule" }
+                                    if editor {
+                                        li { class: "breadcrumb-item",
+                                            Link { to: Route::Schedule { url: url.clone(), view: String::new(), team: String::new(), field: String::new() }, "Schedule" }
+                                        }
+                                        li { class: "breadcrumb-item active", "Edit" }
+                                    } else {
+                                        li { class: "breadcrumb-item active", "Schedule" }
+                                    }
                                 }
                             }
                         }
@@ -1009,7 +1126,7 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                                         }
                                     }
                                     div { class: "btn-group btn-group-sm",
-                                        if !edit_mode() {
+                                        if !editor {
                                             button {
                                                 class: if view_mode() == "team" { "btn btn-primary" } else { "btn btn-outline-primary" },
                                                 onclick: move |_| view_mode.set("team".to_string()),
@@ -1037,10 +1154,14 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                                 }
                                 if data.is_to {
                                     div { class: "d-flex flex-wrap align-items-center gap-1",
-                                        if edit_mode() {
+                                        if editor {
                                             button { class: "btn btn-sm btn-outline-secondary", onclick: move |_| active_modal.set("tags".to_string()), "Tags" }
                                             button { class: "btn btn-sm btn-outline-secondary", onclick: move |_| active_modal.set("fields".to_string()), "Fields" }
-                                            button { class: "btn btn-sm btn-outline-success", onclick: move |_| active_modal.set("match_create".to_string()), "+ Match" }
+                                            button { class: "btn btn-sm btn-outline-success", onclick: move |_| {
+                                                create_prefill.set(None);
+                                                create_prefill_nonce.set(create_prefill_nonce().wrapping_add(1));
+                                                active_modal.set("match_create".to_string());
+                                            }, "+ Match" }
                                             button { class: "btn btn-sm btn-outline-secondary", onclick: move |_| {
                                                 let u = url_for_export.clone();
                                                 spawn(async move {
@@ -1096,6 +1217,18 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                                                 onclick: move |_| active_modal.set("schedule_warnings".to_string()),
                                                 "⚠ Warnings"
                                             }
+                                            button {
+                                                class: if bulk_mode() { "btn btn-sm btn-secondary" } else { "btn btn-sm btn-outline-secondary" },
+                                                title: "Click blocks to multi-select, then apply one length to all (Esc to exit)",
+                                                onclick: move |_| {
+                                                    let on = !bulk_mode();
+                                                    bulk_mode.set(on);
+                                                    if !on {
+                                                        bulk_selected.set(Vec::new());
+                                                    }
+                                                },
+                                                "Bulk length"
+                                            }
                                             div {
                                                 class: "form-check form-switch mb-0 ms-1",
                                                 title: "Place blocks at exact real times (confirmed/completed, falling back to estimates) instead of the planned-or-earlier rule.",
@@ -1117,25 +1250,104 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                                                     "Show times as they happened"
                                                 }
                                             }
-                                        }
-                                        div { class: "form-check form-switch mb-0 ms-1",
-                                            input {
-                                                class: "form-check-input",
-                                                type: "checkbox",
-                                                role: "switch",
-                                                id: "editModeSwitch",
-                                                checked: "{edit_mode}",
-                                                onchange: move |e| {
-                                                    let on = e.value() == "true";
-                                                    edit_mode.set(on);
-                                                    // Team/field views are viewer-only; leave them when entering edit.
-                                                    if on && matches!(view_mode().as_str(), "team" | "field") {
-                                                        view_mode.set("timeline".to_string());
-                                                    }
-                                                }
+                                        } else {
+                                            // Public page: read-only warnings + a link to the edit page.
+                                            button {
+                                                class: "btn btn-sm btn-outline-warning",
+                                                title: "Show schedule warnings (unknown teams, cycles, missing match refs, double-bookings)",
+                                                onclick: move |_| active_modal.set("schedule_warnings".to_string()),
+                                                "⚠ Warnings"
                                             }
-                                            label { class: "form-check-label small", "for": "editModeSwitch", "Edit" }
+                                            Link {
+                                                to: Route::ScheduleEdit { url: url.clone() },
+                                                class: "btn btn-sm btn-primary",
+                                                "Edit schedule"
+                                            }
                                         }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if editor {
+                        if let Some(err) = edit_error() {
+                            div { class: "alert alert-danger alert-dismissible d-flex align-items-center py-2 mb-2",
+                                span { class: "flex-grow-1", "{err}" }
+                                button {
+                                    r#type: "button",
+                                    class: "btn-close",
+                                    "aria-label": "Dismiss",
+                                    onclick: move |_| edit_error.set(None),
+                                }
+                            }
+                        }
+                        if bulk_mode() {
+                            div { class: "card mb-2 border-secondary",
+                                div { class: "card-body py-2 d-flex flex-wrap align-items-center gap-2",
+                                    strong { class: "small", "Bulk length:" }
+                                    span { class: "small text-muted",
+                                        "click blocks to select — {bulk_selected().len()} selected"
+                                    }
+                                    label { class: "small mb-0 ms-2", "Length (min)" }
+                                    input {
+                                        class: "form-control form-control-sm d-inline-block",
+                                        style: "width: 6rem;",
+                                        r#type: "number",
+                                        min: "1",
+                                        value: "{bulk_length_input}",
+                                        onkeydown: move |ev: Event<KeyboardData>| ev.stop_propagation(),
+                                        oninput: move |e| {
+                                            bulk_length_input.set(e.value().parse().unwrap_or(30));
+                                        },
+                                    }
+                                    button {
+                                        class: "btn btn-sm btn-success",
+                                        disabled: bulk_selected().is_empty() || bulk_length_input() == 0,
+                                        onclick: {
+                                            let u = url.clone();
+                                            move |_| {
+                                                let u = u.clone();
+                                                let ids = bulk_selected();
+                                                let len = bulk_length_input();
+                                                spawn(async move {
+                                                    let req = BulkMatchLengthRequest {
+                                                        match_ids: ids,
+                                                        length: len,
+                                                    };
+                                                    match api::bulk_match_length(&u, &req).await {
+                                                        Ok(res) => {
+                                                            let skipped = res
+                                                                .results
+                                                                .iter()
+                                                                .filter(|r| r.status != "updated")
+                                                                .count();
+                                                            if skipped > 0 {
+                                                                edit_error.set(Some(format!(
+                                                                    "Updated {} matches; {} skipped (locked / join / missing).",
+                                                                    res.updated, skipped
+                                                                )));
+                                                            } else {
+                                                                edit_error.set(None);
+                                                            }
+                                                            bulk_mode.set(false);
+                                                            bulk_selected.set(Vec::new());
+                                                            refresh();
+                                                        }
+                                                        Err(e) => edit_error.set(Some(e)),
+                                                    }
+                                                });
+                                            }
+                                        },
+                                        "Apply"
+                                    }
+                                    button {
+                                        class: "btn btn-sm btn-outline-secondary",
+                                        onclick: move |_| {
+                                            bulk_mode.set(false);
+                                            bulk_selected.set(Vec::new());
+                                        },
+                                        "Cancel (Esc)"
                                     }
                                 }
                             }
@@ -1161,9 +1373,9 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                             } else {
                                 highlight_team()
                             },
-                            edit_mode: edit_mode() && view_mode() == "timeline",
+                            edit_mode: edit_mode && view_mode() == "timeline",
                             // "As happened" placement is an edit-mode-only concept.
-                            show_as_happened: edit_mode() && show_as_happened(),
+                            show_as_happened: edit_mode && show_as_happened(),
                             vertical_scale: vertical_scale,
                             // Empty = multi-field grid; non-empty = single-column team view.
                             focus_team_id: if view_mode() == "team" {
@@ -1172,9 +1384,23 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                                 String::new()
                             },
                             tournament_url: url.clone(),
+                            editor: editor && view_mode() == "timeline",
+                            bulk_select_active: bulk_mode(),
+                            selected_ids: bulk_selected(),
                             on_edit_match: {
                                 let matches_for_edit = data.matches.clone();
                                 move |id: String| {
+                                    // Bulk-length tool: clicks toggle selection instead of editing.
+                                    if bulk_mode() {
+                                        let mut sel = bulk_selected();
+                                        if let Some(pos) = sel.iter().position(|s| s == &id) {
+                                            sel.remove(pos);
+                                        } else {
+                                            sel.push(id);
+                                        }
+                                        bulk_selected.set(sel);
+                                        return;
+                                    }
                                     // Structural blocks (breaks/joins) are edited as a same-name group.
                                     if let Some(m) = matches_for_edit.iter().find(|m| m.uuid == id) {
                                         if is_structural_match(m) {
@@ -1187,6 +1413,84 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                                     active_modal.set("match_edit".to_string());
                                 }
                             },
+                            on_drag_create: move |p: DragCreatePayload| {
+                                create_prefill.set(Some(p));
+                                create_prefill_nonce.set(create_prefill_nonce().wrapping_add(1));
+                                active_modal.set("match_create".to_string());
+                            },
+                            on_move_match: {
+                                let u = url.clone();
+                                move |mc: MoveCommitPayload| {
+                                    let u = u.clone();
+                                    if !matches!(mc.schedule_type.as_str(), "STATIC" | "STATBREAK")
+                                        && mc.new_prev_id.is_none()
+                                    {
+                                        edit_error.set(Some(format!(
+                                            "{} matches need a previous match — drop the block after another match on the field.",
+                                            mc.schedule_type
+                                        )));
+                                        return;
+                                    }
+                                    spawn(async move {
+                                        let none_update = UpdateMatchRequest {
+                                            field: None,
+                                            schedule_type: None,
+                                            length: None,
+                                            start_time: None,
+                                            previous_match_id: None,
+                                            refs: None,
+                                            team1: None,
+                                            team2: None,
+                                            set_type: None,
+                                            nsets: None,
+                                            stones_per_set: None,
+                                            ribbon: None,
+                                            skip_condition: None,
+                                        };
+                                        let res = match mc.schedule_type.as_str() {
+                                            "STATIC" => {
+                                                let req = UpdateMatchRequest {
+                                                    field: mc.new_field.clone(),
+                                                    start_time: mc.new_start_utc.clone(),
+                                                    ..none_update
+                                                };
+                                                api::update_match(&u, &mc.match_id, &req).await
+                                            }
+                                            "STATBREAK" => {
+                                                // Static breaks move as a group: shared start time.
+                                                let req = UpdateBreakGroupRequest {
+                                                    schedule_type: None,
+                                                    length: None,
+                                                    teams: None,
+                                                    start_time: mc.new_start_utc.clone(),
+                                                    fields: None,
+                                                };
+                                                api::update_break_group(&u, &mc.group_name, &req)
+                                                    .await
+                                            }
+                                            _ => {
+                                                let req = UpdateMatchRequest {
+                                                    field: mc.new_field.clone(),
+                                                    previous_match_id: mc.new_prev_id.clone(),
+                                                    ..none_update
+                                                };
+                                                api::update_match(&u, &mc.match_id, &req).await
+                                            }
+                                        };
+                                        match res {
+                                            Ok(_) => {
+                                                edit_error.set(None);
+                                                refresh();
+                                            }
+                                            Err(e) => {
+                                                edit_error.set(Some(e));
+                                                // Refetch so the block snaps back to server truth.
+                                                refresh();
+                                            }
+                                        }
+                                    });
+                                }
+                            },
                             key_nav: key_nav,
                             on_key_nav_consumed: move |_| key_nav.set(None),
                         }
@@ -1195,9 +1499,9 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                             data: data.clone(),
                             selected_field: selected_field(),
                             highlight_team: highlight_team(),
-                            edit_mode: edit_mode(),
+                            edit_mode: edit_mode,
                             debug_mode: debug_mode(),
-                            show_as_happened: edit_mode() && show_as_happened(),
+                            show_as_happened: edit_mode && show_as_happened(),
                             tournament_url: url.clone(),
                             on_edit_match: {
                                 let matches_for_edit = data.matches.clone();
@@ -1232,13 +1536,25 @@ pub fn Schedule(url: String, view: String, team: String, field: String) -> Eleme
                         }
                     }
                     if active_modal() == "match_create" {
-                        CreateMatchModal {
-                            tournament_url: url.clone(),
-                            data: data.clone(),
-                            on_close: move |_| active_modal.set("none".to_string()),
-                            on_save: move |_| {
-                                active_modal.set("none".to_string());
-                                refresh();
+                        div { key: "create-{create_prefill_nonce()}",
+                            CreateMatchModal {
+                                tournament_url: url.clone(),
+                                data: data.clone(),
+                                prefill_field: create_prefill().map(|p| p.field_name.clone()),
+                                prefill_start_time: create_prefill()
+                                    .map(|p| p.start_local.format("%Y-%m-%dT%H:%M").to_string()),
+                                prefill_length: create_prefill().and_then(|p| p.length_min),
+                                prefill_prev_match_id: create_prefill()
+                                    .and_then(|p| p.prev_match_id.clone()),
+                                on_close: move |_| {
+                                    create_prefill.set(None);
+                                    active_modal.set("none".to_string());
+                                },
+                                on_save: move |_| {
+                                    create_prefill.set(None);
+                                    active_modal.set("none".to_string());
+                                    refresh();
+                                }
                             }
                         }
                     }
@@ -1379,12 +1695,30 @@ fn CreateMatchModal(
     data: ScheduleSetupResponse,
     on_close: EventHandler<()>,
     on_save: EventHandler<()>,
+    /// Drag-to-create prefill: field column the drag happened in.
+    #[props(default)]
+    prefill_field: Option<String>,
+    /// Drag-to-create prefill: datetime-local start (STATIC semantics).
+    #[props(default)]
+    prefill_start_time: Option<String>,
+    /// Drag-to-create prefill: drag extent in minutes.
+    #[props(default)]
+    prefill_length: Option<u32>,
+    /// Drag-to-create prefill: chain-position default for dynamic types.
+    #[props(default)]
+    prefill_prev_match_id: Option<String>,
 ) -> Element {
     let name = use_signal(|| "".to_string());
-    let mut field = use_signal(|| "".to_string());
+    let mut field = use_signal({
+        let f = prefill_field.clone();
+        move || f.unwrap_or_default()
+    });
     let schedule_type = use_signal(|| "STATIC".to_string());
-    let mut length = use_signal(|| 60u32);
-    let mut start_time = use_signal(|| "".to_string());
+    let mut length = use_signal(move || prefill_length.unwrap_or(60));
+    let mut start_time = use_signal({
+        let s = prefill_start_time.clone();
+        move || s.unwrap_or_default()
+    });
     let mut previous_match_id = use_signal(|| "".to_string());
     let mut refs = use_signal(|| "".to_string());
     let mut team1 = use_signal(|| "".to_string());
@@ -1397,7 +1731,11 @@ fn CreateMatchModal(
     let mut skip_condition_help_open = use_signal(|| false);
     let mut skip_condition_validity = use_signal(|| None::<Result<(), String>>);
     // Break-group mode (type BREAK/STATBREAK): fields the break spans.
-    let mut break_fields = use_signal(Vec::<String>::new);
+    // Drag-to-create seeds the dragged column.
+    let mut break_fields = use_signal({
+        let f = prefill_field.clone();
+        move || f.map(|f| vec![f]).unwrap_or_default()
+    });
 
     let mut error = use_signal(|| None::<String>);
     let mut saving = use_signal(|| false);
@@ -1846,7 +2184,23 @@ fn CreateMatchModal(
                                 div { class: "col-md-6",
                                     div { class: "mb-3",
                                         label { class: "form-label", "Type" }
-                                        select { class: "form-select", value: "{schedule_type}", onchange: move |e| { let mut schedule_type = schedule_type; schedule_type.set(e.value()); },
+                                        select { class: "form-select", value: "{schedule_type}", onchange: {
+                                            let prefill_prev = prefill_prev_match_id.clone();
+                                            move |e: Event<FormData>| {
+                                                let mut schedule_type = schedule_type;
+                                                let v = e.value();
+                                                schedule_type.set(v.clone());
+                                                // Drag-to-create: switching to a dynamic type defaults the
+                                                // previous match to the chain position of the drag start.
+                                                if matches!(v.as_str(), "SAFE" | "FAST" | "JOIN")
+                                                    && previous_match_id().is_empty()
+                                                {
+                                                    if let Some(p) = prefill_prev.clone() {
+                                                        previous_match_id.set(p);
+                                                    }
+                                                }
+                                            }
+                                        },
                                             option { value: "STATIC", "Static" }
                                             option { value: "SAFE", "Safe" }
                                             option { value: "FAST", "Fast" }
@@ -3601,6 +3955,21 @@ fn TimelineEventCard(
     tournament_url: String,
     base_url: String,
     on_edit_match: EventHandler<String>,
+    /// Edit-page interactions enabled (drag-to-move, alt-hover deps).
+    #[props(default = false)]
+    editor: bool,
+    /// Selected by the bulk-length tool.
+    #[props(default = false)]
+    selected: bool,
+    /// Alt-hover dependency highlight class (source / chain / team / ref).
+    #[props(default)]
+    dep_class: Option<String>,
+    /// Pointerdown on the block (id, client_x, client_y) → may start a move drag.
+    #[props(default)]
+    on_move_pointer_down: EventHandler<(String, f64, f64)>,
+    /// Hover tracking for the alt-dependency view: (id, entered, alt_held).
+    #[props(default)]
+    on_hover: EventHandler<(String, bool, bool)>,
 ) -> Element {
     let navigator = use_navigator();
     let event_id_clone = event.id.clone();
@@ -3620,7 +3989,7 @@ fn TimelineEventCard(
     };
     let url_clone = tournament_url.clone();
     let event_class = format!(
-        "schedule-timeline-event{}{}{}",
+        "schedule-timeline-event{}{}{}{}{}",
         if event.highlight_playing {
             " schedule-timeline-event--highlight-playing"
         } else {
@@ -3635,7 +4004,16 @@ fn TimelineEventCard(
             " schedule-timeline-event--structural"
         } else {
             ""
-        }
+        },
+        if selected {
+            " schedule-timeline-event--bulk-selected"
+        } else {
+            ""
+        },
+        dep_class
+            .as_deref()
+            .map(|c| format!(" {c}"))
+            .unwrap_or_default()
     );
     let (t1_kind, t1_label) = team_ref_display(&event.team1);
     let (t2_kind, t2_label) = team_ref_display(&event.team2);
@@ -3671,12 +4049,38 @@ fn TimelineEventCard(
     let field_label = event.field_name.clone();
     let start_time_label = event.start_time.format("%H:%M").to_string();
 
+    let event_id_for_drag = event.id.clone();
+    let event_id_for_enter = event.id.clone();
+    let event_id_for_leave = event.id.clone();
+    let can_drag = editor && !edit_locked;
     rsx! {
         div {
             class: "{event_class}",
             style: "{event_style}",
             title: "{timeline_title}",
-            cursor: if (is_break && !edit_mode) || (edit_mode && edit_locked) { "default" } else { "pointer" },
+            cursor: if can_drag { "grab" } else if (is_break && !edit_mode) || (edit_mode && edit_locked) { "default" } else { "pointer" },
+            onpointerdown: move |ev: Event<PointerData>| {
+                if !editor {
+                    return;
+                }
+                // Never let a press on a block start an empty-space create drag.
+                ev.stop_propagation();
+                if !can_drag || ev.pointer_type() != "mouse" {
+                    return;
+                }
+                let c = ev.client_coordinates();
+                on_move_pointer_down.call((event_id_for_drag.clone(), c.x, c.y));
+            },
+            onmouseenter: move |ev: Event<MouseData>| {
+                if editor {
+                    on_hover.call((event_id_for_enter.clone(), true, ev.modifiers().alt()));
+                }
+            },
+            onmouseleave: move |ev: Event<MouseData>| {
+                if editor {
+                    on_hover.call((event_id_for_leave.clone(), false, ev.modifiers().alt()));
+                }
+            },
             onclick: move |_| {
                 if is_break && !edit_mode {
                 } else if edit_mode {
@@ -3833,6 +4237,107 @@ fn TimelineEventCard(
     }
 }
 
+/// In-flight drag gesture on the edit-page timeline.
+#[derive(Clone, Debug, PartialEq)]
+enum TimelineDrag {
+    /// Drag on empty grid space: gcal-style growing create placeholder.
+    Create {
+        col: usize,
+        anchor_min: i64,
+        cur_min: i64,
+    },
+    /// Drag of an existing block (ghost follows the cursor).
+    Move {
+        id: String,
+        schedule_type: String,
+        name: String,
+        duration_min: i64,
+        grab_offset_min: i64,
+        orig_col: usize,
+        orig_start_min: i64,
+        cur_col: usize,
+        cur_start_min: i64,
+        moved: bool,
+    },
+}
+
+/// Snap minutes-from-midnight to the nearest 5-minute increment.
+fn snap5(min: i64) -> i64 {
+    (((min as f64) / 5.0).round() as i64 * 5).clamp(0, 24 * 60)
+}
+
+/// Convert viewport client coordinates to (field column, minutes from 00:00)
+/// using the events-layer bounding rect — the same math block placement uses,
+/// so zoom (`--slot-height`) and scrolling are automatically respected.
+#[allow(unused_variables)]
+fn grid_pos_from_client(client_x: f64, client_y: f64, num_fields: usize) -> Option<(usize, i64)> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let doc = web_sys::window()?.document()?;
+        let el = doc.get_element_by_id("schedule-timeline-events-layer")?;
+        let rect = el.get_bounding_client_rect();
+        if rect.width() <= 0.0 || rect.height() <= 0.0 {
+            return None;
+        }
+        let x = client_x - rect.left();
+        let y = client_y - rect.top();
+        if x < 0.0 || x > rect.width() || y < 0.0 || y > rect.height() {
+            return None;
+        }
+        let col = ((x / rect.width()) * num_fields as f64).floor() as isize;
+        let col = col.clamp(0, num_fields.saturating_sub(1) as isize) as usize;
+        let minutes = ((y / rect.height()) * (24.0 * 60.0)).round() as i64;
+        Some((col, minutes.clamp(0, 24 * 60)))
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        None
+    }
+}
+
+/// Format minutes-from-midnight as "HH:MM".
+fn fmt_minutes(min: i64) -> String {
+    format!("{:02}:{:02}", (min / 60).clamp(0, 23), min % 60)
+}
+
+/// The match on `field_name` whose displayed start (local) is the latest one
+/// at-or-before `before_local`. Returns (uuid, name, display end local).
+/// Used for drag-created previous-match defaults and dynamic-move snapping.
+fn latest_match_before(
+    matches: &[MatchSetupData],
+    field_name: &str,
+    before_local: chrono::NaiveDateTime,
+    exclude_uuid: &str,
+    show_as_happened: bool,
+    tz_offset_minutes: i64,
+) -> Option<(String, String, chrono::NaiveDateTime)> {
+    matches
+        .iter()
+        .filter(|m| m.status != "SKIPPED")
+        .filter(|m| m.uuid != exclude_uuid)
+        .filter(|m| m.field.as_deref() == Some(field_name))
+        .filter_map(|m| {
+            let (s, e) = display_interval_utc(m, show_as_happened)?;
+            let s_local = s + chrono::Duration::minutes(tz_offset_minutes);
+            let e_local = e + chrono::Duration::minutes(tz_offset_minutes);
+            if s_local <= before_local {
+                Some((m.uuid.clone(), m.name.clone(), s_local, e_local))
+            } else {
+                None
+            }
+        })
+        .max_by_key(|(_, _, s, _)| *s)
+        .map(|(u, n, _, e)| (u, n, e))
+}
+
+/// Strip a `Name::winner` / `Name::loser` reference token to the match name.
+fn ref_token_match_name(token: &str) -> Option<&str> {
+    let t = token.trim();
+    t.strip_suffix("::winner")
+        .or_else(|| t.strip_suffix("::loser"))
+        .map(str::trim)
+}
+
 #[component]
 fn ScheduleTimeline(
     data: ScheduleSetupResponse,
@@ -3848,6 +4353,21 @@ fn ScheduleTimeline(
     focus_team_id: String,
     tournament_url: String,
     on_edit_match: EventHandler<String>,
+    /// Edit-page interactions: drag-to-create, drag-to-move, alt-hover dependency lines.
+    #[props(default = false)]
+    editor: bool,
+    /// Bulk-length selection mode is active (drags disabled; clicks toggle selection).
+    #[props(default = false)]
+    bulk_select_active: bool,
+    /// Blocks currently selected by the bulk-length tool.
+    #[props(default)]
+    selected_ids: Vec<String>,
+    /// Fired when a drag-to-create gesture (or plain empty-space click) completes.
+    #[props(default)]
+    on_drag_create: EventHandler<DragCreatePayload>,
+    /// Fired when a drag-to-move gesture commits.
+    #[props(default)]
+    on_move_match: EventHandler<MoveCommitPayload>,
     key_nav: Signal<Option<String>>,
     on_key_nav_consumed: EventHandler<()>,
 ) -> Element {
@@ -3942,6 +4462,62 @@ fn ScheduleTimeline(
         });
     }
     let _ = now_tick();
+
+    // ------------------------------------------------------------------
+    // Edit-page interaction state (drag-to-create / drag-to-move / alt-hover).
+    // ------------------------------------------------------------------
+    let mut drag_state = use_signal(|| None::<TimelineDrag>);
+    // A completed move drag must swallow the click that the browser fires on release.
+    let mut suppress_next_click = use_signal(|| false);
+    // Alt-hover dependency view state.
+    let mut hovered_block = use_signal(|| None::<String>);
+    let mut alt_down = use_signal(|| false);
+
+    // Window-level Alt tracking so pressing/releasing Alt while stationary
+    // over a block immediately shows/hides the dependency lines. The `alive`
+    // cell stops the leaked (`forget`) listeners from writing to dropped
+    // signals after the component unmounts.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let alive = use_hook(|| Rc::new(std::cell::Cell::new(true)));
+        use_drop({
+            let alive = alive.clone();
+            move || alive.set(false)
+        });
+        let mut installed = use_signal(|| false);
+        use_effect(move || {
+            if !editor || installed() {
+                return;
+            }
+            installed.set(true);
+            use wasm_bindgen::JsCast;
+            use wasm_bindgen::closure::Closure;
+            if let Some(window) = web_sys::window() {
+                let mut alt_sig_down = alt_down;
+                let alive_down = alive.clone();
+                let on_down = Closure::wrap(Box::new(move |e: web_sys::KeyboardEvent| {
+                    if alive_down.get() && e.key() == "Alt" && !*alt_sig_down.peek() {
+                        alt_sig_down.set(true);
+                    }
+                }) as Box<dyn FnMut(_)>);
+                let mut alt_sig_up = alt_down;
+                let alive_up = alive.clone();
+                let on_up = Closure::wrap(Box::new(move |e: web_sys::KeyboardEvent| {
+                    if alive_up.get() && e.key() == "Alt" && *alt_sig_up.peek() {
+                        alt_sig_up.set(false);
+                    }
+                }) as Box<dyn FnMut(_)>);
+                let _ = window.add_event_listener_with_callback(
+                    "keydown",
+                    on_down.as_ref().unchecked_ref(),
+                );
+                let _ = window
+                    .add_event_listener_with_callback("keyup", on_up.as_ref().unchecked_ref());
+                on_down.forget();
+                on_up.forget();
+            }
+        });
+    }
 
     // All match dates in local time (unique, sorted) for prev/next navigation
     // Use plan times for day navigation so the calendar of the day stays stable.
@@ -4546,6 +5122,434 @@ fn ScheduleTimeline(
         None
     };
 
+    // ------------------------------------------------------------------
+    // Edit-page interactions: precomputed lookups + handlers.
+    // ------------------------------------------------------------------
+    let num_fields_total = visible_fields.len().max(1);
+    let field_names: Vec<String> = visible_fields.iter().map(|f| f.name.clone()).collect();
+    let field_col_index: HashMap<u32, usize> = visible_fields
+        .iter()
+        .enumerate()
+        .map(|(i, f)| (f.id, i))
+        .collect();
+    let day_start = current_visible_date.and_hms_opt(0, 0, 0).unwrap_or_default();
+    // Per-block drag info for today's visible blocks: (schedule_type, name, start_min, duration_min, col).
+    let drag_block_info: HashMap<String, (String, String, i64, i64, usize)> = timeline_events
+        .iter()
+        .filter(|e| e.start_time.date() == current_visible_date)
+        .filter_map(|e| {
+            let col = *field_col_index.get(&e.field_id)?;
+            let start_min = (e.start_time.hour() as i64) * 60 + e.start_time.minute() as i64;
+            let dur = (e.end_time - e.start_time).num_minutes().max(1);
+            Some((
+                e.id.clone(),
+                (
+                    e.schedule_type.clone().unwrap_or_else(|| "STATIC".into()),
+                    e.name.clone(),
+                    start_min,
+                    dur,
+                    col,
+                ),
+            ))
+        })
+        .collect();
+
+    // Block pointerdown → start a move drag (cards stop propagation, so the
+    // container's pointerdown only ever starts create drags on empty space).
+    let on_block_drag_start: EventHandler<(String, f64, f64)> = EventHandler::new({
+        let info = drag_block_info.clone();
+        move |(id, cx, cy): (String, f64, f64)| {
+            if !editor || bulk_select_active {
+                return;
+            }
+            // Any fresh press clears a stale click-suppression flag (e.g. after a
+            // drag that released over empty space, where no click ever fired).
+            if suppress_next_click.peek().to_owned() {
+                suppress_next_click.set(false);
+            }
+            let Some((st, name, start_min, dur, col)) = info.get(&id).cloned() else {
+                return;
+            };
+            if st == "JOIN" {
+                return;
+            }
+            let Some((_, ptr_min)) = grid_pos_from_client(cx, cy, num_fields_total) else {
+                return;
+            };
+            drag_state.set(Some(TimelineDrag::Move {
+                id,
+                schedule_type: st,
+                name,
+                duration_min: dur,
+                grab_offset_min: ptr_min - start_min,
+                orig_col: col,
+                orig_start_min: start_min,
+                cur_col: col,
+                cur_start_min: start_min,
+                moved: false,
+            }));
+        }
+    });
+
+    // Card hover → track hovered block + Alt state for the dependency view.
+    let on_block_hover: EventHandler<(String, bool, bool)> =
+        EventHandler::new(move |(id, entered, alt): (String, bool, bool)| {
+            if entered {
+                hovered_block.set(Some(id));
+            } else if hovered_block.peek().as_deref() == Some(id.as_str()) {
+                hovered_block.set(None);
+            }
+            if *alt_down.peek() != alt {
+                alt_down.set(alt);
+            }
+        });
+
+    // Swallow the click that follows a completed move drag so it doesn't open
+    // the edit modal.
+    let wrapped_on_edit: EventHandler<String> = EventHandler::new(move |id: String| {
+        if suppress_next_click() {
+            suppress_next_click.set(false);
+            return;
+        }
+        on_edit_match.call(id);
+    });
+
+    // Alt-hover dependency edges for the hovered block: (from, to, kind)
+    // kind: 0 = chain (previous_match), 1 = team1 result, 2 = team2 result, 3 = ref result.
+    let dep_edges: Vec<(String, String, u8)> = if editor && alt_down() {
+        if let Some(hid) = hovered_block() {
+            let name_to_uuid: HashMap<&str, &str> = data
+                .matches
+                .iter()
+                .filter(|m| !is_structural_match(m))
+                .map(|m| (m.name.as_str(), m.uuid.as_str()))
+                .collect();
+            let mut edges: Vec<(String, String, u8)> = Vec::new();
+            if let Some(m) = data.matches.iter().find(|m| m.uuid == hid) {
+                if let Some(prev) = m.previous_match.as_deref() {
+                    if !prev.is_empty() {
+                        edges.push((hid.clone(), prev.to_string(), 0));
+                    }
+                }
+                for (tok, kind) in [(m.team1_initial.as_deref(), 1u8), (m.team2_initial.as_deref(), 2u8)] {
+                    if let Some(name) = tok.and_then(ref_token_match_name) {
+                        if let Some(&uuid) = name_to_uuid.get(name) {
+                            edges.push((hid.clone(), uuid.to_string(), kind));
+                        }
+                    }
+                }
+                for tok in m.refs_initial.as_deref().unwrap_or("").split(',') {
+                    if let Some(name) = ref_token_match_name(tok) {
+                        if let Some(&uuid) = name_to_uuid.get(name) {
+                            edges.push((hid.clone(), uuid.to_string(), 3));
+                        }
+                    }
+                }
+            }
+            edges
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    };
+    // Highlight classes for dependency targets (and the hovered source).
+    let dep_class_map: HashMap<String, &'static str> = {
+        let mut map = HashMap::new();
+        if !dep_edges.is_empty() {
+            for (from, to, kind) in &dep_edges {
+                map.insert(from.clone(), "schedule-timeline-event--dep-source");
+                let class = match kind {
+                    0 => "schedule-timeline-event--dep-chain",
+                    1 | 2 => "schedule-timeline-event--dep-team",
+                    _ => "schedule-timeline-event--dep-ref",
+                };
+                // Chain highlight wins if a block is referenced multiple ways.
+                map.entry(to.clone()).or_insert(class);
+            }
+        }
+        map
+    };
+
+    // Ghost placement for the in-flight drag:
+    // (col, start_min, duration_min, title, sub_label, blocked, prev_gap_line: Option<(col, min)>)
+    #[allow(clippy::type_complexity)]
+    let ghost_render: Option<(usize, i64, i64, String, String, bool, Option<(usize, i64)>)> =
+        if editor {
+            match drag_state() {
+                Some(TimelineDrag::Create {
+                    col,
+                    anchor_min,
+                    cur_min,
+                }) => {
+                    let start = anchor_min.min(cur_min);
+                    let dur = (anchor_min - cur_min).abs().max(10);
+                    let title =
+                        format!("{} – {}", fmt_minutes(start), fmt_minutes(start + dur));
+                    Some((col, start, dur, title, "new match".to_string(), false, None))
+                }
+                Some(TimelineDrag::Move {
+                    ref id,
+                    ref schedule_type,
+                    duration_min,
+                    cur_col,
+                    cur_start_min,
+                    moved,
+                    ..
+                }) if moved => {
+                    let field_name = field_names.get(cur_col).cloned().unwrap_or_default();
+                    if matches!(schedule_type.as_str(), "STATIC" | "STATBREAK") {
+                        // Static blocks place freely (5-min snapped).
+                        let title = format!(
+                            "{} – {}",
+                            fmt_minutes(cur_start_min),
+                            fmt_minutes(cur_start_min + duration_min)
+                        );
+                        Some((cur_col, cur_start_min, duration_min, title, field_name, false, None))
+                    } else {
+                        // Dynamic blocks snap to the gap after the would-be previous match.
+                        let drop_local = day_start + chrono::Duration::minutes(cur_start_min);
+                        match latest_match_before(
+                            &data.matches,
+                            &field_name,
+                            drop_local,
+                            id,
+                            show_as_happened,
+                            tz_offset_minutes,
+                        ) {
+                            Some((_, prev_name, prev_end_local)) => {
+                                let snap_min = if prev_end_local.date() == current_visible_date {
+                                    ((prev_end_local - day_start).num_minutes()).clamp(0, 24 * 60)
+                                } else {
+                                    0
+                                };
+                                let line = if prev_end_local.date() == current_visible_date {
+                                    Some((cur_col, snap_min))
+                                } else {
+                                    None
+                                };
+                                Some((
+                                    cur_col,
+                                    snap_min,
+                                    duration_min,
+                                    format!("after: {prev_name}"),
+                                    field_name,
+                                    false,
+                                    line,
+                                ))
+                            }
+                            None => Some((
+                                cur_col,
+                                cur_start_min,
+                                duration_min,
+                                "needs a previous match".to_string(),
+                                field_name,
+                                true,
+                                None,
+                            )),
+                        }
+                    }
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+    // Container pointer handlers (edit page only; touch is reserved for scroll/pinch-zoom).
+    let grid_pointer_down = {
+        move |ev: Event<PointerData>| {
+            if !editor || bulk_select_active {
+                return;
+            }
+            if ev.pointer_type() != "mouse" {
+                return;
+            }
+            if drag_state.peek().is_some() {
+                return;
+            }
+            if suppress_next_click.peek().to_owned() {
+                suppress_next_click.set(false);
+            }
+            let c = ev.client_coordinates();
+            let Some((col, min)) = grid_pos_from_client(c.x, c.y, num_fields_total) else {
+                return;
+            };
+            let snapped = snap5(min);
+            drag_state.set(Some(TimelineDrag::Create {
+                col,
+                anchor_min: snapped,
+                cur_min: snapped,
+            }));
+        }
+    };
+    let grid_pointer_move = {
+        move |ev: Event<PointerData>| {
+            if !editor {
+                return;
+            }
+            let alt = ev.modifiers().alt();
+            if *alt_down.peek() != alt {
+                alt_down.set(alt);
+            }
+            let Some(state) = drag_state.peek().clone() else {
+                return;
+            };
+            let c = ev.client_coordinates();
+            let Some((col, min)) = grid_pos_from_client(c.x, c.y, num_fields_total) else {
+                return;
+            };
+            match state {
+                TimelineDrag::Create {
+                    col: c0,
+                    anchor_min,
+                    cur_min,
+                } => {
+                    let cur = snap5(min);
+                    if cur != cur_min {
+                        drag_state.set(Some(TimelineDrag::Create {
+                            col: c0,
+                            anchor_min,
+                            cur_min: cur,
+                        }));
+                    }
+                }
+                TimelineDrag::Move {
+                    id,
+                    schedule_type,
+                    name,
+                    duration_min,
+                    grab_offset_min,
+                    orig_col,
+                    orig_start_min,
+                    cur_col,
+                    cur_start_min,
+                    moved,
+                } => {
+                    let new_start =
+                        snap5(min - grab_offset_min).clamp(0, 24 * 60 - duration_min.min(24 * 60));
+                    let new_moved = moved || new_start != orig_start_min || col != orig_col;
+                    if new_start != cur_start_min || col != cur_col || new_moved != moved {
+                        drag_state.set(Some(TimelineDrag::Move {
+                            id,
+                            schedule_type,
+                            name,
+                            duration_min,
+                            grab_offset_min,
+                            orig_col,
+                            orig_start_min,
+                            cur_col: col,
+                            cur_start_min: new_start,
+                            moved: new_moved,
+                        }));
+                    }
+                }
+            }
+        }
+    };
+    let grid_pointer_up = {
+        let matches_for_drop = data.matches.clone();
+        let field_names_for_drop = field_names.clone();
+        move |_ev: Event<PointerData>| {
+            let Some(state) = drag_state.peek().clone() else {
+                return;
+            };
+            drag_state.set(None);
+            match state {
+                TimelineDrag::Create {
+                    col,
+                    anchor_min,
+                    cur_min,
+                } => {
+                    let start = anchor_min.min(cur_min);
+                    let extent = (anchor_min - cur_min).abs();
+                    let Some(field_name) = field_names_for_drop.get(col).cloned() else {
+                        return;
+                    };
+                    let start_local = day_start + chrono::Duration::minutes(start);
+                    // Plain click (no drag) = default length; otherwise min 10 minutes.
+                    let length_min = if extent == 0 {
+                        None
+                    } else {
+                        Some(extent.max(10) as u32)
+                    };
+                    let prev_match_id = latest_match_before(
+                        &matches_for_drop,
+                        &field_name,
+                        start_local,
+                        "",
+                        show_as_happened,
+                        tz_offset_minutes,
+                    )
+                    .map(|(u, _, _)| u);
+                    on_drag_create.call(DragCreatePayload {
+                        field_name,
+                        start_local,
+                        length_min,
+                        prev_match_id,
+                    });
+                }
+                TimelineDrag::Move {
+                    id,
+                    schedule_type,
+                    name,
+                    cur_col,
+                    cur_start_min,
+                    orig_col,
+                    orig_start_min,
+                    moved,
+                    ..
+                } => {
+                    if !moved || (cur_col == orig_col && cur_start_min == orig_start_min) {
+                        // Plain click: let the block's own click handler open the modal.
+                        return;
+                    }
+                    suppress_next_click.set(true);
+                    let Some(field_name) = field_names_for_drop.get(cur_col).cloned() else {
+                        return;
+                    };
+                    let start_local = day_start + chrono::Duration::minutes(cur_start_min);
+                    if matches!(schedule_type.as_str(), "STATIC" | "STATBREAK") {
+                        let start_utc = start_local - chrono::Duration::minutes(tz_offset_minutes);
+                        on_move_match.call(MoveCommitPayload {
+                            match_id: id,
+                            schedule_type,
+                            group_name: name,
+                            new_field: Some(field_name),
+                            new_start_utc: Some(
+                                start_utc.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+                            ),
+                            new_prev_id: None,
+                        });
+                    } else {
+                        let new_prev_id = latest_match_before(
+                            &matches_for_drop,
+                            &field_name,
+                            start_local,
+                            &id,
+                            show_as_happened,
+                            tz_offset_minutes,
+                        )
+                        .map(|(u, _, _)| u);
+                        on_move_match.call(MoveCommitPayload {
+                            match_id: id,
+                            schedule_type,
+                            group_name: name,
+                            new_field: Some(field_name),
+                            new_start_utc: None,
+                            new_prev_id,
+                        });
+                    }
+                }
+            }
+        }
+    };
+    let grid_pointer_cancel = move |_ev: Event<PointerData>| {
+        if drag_state.peek().is_some() {
+            drag_state.set(None);
+        }
+    };
+
     rsx! {
         div { class: "schedule-timeline-wrapper", id: "schedule-timeline-wrapper",
             div { class: "schedule-timeline-nav",
@@ -4740,6 +5744,14 @@ fn ScheduleTimeline(
                     class: if team_view { "schedule-timeline schedule-timeline--team-view" } else { "schedule-timeline" },
                     // Important: this is the positioning container for join overlays.
                     style: "position: relative; --num-fields: {visible_fields.len()}; --time-col-width: {TIME_COL_WIDTH_PX}px; --slot-height: {slot_height_rem}rem;",
+                    // Edit page: drag-to-create on empty grid space, drag-to-move ghosts.
+                    // Blocks stop pointerdown propagation, so a drag starting here is
+                    // always on empty space. Touch pointers are ignored (pinch-zoom).
+                    onpointerdown: grid_pointer_down,
+                    onpointermove: grid_pointer_move,
+                    onpointerup: grid_pointer_up,
+                    onpointerleave: grid_pointer_cancel,
+                    onpointercancel: grid_pointer_cancel,
                     // Now line across the grid when viewing today (#196)
                     if let Some(style) = now_line_style.clone() {
                         div {
@@ -4782,6 +5794,8 @@ fn ScheduleTimeline(
                                                             if edit_mode {
                                                                 div {
                                                                     class: "schedule-timeline-join-label",
+                                                                    // Don't let a click on the join label start a create drag.
+                                                                    onpointerdown: move |ev: Event<PointerData>| ev.stop_propagation(),
                                                                     onclick: move |_| on_edit_match.call(match_id.clone()),
                                                                     "{join_name}"
                                                                 }
@@ -4806,6 +5820,9 @@ fn ScheduleTimeline(
                         .enumerate()
                         .map(|(i, f)| (f.id, i))
                         .collect();
+                    // Geometry per visible block: (left%, width%, top slots, height slots).
+                    // Reused by the dependency-line SVG below.
+                    let mut geom_by_id: HashMap<String, (f64, f64, f64, f64)> = HashMap::new();
                     let overlay_events: Vec<(TimelineEvent, String)> = timeline_events
                         .iter()
                         .filter(|e| e.start_time.date() == current_visible_date)
@@ -4828,6 +5845,7 @@ fn ScheduleTimeline(
                             let col_w = 100.0 / num_fields as f64;
                             let left = col as f64 * col_w + (lane_l / 100.0) * col_w;
                             let width = (lane_w / 100.0) * col_w;
+                            geom_by_id.insert(e.id.clone(), (left, width, start_slots, duration_slots));
                             let is_structural = is_structural_type(e.schedule_type.as_deref());
                             let bg = if is_structural { "#f1f3f5" } else { "#ffffff" };
                             let style = format!(
@@ -4839,11 +5857,63 @@ fn ScheduleTimeline(
                             Some((e.clone(), style))
                         })
                         .collect();
+                    // Dependency lines: only edges whose target is visible in the current day/filter.
+                    // Endpoints in overlay percentages (x: both axes % of the layer box).
+                    let dep_lines: Vec<(f64, f64, f64, f64, u8)> = dep_edges
+                        .iter()
+                        .filter_map(|(from, to, kind)| {
+                            let (fl, fw, ft, fh) = *geom_by_id.get(from)?;
+                            let (tl, tw, tt, th) = *geom_by_id.get(to)?;
+                            let fx = fl + fw / 2.0;
+                            let tx = tl + tw / 2.0;
+                            let fcy = (ft + fh / 2.0) / slots_per_day as f64 * 100.0;
+                            let tcy = (tt + th / 2.0) / slots_per_day as f64 * 100.0;
+                            // Connect edge midpoints: top edge of the lower block to the
+                            // bottom edge of the upper block.
+                            let (fy, ty) = if tcy < fcy {
+                                (
+                                    ft / slots_per_day as f64 * 100.0,
+                                    (tt + th) / slots_per_day as f64 * 100.0,
+                                )
+                            } else {
+                                (
+                                    (ft + fh) / slots_per_day as f64 * 100.0,
+                                    tt / slots_per_day as f64 * 100.0,
+                                )
+                            };
+                            Some((fx, fy, tx, ty, *kind))
+                        })
+                        .collect();
+                    let dep_lines_active = !dep_lines.is_empty();
+                    // Ghost block + snap-gap indicator for the in-flight drag.
+                    let ghost_block = ghost_render.as_ref().map(
+                        |(col, start_min, dur_min, title, sub, blocked, gap_line)| {
+                            let col_w = 100.0 / num_fields as f64;
+                            let left = *col as f64 * col_w;
+                            let top_slots = *start_min as f64 / SLOT_MINUTES as f64;
+                            let height_slots = *dur_min as f64 / SLOT_MINUTES as f64;
+                            let style = format!(
+                                "left: calc({left}% + 1px); width: calc({col_w}% - 2px); \
+                                 top: calc(var(--slot-height) * {top_slots}); \
+                                 height: calc(var(--slot-height) * {height_slots});"
+                            );
+                            let gap_style = gap_line.map(|(gcol, gmin)| {
+                                let gleft = gcol as f64 * col_w;
+                                let gtop = gmin as f64 / SLOT_MINUTES as f64;
+                                format!(
+                                    "left: calc({gleft}% + 1px); width: calc({col_w}% - 2px); \
+                                     top: calc(var(--slot-height) * {gtop});"
+                                )
+                            });
+                            (style, title.clone(), sub.clone(), *blocked, gap_style)
+                        },
+                    );
                     let base_url = base_url.clone();
                     let tournament_url = tournament_url.clone();
                     rsx! {
                         div {
                             class: "schedule-timeline-events-layer",
+                            id: "schedule-timeline-events-layer",
                             style: format!(
                                 "position: absolute; left: var(--time-col-width); right: 0; \
                                  top: var(--header-height); \
@@ -4855,13 +5925,82 @@ fn ScheduleTimeline(
                                 div {
                                     style: "pointer-events: auto;",
                                     TimelineEventCard {
-                                        event: ev,
+                                        event: ev.clone(),
                                         event_style: style,
                                         team_view: team_view,
                                         edit_mode: edit_mode,
                                         tournament_url: tournament_url.clone(),
                                         base_url: base_url.clone(),
-                                        on_edit_match: on_edit_match,
+                                        on_edit_match: wrapped_on_edit,
+                                        editor: editor,
+                                        selected: selected_ids.contains(&ev.id),
+                                        dep_class: dep_class_map.get(&ev.id).map(|c| c.to_string()),
+                                        on_move_pointer_down: on_block_drag_start,
+                                        on_hover: on_block_hover,
+                                    }
+                                }
+                            }
+                            if let Some((ghost_style, ghost_title, ghost_sub, ghost_blocked, gap_style)) = ghost_block {
+                                if let Some(gs) = gap_style {
+                                    div { class: "schedule-drag-gap-line", style: "{gs}" }
+                                }
+                                div {
+                                    class: if ghost_blocked { "schedule-drag-ghost schedule-drag-ghost--blocked" } else { "schedule-drag-ghost" },
+                                    style: "{ghost_style}",
+                                    div { class: "schedule-drag-ghost-title", "{ghost_title}" }
+                                    div { class: "schedule-drag-ghost-sub", "{ghost_sub}" }
+                                }
+                            }
+                            if dep_lines_active {
+                                svg {
+                                    class: "schedule-dep-lines",
+                                    style: "position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; z-index: 30; overflow: visible;",
+                                    for (i, (x1, y1, x2, y2, kind)) in dep_lines.iter().enumerate() {
+                                        g {
+                                            key: "{i}",
+                                        line {
+                                            x1: "{x1}%",
+                                            y1: "{y1}%",
+                                            x2: "{x2}%",
+                                            y2: "{y2}%",
+                                            stroke: match kind {
+                                                0 => "#0d6efd",
+                                                1 | 2 => "#d63384",
+                                                _ => "#fd7e14",
+                                            },
+                                            stroke_width: "2.5",
+                                            stroke_dasharray: match kind {
+                                                0 => "none",
+                                                1 => "none",
+                                                2 => "7 4",
+                                                _ => "3 3",
+                                            },
+                                        }
+                                        circle {
+                                            cx: "{x2}%",
+                                            cy: "{y2}%",
+                                            r: "3.5",
+                                            fill: match kind {
+                                                0 => "#0d6efd",
+                                                1 | 2 => "#d63384",
+                                                _ => "#fd7e14",
+                                            },
+                                        }
+                                        }
+                                    }
+                                }
+                                div { class: "schedule-dep-legend",
+                                    span { class: "schedule-dep-legend-item",
+                                        span { class: "schedule-dep-legend-swatch", style: "background:#0d6efd;" }
+                                        "previous match"
+                                    }
+                                    span { class: "schedule-dep-legend-item",
+                                        span { class: "schedule-dep-legend-swatch", style: "background:#d63384;" }
+                                        "team result (dashed = team 2)"
+                                    }
+                                    span { class: "schedule-dep-legend-item",
+                                        span { class: "schedule-dep-legend-swatch", style: "background:#fd7e14;" }
+                                        "ref result"
                                     }
                                 }
                             }

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -480,13 +480,16 @@ pub(crate) struct DragCreatePayload {
 }
 
 /// Placeholder block shown on the editor timeline while the create card is
-/// open: mirrors the card's field / start-time / length values so the user can
-/// see where the new match will land. Cleared on save or cancel.
+/// open: mirrors the card's field(s) / start-time / length values so the user
+/// can see where the new match will land. Break/join group forms list every
+/// checked field (one placeholder per field). Cleared on save or cancel.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct PendingCreateGhost {
-    field_name: String,
+    field_names: Vec<String>,
     start_local: chrono::NaiveDateTime,
     length_min: i64,
+    /// JOIN groups render as a thin line-like placeholder, not a block.
+    is_join: bool,
 }
 
 /// Payload emitted by the edit-page timeline when a drag-to-move gesture commits.
@@ -1173,7 +1176,7 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                             div {
                                                 class: "d-flex align-items-center gap-1 ms-1",
                                                 title: "Schedule type new matches start with (click or drag on the schedule to create one)",
-                                                label { class: "small text-muted mb-0", r#for: "defaultMatchTypeSelect", "New match type" }
+                                                label { class: "small text-muted mb-0", r#for: "defaultMatchTypeSelect", "Default new match type" }
                                                 select {
                                                     id: "defaultMatchTypeSelect",
                                                     class: "form-select form-select-sm w-auto",
@@ -1182,6 +1185,9 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                                     option { value: "STATIC", "Static" }
                                                     option { value: "SAFE", "Safe" }
                                                     option { value: "FAST", "Fast" }
+                                                    option { value: "BREAK", "Break" }
+                                                    option { value: "STATBREAK", "Static Break" }
+                                                    option { value: "JOIN", "Join" }
                                                 }
                                             }
                                             button { class: "btn btn-sm btn-outline-secondary", onclick: move |_| {
@@ -1249,7 +1255,7 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                                         bulk_selected.set(Vec::new());
                                                     }
                                                 },
-                                                "Bulk length"
+                                                "Bulk change length"
                                             }
                                             div {
                                                 class: "form-check form-switch mb-0 ms-1",
@@ -1756,7 +1762,8 @@ fn CreateMatchModal(
     /// Drag-to-create prefill: chain-position default for dynamic types.
     #[props(default)]
     prefill_prev_match_id: Option<String>,
-    /// Toolbar "New match type" default (STATIC/SAFE/FAST).
+    /// Toolbar "Default new match type" (any schedule type; structural types
+    /// open the card in the corresponding group form).
     #[props(default)]
     default_schedule_type: Option<String>,
     /// Page-level "show times as they happened" toggle (for previous-match lookup).
@@ -1777,7 +1784,12 @@ fn CreateMatchModal(
     });
     let initial_type = default_schedule_type
         .clone()
-        .filter(|t| matches!(t.as_str(), "STATIC" | "SAFE" | "FAST"))
+        .filter(|t| {
+            matches!(
+                t.as_str(),
+                "STATIC" | "SAFE" | "FAST" | "BREAK" | "STATBREAK" | "JOIN"
+            )
+        })
         .unwrap_or_else(|| "STATIC".to_string());
     let schedule_type = use_signal({
         let t = initial_type.clone();
@@ -1818,26 +1830,30 @@ fn CreateMatchModal(
     let mut saving = use_signal(|| false);
 
     // Keep the timeline's pending-create placeholder in sync with the card's
-    // field / start-time / length. Cleared by the page on save/cancel.
+    // field(s) / start-time / length. Group forms (break/join) place one
+    // placeholder on every checked field. Cleared by the page on save/cancel.
     {
         let mut create_ghost = create_ghost;
         use_effect(move || {
             let st = schedule_type();
-            let field_name = if matches!(st.as_str(), "BREAK" | "STATBREAK" | "JOIN") {
-                break_fields().first().cloned().unwrap_or_default()
+            let is_group = matches!(st.as_str(), "BREAK" | "STATBREAK" | "JOIN");
+            let field_names: Vec<String> = if is_group {
+                break_fields()
             } else {
-                field()
+                let f = field();
+                if f.is_empty() { Vec::new() } else { vec![f] }
             };
             let parsed = chrono::NaiveDateTime::parse_from_str(
                 start_time().trim(),
                 "%Y-%m-%dT%H:%M",
             )
             .ok();
-            let next = match (field_name.is_empty(), parsed) {
+            let next = match (field_names.is_empty(), parsed) {
                 (false, Some(start_local)) => Some(PendingCreateGhost {
-                    field_name,
+                    field_names,
                     start_local,
                     length_min: (length() as i64).max(10),
+                    is_join: st == "JOIN",
                 }),
                 _ => None,
             };
@@ -4111,8 +4127,9 @@ fn TimelineEventCard(
     /// Alt-hover dependency highlight class (source / chain / team / ref).
     #[props(default)]
     dep_class: Option<String>,
-    /// Alt-hover: nested outline rings for the hovered source block (one ring
-    /// per dependency edge, colored like its line). Inline `box-shadow: …;`.
+    /// Alt-hover: nested outline rings (one per edge touching this block —
+    /// outgoing for the hovered source, incoming for dependency targets),
+    /// colored like the lines. Inline `box-shadow: …;`.
     #[props(default)]
     dep_shadow: Option<String>,
     /// Pointerdown on the block (id, client_x, client_y) → may start a move drag.
@@ -4533,6 +4550,168 @@ fn ref_token_match_name(token: &str) -> Option<&str> {
         .map(str::trim)
 }
 
+/// Line color for a dependency edge kind
+/// (0 = chain / previous match, 1 = team1 result, 2 = team2 result, _ = ref result).
+fn dep_edge_color(kind: u8) -> &'static str {
+    match kind {
+        0 => "#0d6efd",
+        1 | 2 => "#d63384",
+        _ => "#fd7e14",
+    }
+}
+
+/// Stacked outline rings for a block in the alt-dependency view: one 3px ring
+/// per edge (in order), colored like its line, with 1px translucent-white
+/// separators so adjacent same-color rings stay countable. Returns an inline
+/// `box-shadow: …;` declaration.
+fn dep_ring_shadow(kinds: &[u8]) -> String {
+    let shadows: Vec<String> = kinds
+        .iter()
+        .enumerate()
+        .map(|(i, kind)| {
+            let inner = (i as u32) * 4;
+            format!(
+                "0 0 0 {}px {}, 0 0 0 {}px rgba(255,255,255,0.9)",
+                inner + 3,
+                dep_edge_color(*kind),
+                inner + 4
+            )
+        })
+        .collect();
+    format!("box-shadow: {};", shadows.join(", "))
+}
+
+/// Block geometry in the events-layer coordinate space, as produced by the
+/// overlay layout: `left`/`width` are lane-adjusted percentages of the layer
+/// width; `top`/`height` are in slot units (percent-of-height = slots /
+/// slots_per_day * 100). Both the block styles and the dependency lines are
+/// derived from the same values, so endpoints land exactly on block edges.
+/// (The blocks' cosmetic ±1px horizontal inset cancels out at the midpoint:
+/// (left+1px) + (width−2px)/2 == left + width/2.)
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct DepBlockGeom {
+    /// Lane-adjusted left edge, % of layer width.
+    left: f64,
+    /// Lane-adjusted width, % of layer width.
+    width: f64,
+    /// Top edge in slot units.
+    top_slots: f64,
+    /// Height in slot units.
+    height_slots: f64,
+}
+
+/// Endpoints for the `index`-th of `n_lines` visible dependency lines leaving
+/// the hovered block `from` toward `to`, in events-layer percentages
+/// (x: % of width, y: % of height).
+///
+/// - The line leaves the vertical edge of `from` facing `to` (top edge if the
+///   target's center is above, else bottom edge) and arrives at the opposing
+///   edge of `to`, both at the blocks' horizontal midpoints.
+/// - When several lines leave the hovered block, their origins fan out around
+///   its midpoint in ~0.6%-of-layer steps, clamped so the whole fan stays
+///   within the middle 80% of the block's width. `index`/`n_lines` must count
+///   only *visible* lines, otherwise a lone line gets a spurious offset.
+fn dep_line_endpoints(
+    index: usize,
+    n_lines: usize,
+    from: DepBlockGeom,
+    to: DepBlockGeom,
+    slots_per_day: usize,
+) -> (f64, f64, f64, f64) {
+    let step = if n_lines > 1 {
+        (0.6_f64).min(from.width * 0.8 / (n_lines as f64 - 1.0))
+    } else {
+        0.0
+    };
+    let offset = (index as f64 - (n_lines as f64 - 1.0) / 2.0) * step;
+    let fx = from.left + from.width / 2.0 + offset;
+    let tx = to.left + to.width / 2.0;
+    let slot_pct = |slots: f64| slots / slots_per_day as f64 * 100.0;
+    let fcy = slot_pct(from.top_slots + from.height_slots / 2.0);
+    let tcy = slot_pct(to.top_slots + to.height_slots / 2.0);
+    let (fy, ty) = if tcy < fcy {
+        // Target above: leave from the top edge, arrive at the target's bottom.
+        (
+            slot_pct(from.top_slots),
+            slot_pct(to.top_slots + to.height_slots),
+        )
+    } else {
+        (
+            slot_pct(from.top_slots + from.height_slots),
+            slot_pct(to.top_slots),
+        )
+    };
+    (fx, fy, tx, ty)
+}
+
+#[cfg(test)]
+mod dep_geometry_tests {
+    use super::*;
+
+    const SLOTS: usize = 48; // 24h of 30-min slots
+
+    fn geom(left: f64, width: f64, top_slots: f64, height_slots: f64) -> DepBlockGeom {
+        DepBlockGeom {
+            left,
+            width,
+            top_slots,
+            height_slots,
+        }
+    }
+
+    #[test]
+    fn single_line_starts_at_block_edge_midpoint() {
+        // Hovered block: second of four field columns (25% wide), 10:00–11:00.
+        let from = geom(25.0, 25.0, 20.0, 2.0);
+        // Target above it, first column, 08:00–09:00.
+        let to = geom(0.0, 25.0, 16.0, 2.0);
+        let (fx, fy, tx, ty) = dep_line_endpoints(0, 1, from, to, SLOTS);
+        assert_eq!(fx, 25.0 + 12.5); // exact horizontal midpoint, no fan offset
+        assert_eq!(fy, 20.0 / 48.0 * 100.0); // top edge (target is above)
+        assert_eq!(tx, 12.5);
+        assert_eq!(ty, (16.0 + 2.0) / 48.0 * 100.0); // target bottom edge
+    }
+
+    #[test]
+    fn single_line_respects_lane_inset() {
+        // Hovered block in the right lane of a two-lane column: lane-adjusted
+        // left/width, so the midpoint is the lane's center, not the column's.
+        let from = geom(37.5, 12.5, 20.0, 2.0);
+        let to = geom(0.0, 25.0, 30.0, 2.0);
+        let (fx, fy, _, ty) = dep_line_endpoints(0, 1, from, to, SLOTS);
+        assert_eq!(fx, 37.5 + 6.25);
+        assert_eq!(fy, (20.0 + 2.0) / 48.0 * 100.0); // bottom edge (target below)
+        assert_eq!(ty, 30.0 / 48.0 * 100.0);
+    }
+
+    #[test]
+    fn fan_is_centered_and_stays_inside_block() {
+        let from = geom(0.0, 25.0, 20.0, 2.0);
+        let to = geom(50.0, 25.0, 16.0, 2.0);
+        let n = 3;
+        let xs: Vec<f64> = (0..n)
+            .map(|i| dep_line_endpoints(i, n, from, to, SLOTS).0)
+            .collect();
+        // Centered on the midpoint, symmetric, evenly spaced.
+        assert_eq!(xs[1], 12.5);
+        assert!((xs[1] - xs[0] - (xs[2] - xs[1])).abs() < 1e-9);
+        // Whole fan within the block's width.
+        assert!(xs[0] > 0.0 && xs[2] < 25.0);
+    }
+
+    #[test]
+    fn ring_shadow_one_ring_per_edge_in_order() {
+        let css = dep_ring_shadow(&[0, 1, 3]);
+        assert!(css.starts_with("box-shadow: "));
+        assert_eq!(css.matches("rgba(255,255,255,0.9)").count(), 3);
+        // Ring order (inner→outer) follows edge order; colors match the lines.
+        let chain = css.find("#0d6efd").unwrap();
+        let team = css.find("#d63384").unwrap();
+        let refc = css.find("#fd7e14").unwrap();
+        assert!(chain < team && team < refc);
+    }
+}
+
 #[component]
 fn ScheduleTimeline(
     data: ScheduleSetupResponse,
@@ -4712,14 +4891,33 @@ fn ScheduleTimeline(
                         alt_sig_up.set(false);
                     }
                 }) as Box<dyn FnMut(_)>);
+                // Window blur (e.g. Alt+Tab away): the Alt keyup never arrives, so
+                // reset the whole alt-hover state or the rings/lines stay stuck.
+                let mut alt_sig_blur = alt_down;
+                let mut hovered_blur = hovered_block;
+                let alive_blur = alive.clone();
+                let on_blur = Closure::wrap(Box::new(move |_e: web_sys::FocusEvent| {
+                    if !alive_blur.get() {
+                        return;
+                    }
+                    if *alt_sig_blur.peek() {
+                        alt_sig_blur.set(false);
+                    }
+                    if hovered_blur.peek().is_some() {
+                        hovered_blur.set(None);
+                    }
+                }) as Box<dyn FnMut(_)>);
                 let _ = window.add_event_listener_with_callback(
                     "keydown",
                     on_down.as_ref().unchecked_ref(),
                 );
                 let _ = window
                     .add_event_listener_with_callback("keyup", on_up.as_ref().unchecked_ref());
+                let _ = window
+                    .add_event_listener_with_callback("blur", on_blur.as_ref().unchecked_ref());
                 on_down.forget();
                 on_up.forget();
+                on_blur.forget();
             }
         });
     }
@@ -5476,31 +5674,20 @@ fn ScheduleTimeline(
         }
         map
     };
-    // Nested outline rings on the hovered block: one ring per dependency edge,
-    // colored like its line (3px ring + 1px white separator each), so the
-    // number of dependencies is countable at a glance.
-    let dep_source_shadow: Option<String> = if dep_edges.is_empty() {
-        None
-    } else {
-        let shadows: Vec<String> = dep_edges
-            .iter()
-            .enumerate()
-            .map(|(i, (_, _, kind))| {
-                let color = match kind {
-                    0 => "#0d6efd",
-                    1 | 2 => "#d63384",
-                    _ => "#fd7e14",
-                };
-                let inner = (i as u32) * 4;
-                format!(
-                    "0 0 0 {}px {}, 0 0 0 {}px rgba(255,255,255,0.9)",
-                    inner + 3,
-                    color,
-                    inner + 4
-                )
-            })
-            .collect();
-        Some(format!("box-shadow: {};", shadows.join(", ")))
+    // Nested outline rings, one ring per edge, colored like its line: the
+    // hovered source gets a ring per OUTGOING edge, and every dependency
+    // target gets a ring per INCOMING edge from the hovered match (e.g. a
+    // match used as `A::winner` team and `A::loser` ref shows two rings on A).
+    let dep_shadow_by_id: HashMap<String, String> = {
+        let mut kinds_by_id: HashMap<String, Vec<u8>> = HashMap::new();
+        for (from, to, kind) in &dep_edges {
+            kinds_by_id.entry(from.clone()).or_default().push(*kind);
+            kinds_by_id.entry(to.clone()).or_default().push(*kind);
+        }
+        kinds_by_id
+            .into_iter()
+            .map(|(id, kinds)| (id, dep_ring_shadow(&kinds)))
+            .collect()
     };
 
     // Ghost placement for the in-flight drag:
@@ -6090,43 +6277,46 @@ fn ScheduleTimeline(
                             Some((e.clone(), style))
                         })
                         .collect();
-                    // Dependency lines: only edges whose target is visible in the current day/filter.
-                    // Endpoints in overlay percentages (x: both axes % of the layer box).
-                    // At the hovered block, parallel edges fan out with small lateral
-                    // offsets along its edge instead of stacking on the midpoint.
-                    let n_dep_edges = dep_edges.len();
-                    let dep_lines: Vec<(f64, f64, f64, f64, u8)> = dep_edges
+                    // Dependency lines: only edges whose BOTH endpoints are visible in
+                    // the current day/filter. Filter first, then assign fan offsets by
+                    // the index among visible lines — indexing over all edges gave a
+                    // lone visible line a spurious offset whenever a sibling edge's
+                    // target was hidden (other day / other field filter).
+                    let visible_dep_edges: Vec<(DepBlockGeom, DepBlockGeom, u8)> = dep_edges
                         .iter()
-                        .enumerate()
-                        .filter_map(|(i, (from, to, kind))| {
+                        .filter_map(|(from, to, kind)| {
                             let (fl, fw, ft, fh) = *geom_by_id.get(from)?;
                             let (tl, tw, tt, th) = *geom_by_id.get(to)?;
-                            // ~0.6% of the layer width (a few px) per edge, clamped so
-                            // the fan stays within the hovered block's width.
-                            let step = if n_dep_edges > 1 {
-                                (0.6_f64).min(fw * 0.8 / (n_dep_edges as f64 - 1.0))
-                            } else {
-                                0.0
-                            };
-                            let offset = (i as f64 - (n_dep_edges as f64 - 1.0) / 2.0) * step;
-                            let fx = fl + fw / 2.0 + offset;
-                            let tx = tl + tw / 2.0;
-                            let fcy = (ft + fh / 2.0) / slots_per_day as f64 * 100.0;
-                            let tcy = (tt + th / 2.0) / slots_per_day as f64 * 100.0;
-                            // Connect edge midpoints: top edge of the lower block to the
-                            // bottom edge of the upper block.
-                            let (fy, ty) = if tcy < fcy {
-                                (
-                                    ft / slots_per_day as f64 * 100.0,
-                                    (tt + th) / slots_per_day as f64 * 100.0,
-                                )
-                            } else {
-                                (
-                                    (ft + fh) / slots_per_day as f64 * 100.0,
-                                    tt / slots_per_day as f64 * 100.0,
-                                )
-                            };
-                            Some((fx, fy, tx, ty, *kind))
+                            Some((
+                                DepBlockGeom {
+                                    left: fl,
+                                    width: fw,
+                                    top_slots: ft,
+                                    height_slots: fh,
+                                },
+                                DepBlockGeom {
+                                    left: tl,
+                                    width: tw,
+                                    top_slots: tt,
+                                    height_slots: th,
+                                },
+                                *kind,
+                            ))
+                        })
+                        .collect();
+                    let n_dep_lines = visible_dep_edges.len();
+                    let dep_lines: Vec<(f64, f64, f64, f64, u8)> = visible_dep_edges
+                        .iter()
+                        .enumerate()
+                        .map(|(i, (from_geom, to_geom, kind))| {
+                            let (fx, fy, tx, ty) = dep_line_endpoints(
+                                i,
+                                n_dep_lines,
+                                *from_geom,
+                                *to_geom,
+                                slots_per_day,
+                            );
+                            (fx, fy, tx, ty, *kind)
                         })
                         .collect();
                     let dep_lines_active = !dep_lines.is_empty();
@@ -6153,29 +6343,60 @@ fn ScheduleTimeline(
                             (style, title.clone(), sub.clone(), *blocked, gap_style)
                         },
                     );
-                    // Pending-create placeholder: mirrors the open create card's
-                    // field/start/length so the drag target stays visible.
-                    let pending_block = pending_create.as_ref().and_then(|g| {
-                        if g.start_local.date() != current_visible_date {
-                            return None;
-                        }
-                        let col = field_names.iter().position(|n| n == &g.field_name)?;
-                        let col_w = 100.0 / num_fields as f64;
-                        let left = col as f64 * col_w;
-                        let start_min =
-                            (g.start_local.hour() as i64) * 60 + g.start_local.minute() as i64;
-                        let dur = g.length_min.max(10);
-                        let top_slots = start_min as f64 / SLOT_MINUTES as f64;
-                        let height_slots = dur as f64 / SLOT_MINUTES as f64;
-                        let style = format!(
-                            "left: calc({left}% + 1px); width: calc({col_w}% - 2px); \
-                             top: calc(var(--slot-height) * {top_slots}); \
-                             height: calc(var(--slot-height) * {height_slots});"
-                        );
-                        let title =
-                            format!("{} – {}", fmt_minutes(start_min), fmt_minutes(start_min + dur));
-                        Some((style, title))
-                    });
+                    // Pending-create placeholders: mirror the open create card's
+                    // field(s)/start/length so the drag target stays visible. Group
+                    // forms render one placeholder per checked field; joins render
+                    // as a thin line-like strip.
+                    let pending_blocks: Vec<(String, String, String, bool)> = pending_create
+                        .as_ref()
+                        .map(|g| {
+                            if g.start_local.date() != current_visible_date {
+                                return Vec::new();
+                            }
+                            let start_min = (g.start_local.hour() as i64) * 60
+                                + g.start_local.minute() as i64;
+                            let dur = g.length_min.max(10);
+                            let top_slots = start_min as f64 / SLOT_MINUTES as f64;
+                            let col_w = 100.0 / num_fields as f64;
+                            let (title, sub) = if g.is_join {
+                                (fmt_minutes(start_min), "new join".to_string())
+                            } else {
+                                (
+                                    format!(
+                                        "{} – {}",
+                                        fmt_minutes(start_min),
+                                        fmt_minutes(start_min + dur)
+                                    ),
+                                    "new match".to_string(),
+                                )
+                            };
+                            g.field_names
+                                .iter()
+                                .filter_map(|fname| {
+                                    let col = field_names.iter().position(|n| n == fname)?;
+                                    let left = col as f64 * col_w;
+                                    let height = if g.is_join {
+                                        // Thin strip standing in for the join line.
+                                        "height: 6px; padding: 0;".to_string()
+                                    } else {
+                                        let height_slots = dur as f64 / SLOT_MINUTES as f64;
+                                        format!(
+                                            "height: calc(var(--slot-height) * {height_slots});"
+                                        )
+                                    };
+                                    Some((
+                                        format!(
+                                            "left: calc({left}% + 1px); width: calc({col_w}% - 2px); \
+                                             top: calc(var(--slot-height) * {top_slots}); {height}"
+                                        ),
+                                        title.clone(),
+                                        sub.clone(),
+                                        g.is_join,
+                                    ))
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
                     let base_url = base_url.clone();
                     let tournament_url = tournament_url.clone();
                     rsx! {
@@ -6203,13 +6424,8 @@ fn ScheduleTimeline(
                                         editor: editor,
                                         selected: selected_ids.contains(&ev.id),
                                         dep_class: dep_class_map.get(&ev.id).map(|c| c.to_string()),
-                                        dep_shadow: if dep_class_map.get(&ev.id).copied()
-                                            == Some("schedule-timeline-event--dep-source")
-                                        {
-                                            dep_source_shadow.clone()
-                                        } else {
-                                            None
-                                        },
+                                        // Rings for the hovered source AND every dependency target.
+                                        dep_shadow: dep_shadow_by_id.get(&ev.id).cloned(),
                                         on_move_pointer_down: on_block_drag_start,
                                         on_hover: on_block_hover,
                                         result_pick_active: result_pick_active,
@@ -6217,12 +6433,16 @@ fn ScheduleTimeline(
                                     }
                                 }
                             }
-                            if let Some((pending_style, pending_title)) = pending_block {
+                            for (pi, (pending_style, pending_title, pending_sub, pending_thin)) in pending_blocks.into_iter().enumerate() {
                                 div {
+                                    key: "pending-{pi}",
                                     class: "schedule-drag-ghost schedule-drag-ghost--pending",
                                     style: "{pending_style}",
-                                    div { class: "schedule-drag-ghost-title", "{pending_title}" }
-                                    div { class: "schedule-drag-ghost-sub", "new match" }
+                                    // Join strips are too thin for inner labels.
+                                    if !pending_thin {
+                                        div { class: "schedule-drag-ghost-title", "{pending_title}" }
+                                        div { class: "schedule-drag-ghost-sub", "{pending_sub}" }
+                                    }
                                 }
                             }
                             if let Some((ghost_style, ghost_title, ghost_sub, ghost_blocked, gap_style)) = ghost_block {

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -4229,11 +4229,11 @@ fn TimelineEventCard(
     let event_id_for_enter = event.id.clone();
     let event_id_for_leave = event.id.clone();
     let can_drag = editor;
-    // Hovered dependency source: append the per-edge outline rings.
-    let event_style = match dep_shadow.as_deref() {
-        Some(shadow) => format!("{event_style} {shadow}"),
-        None => event_style.clone(),
-    };
+    // NOTE: the dependency rings are deliberately NOT merged into the block's
+    // inline style. Removing a property from a `style` string does not
+    // reliably remove it from the live DOM (the stale box-shadow survived
+    // until a full view teardown); a conditionally-rendered child element is
+    // diffed by element add/remove, which always cleans up.
     rsx! {
         div {
             class: "{event_class}",
@@ -4277,6 +4277,12 @@ fn TimelineEventCard(
                     });
                 }
             },
+            // Dependency rings: one colored ring per distinct edge this block
+            // supplies to the alt-hovered match. Rendered as a child element so
+            // mount/unmount fully controls the visual (see NOTE above rsx!).
+            if let Some(shadow) = dep_shadow.as_deref() {
+                div { class: "schedule-dep-rings", style: "{shadow}" }
+            }
             if !is_structural || editor {
                 span {
                     class: "schedule-timeline-status-tag schedule-timeline-status-tag--corner",
@@ -4605,46 +4611,36 @@ struct DepBlockGeom {
     height_slots: f64,
 }
 
-/// Fan offset for the `index`-th of `n` line endpoints sharing a block edge:
-/// centered on the midpoint, ~0.6%-of-layer steps, clamped so the whole fan
-/// stays within the middle 80% of the block's width. Counts must cover only
-/// *visible* lines, otherwise a lone line gets a spurious offset.
-fn dep_fan_offset(index: usize, n: usize, block_width: f64) -> f64 {
-    let step = if n > 1 {
-        (0.6_f64).min(block_width * 0.8 / (n as f64 - 1.0))
-    } else {
-        0.0
-    };
-    (index as f64 - (n as f64 - 1.0) / 2.0) * step
-}
-
 /// Endpoints for one dependency line, in events-layer percentages
 /// (x: % of width, y: % of height).
 ///
 /// Lines always flow supply → demand: they LEAVE the BOTTOM edge of the
 /// dependency block `dep` and ENTER the TOP edge of the hovered (dependent)
-/// block `hovered`, each at the block's horizontal midpoint plus a fan offset.
-///
-/// - `exit_index`/`n_exit`: this line's position among the visible lines
-///   leaving `dep` (fans the bottom-edge exits when one dependency supplies
-///   several distinct things).
-/// - `entry_index`/`n_entry`: this line's position among ALL visible lines
-///   entering `hovered` (fans the top-edge entries).
+/// block `hovered`, each at the block's exact horizontal midpoint. Lines that
+/// share the same (dep, hovered) pair are separated afterwards by a whole-line
+/// pixel translate (`dep_pair_dx`), not by moving the endpoints.
 fn dep_line_endpoints(
-    exit_index: usize,
-    n_exit: usize,
-    entry_index: usize,
-    n_entry: usize,
     dep: DepBlockGeom,
     hovered: DepBlockGeom,
     slots_per_day: usize,
 ) -> (f64, f64, f64, f64) {
     let slot_pct = |slots: f64| slots / slots_per_day as f64 * 100.0;
-    let x1 = dep.left + dep.width / 2.0 + dep_fan_offset(exit_index, n_exit, dep.width);
+    let x1 = dep.left + dep.width / 2.0;
     let y1 = slot_pct(dep.top_slots + dep.height_slots);
-    let x2 = hovered.left + hovered.width / 2.0 + dep_fan_offset(entry_index, n_entry, hovered.width);
+    let x2 = hovered.left + hovered.width / 2.0;
     let y2 = slot_pct(hovered.top_slots);
     (x1, y1, x2, y2)
+}
+
+/// Stroke width of the dependency lines (px).
+const DEP_LINE_STROKE: f64 = 3.75;
+
+/// Horizontal pixel translate for the `index`-th of `n` lines sharing the same
+/// (dependency, hovered) pair: lines sit RIGHT next to each other — edge to
+/// edge, like one line n× as thick colored in stripes. Applied as an SVG
+/// `translate` so the spacing is exact pixels at any layer width or zoom.
+fn dep_pair_dx(index: usize, n: usize) -> f64 {
+    (index as f64 - (n as f64 - 1.0) / 2.0) * DEP_LINE_STROKE
 }
 
 #[cfg(test)]
@@ -4668,8 +4664,8 @@ mod dep_geometry_tests {
         let dep = geom(0.0, 25.0, 16.0, 2.0);
         // Hovered block below it, second column, 10:00–11:00.
         let hovered = geom(25.0, 25.0, 20.0, 2.0);
-        let (x1, y1, x2, y2) = dep_line_endpoints(0, 1, 0, 1, dep, hovered, SLOTS);
-        assert_eq!(x1, 12.5); // dependency horizontal midpoint, no fan offset
+        let (x1, y1, x2, y2) = dep_line_endpoints(dep, hovered, SLOTS);
+        assert_eq!(x1, 12.5); // dependency horizontal midpoint
         assert_eq!(y1, (16.0 + 2.0) / 48.0 * 100.0); // dependency BOTTOM edge
         assert_eq!(x2, 25.0 + 12.5); // hovered horizontal midpoint
         assert_eq!(y2, 20.0 / 48.0 * 100.0); // hovered TOP edge
@@ -4681,36 +4677,24 @@ mod dep_geometry_tests {
         // hovered block's top (the flow direction is semantic, not spatial).
         let dep = geom(0.0, 25.0, 30.0, 2.0);
         let hovered = geom(37.5, 12.5, 20.0, 2.0);
-        let (x1, y1, _, y2) = dep_line_endpoints(0, 1, 0, 1, dep, hovered, SLOTS);
+        let (x1, y1, x2, y2) = dep_line_endpoints(dep, hovered, SLOTS);
         assert_eq!(x1, 12.5);
         assert_eq!(y1, (30.0 + 2.0) / 48.0 * 100.0); // dep bottom
-        assert_eq!(y2, 20.0 / 48.0 * 100.0); // hovered top (lane-inset midpoint on x2)
+        assert_eq!(x2, 37.5 + 6.25); // lane-inset midpoint
+        assert_eq!(y2, 20.0 / 48.0 * 100.0); // hovered top
     }
 
     #[test]
-    fn entry_fan_is_centered_and_stays_inside_block() {
-        let dep = geom(50.0, 25.0, 16.0, 2.0);
-        let hovered = geom(0.0, 25.0, 20.0, 2.0);
-        let n = 3;
-        let xs: Vec<f64> = (0..n)
-            .map(|i| dep_line_endpoints(0, 1, i, n, dep, hovered, SLOTS).2)
-            .collect();
-        // Centered on the hovered block's midpoint, symmetric, evenly spaced.
-        assert_eq!(xs[1], 12.5);
-        assert!((xs[1] - xs[0] - (xs[2] - xs[1])).abs() < 1e-9);
-        // Whole fan within the hovered block's width.
-        assert!(xs[0] > 0.0 && xs[2] < 25.0);
-    }
-
-    #[test]
-    fn exit_fan_separates_lines_leaving_one_dependency() {
-        // A dependency supplying a team AND a ref: two exits, side by side.
-        let dep = geom(0.0, 25.0, 16.0, 2.0);
-        let hovered = geom(25.0, 25.0, 20.0, 2.0);
-        let (xa, ..) = dep_line_endpoints(0, 2, 0, 2, dep, hovered, SLOTS);
-        let (xb, ..) = dep_line_endpoints(1, 2, 1, 2, dep, hovered, SLOTS);
-        assert!(xa < 12.5 && 12.5 < xb); // straddle the midpoint
-        assert!((12.5 - xa - (xb - 12.5)).abs() < 1e-9); // symmetric
+    fn pair_lines_hug_edge_to_edge() {
+        // Two lines on the same (dep, hovered) pair: shifted by exactly one
+        // stroke width total, symmetric around zero — one thick bi-color line.
+        let (a, b) = (dep_pair_dx(0, 2), dep_pair_dx(1, 2));
+        assert_eq!(b - a, DEP_LINE_STROKE); // edges touch, no gap, no overlap
+        assert_eq!(a + b, 0.0); // centered on the true line position
+        // A lone line gets no shift; three lines stay contiguous and centered.
+        assert_eq!(dep_pair_dx(0, 1), 0.0);
+        assert_eq!(dep_pair_dx(1, 3), 0.0);
+        assert_eq!(dep_pair_dx(2, 3) - dep_pair_dx(1, 3), DEP_LINE_STROKE);
     }
 
     #[test]
@@ -6372,39 +6356,33 @@ fn ScheduleTimeline(
                             ))
                         })
                         .collect();
-                    // Lines flow dependency-bottom → hovered-top. Entries fan
-                    // by position among ALL visible lines; exits fan by
-                    // position among the lines leaving that same dependency.
-                    let n_entry = visible_dep_edges.len();
-                    let n_exit_by_dep: HashMap<&str, usize> = {
+                    // Lines flow dependency-bottom → hovered-top, endpoint =
+                    // exact midpoints. Lines sharing the same (dep, hovered)
+                    // pair are translated sideways by whole stroke-widths so
+                    // they hug like one thick multi-colored line.
+                    let n_pair_by_dep: HashMap<&str, usize> = {
                         let mut m: HashMap<&str, usize> = HashMap::new();
                         for (dep_id, ..) in &visible_dep_edges {
                             *m.entry(dep_id.as_str()).or_insert(0) += 1;
                         }
                         m
                     };
-                    let mut exit_seen: HashMap<&str, usize> = HashMap::new();
-                    let dep_lines: Vec<(f64, f64, f64, f64, u8)> = visible_dep_edges
+                    let mut pair_seen: HashMap<&str, usize> = HashMap::new();
+                    // (x1, y1, x2, y2, dx_px, kind)
+                    let dep_lines: Vec<(f64, f64, f64, f64, f64, u8)> = visible_dep_edges
                         .iter()
-                        .enumerate()
-                        .map(|(entry_index, (dep_id, dep_geom, hovered_geom, kind))| {
-                            let exit_index = {
-                                let e = exit_seen.entry(dep_id.as_str()).or_insert(0);
+                        .map(|(dep_id, dep_geom, hovered_geom, kind)| {
+                            let pair_index = {
+                                let e = pair_seen.entry(dep_id.as_str()).or_insert(0);
                                 let i = *e;
                                 *e += 1;
                                 i
                             };
-                            let n_exit = *n_exit_by_dep.get(dep_id.as_str()).unwrap_or(&1);
-                            let (x1, y1, x2, y2) = dep_line_endpoints(
-                                exit_index,
-                                n_exit,
-                                entry_index,
-                                n_entry,
-                                *dep_geom,
-                                *hovered_geom,
-                                slots_per_day,
-                            );
-                            (x1, y1, x2, y2, *kind)
+                            let n_pair = *n_pair_by_dep.get(dep_id.as_str()).unwrap_or(&1);
+                            let dx = dep_pair_dx(pair_index, n_pair);
+                            let (x1, y1, x2, y2) =
+                                dep_line_endpoints(*dep_geom, *hovered_geom, slots_per_day);
+                            (x1, y1, x2, y2, dx, *kind)
                         })
                         .collect();
                     let dep_lines_active = !dep_lines.is_empty();
@@ -6548,16 +6526,19 @@ fn ScheduleTimeline(
                                 svg {
                                     class: "schedule-dep-lines",
                                     style: "position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; z-index: 30; overflow: visible;",
-                                    for (i, (x1, y1, x2, y2, kind)) in dep_lines.iter().enumerate() {
+                                    for (i, (x1, y1, x2, y2, dx, kind)) in dep_lines.iter().enumerate() {
+                                        // Same-pair lines are shifted by whole
+                                        // stroke-widths so they touch edge to edge.
                                         g {
                                             key: "{i}",
+                                            transform: "translate({dx}, 0)",
                                         line {
                                             x1: "{x1}%",
                                             y1: "{y1}%",
                                             x2: "{x2}%",
                                             y2: "{y2}%",
                                             stroke: dep_edge_color(*kind),
-                                            stroke_width: "2.5",
+                                            stroke_width: "{DEP_LINE_STROKE}",
                                             stroke_dasharray: match kind {
                                                 0 | 1 => "none",
                                                 _ => "3 3",

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -640,6 +640,9 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
     let mut bulk_mode = use_signal(|| false);
     let mut bulk_selected = use_signal(Vec::<String>::new);
     let mut bulk_length_input = use_signal(|| 30u32);
+    // "Push back day" tool: shift every not-yet-started match's plan by N minutes.
+    let mut push_back_open = use_signal(|| false);
+    let mut push_back_minutes = use_signal(|| 30i32);
     // Inline error affordance for drag-move / bulk failures (dismissible alert near the toolbar).
     let mut edit_error = use_signal(|| None::<String>);
     // Prefill for the create-match card when opened from a drag-to-create gesture.
@@ -851,9 +854,7 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
         Some(data) => {
             let is_to = data.is_to;
             let url_for_export = url.clone();
-            let url_for_recompute = url.clone();
             let url_for_export_key = url_for_export.clone();
-            let url_for_recompute_key = url_for_recompute.clone();
             let handle_keydown = move |ev: Event<KeyboardData>| {
                 let key_str = ev.key().to_string();
                 let modal_open = active_modal() != "none";
@@ -970,18 +971,6 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                             if editor {
                                 ev.prevent_default();
                                 active_modal.set("toml_import".to_string());
-                            }
-                        }
-                        "r" | "R" => {
-                            if editor {
-                                ev.prevent_default();
-                                let u = url_for_recompute_key.clone();
-                                let mut trigger = refresh_trigger;
-                                spawn(async move {
-                                    if let Ok(_) = api::recompute_schedule(&u).await {
-                                        trigger.set(trigger() + 1);
-                                    }
-                                });
                             }
                         }
                         _ => {}
@@ -1227,17 +1216,10 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                             }, "Export TOML" }
                                             button { class: "btn btn-sm btn-outline-secondary", onclick: move |_| active_modal.set("toml_import".to_string()), "Import TOML" }
                                             button {
-                                                class: "btn btn-sm btn-outline-primary",
-                                                onclick: move |_| {
-                                                    let u = url_for_recompute.clone();
-                                                    let mut trigger = refresh_trigger;
-                                                    spawn(async move {
-                                                        if let Ok(_) = api::recompute_schedule(&u).await {
-                                                            trigger.set(trigger() + 1);
-                                                        }
-                                                    });
-                                                },
-                                                "Recompute Times"
+                                                class: if push_back_open() { "btn btn-sm btn-primary" } else { "btn btn-sm btn-outline-primary" },
+                                                title: "Shift every not-yet-started match's planned time by N minutes (e.g. the day started late)",
+                                                onclick: move |_| push_back_open.set(!push_back_open()),
+                                                "Push back day…"
                                             }
                                             button {
                                                 class: "btn btn-sm btn-outline-warning",
@@ -1293,6 +1275,55 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                     class: "btn-close",
                                     "aria-label": "Dismiss",
                                     onclick: move |_| edit_error.set(None),
+                                }
+                            }
+                        }
+                        if push_back_open() {
+                            div { class: "card mb-2 border-secondary",
+                                div { class: "card-body py-2 d-flex flex-wrap align-items-center gap-2",
+                                    strong { class: "small", "Push back day:" }
+                                    span { class: "small text-muted",
+                                        "shifts the plan of every match that hasn't started (negative pulls the day forward)"
+                                    }
+                                    label { class: "small mb-0 ms-2", "Minutes" }
+                                    input {
+                                        class: "form-control form-control-sm d-inline-block",
+                                        style: "width: 6rem;",
+                                        r#type: "number",
+                                        value: "{push_back_minutes}",
+                                        onkeydown: move |ev: Event<KeyboardData>| ev.stop_propagation(),
+                                        oninput: move |e| {
+                                            push_back_minutes.set(e.value().parse().unwrap_or(0));
+                                        },
+                                    }
+                                    button {
+                                        class: "btn btn-sm btn-success",
+                                        disabled: push_back_minutes() == 0,
+                                        onclick: {
+                                            let u = url.clone();
+                                            move |_| {
+                                                let u = u.clone();
+                                                let minutes = push_back_minutes();
+                                                spawn(async move {
+                                                    let req = PushBackRequest { minutes };
+                                                    match api::push_back_matches(&u, &req).await {
+                                                        Ok(_) => {
+                                                            edit_error.set(None);
+                                                            push_back_open.set(false);
+                                                            refresh();
+                                                        }
+                                                        Err(e) => edit_error.set(Some(e)),
+                                                    }
+                                                });
+                                            }
+                                        },
+                                        "Apply"
+                                    }
+                                    button {
+                                        class: "btn btn-sm btn-outline-secondary",
+                                        onclick: move |_| push_back_open.set(false),
+                                        "Cancel"
+                                    }
                                 }
                             }
                         }

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -4239,6 +4239,10 @@ fn TimelineEventCard(
             class: "{event_class}",
             style: "{event_style}",
             title: "{timeline_title}",
+            // Hit-test anchor: the grid's pointermove reconciles hovered_block
+            // from the real DOM (see reconcile_hover_from_point), so a missed
+            // mouseleave can never wedge the alt-dependency outlines.
+            "data-event-id": "{event.id}",
             cursor: if can_drag { "grab" } else if is_break && !edit_mode { "default" } else { "pointer" },
             onpointerdown: move |ev: Event<PointerData>| {
                 if !editor {
@@ -5802,6 +5806,32 @@ fn ScheduleTimeline(
             }));
         }
     };
+    // Reconcile hovered_block against the element actually under the pointer.
+    // mouseenter/mouseleave are non-bubbling synthetic events and a dropped
+    // mouseleave used to leave hovered_block stuck (alt-dependency outlines
+    // persisting after the cursor left the block); hit-testing on every grid
+    // pointermove makes the state self-healing.
+    #[cfg(target_arch = "wasm32")]
+    let mut reconcile_hover_from_point = {
+        let mut hovered_block = hovered_block;
+        move |client_x: f64, client_y: f64| {
+            let under: Option<String> = web_sys::window()
+                .and_then(|w| w.document())
+                .and_then(|d| d.element_from_point(client_x as f32, client_y as f32))
+                .and_then(|el| {
+                    use wasm_bindgen::JsCast;
+                    el.dyn_into::<web_sys::Element>().ok()
+                })
+                .and_then(|el| el.closest("[data-event-id]").ok().flatten())
+                .and_then(|el| el.get_attribute("data-event-id"));
+            if *hovered_block.peek() != under {
+                hovered_block.set(under);
+            }
+        }
+    };
+    #[cfg(not(target_arch = "wasm32"))]
+    let reconcile_hover_from_point = move |_client_x: f64, _client_y: f64| {};
+
     let grid_pointer_move = {
         move |ev: Event<PointerData>| {
             if !editor {
@@ -5810,6 +5840,12 @@ fn ScheduleTimeline(
             let alt = ev.modifiers().alt();
             if *alt_down.peek() != alt {
                 alt_down.set(alt);
+            }
+            // Keep the alt-hover target honest whenever the dependency view is
+            // active (cheap: one elementFromPoint per move while Alt is held).
+            if alt {
+                let c = ev.client_coordinates();
+                reconcile_hover_from_point(c.x, c.y);
             }
             let Some(state) = drag_state.peek().clone() else {
                 return;
@@ -5966,6 +6002,10 @@ fn ScheduleTimeline(
     let grid_pointer_cancel = move |_ev: Event<PointerData>| {
         if drag_state.peek().is_some() {
             drag_state.set(None);
+        }
+        // Pointer left the grid: nothing can be alt-hovered anymore.
+        if hovered_block.peek().is_some() {
+            hovered_block.set(None);
         }
     };
 

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -416,9 +416,10 @@ struct ScheduleNavState {
     field: String,
 }
 
-/// View modes: "team" / "field" are public; "timeline" (all fields) / "table" are TO-only.
+/// Public view modes: "team" / "field". The all-fields "timeline" and "table"
+/// views live exclusively on the edit page (`/:url/schedule/edit`).
 fn is_valid_view(view: &str) -> bool {
-    matches!(view, "team" | "field" | "timeline" | "table")
+    matches!(view, "team" | "field")
 }
 
 const VERTICAL_SCALE_KEY: &str = "schedule_vertical_scale";
@@ -476,6 +477,16 @@ pub(crate) struct DragCreatePayload {
     length_min: Option<u32>,
     /// Suggested previous match on that field (latest displayed start at-or-before the drag start).
     prev_match_id: Option<String>,
+}
+
+/// Placeholder block shown on the editor timeline while the create card is
+/// open: mirrors the card's field / start-time / length values so the user can
+/// see where the new match will land. Cleared on save or cancel.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct PendingCreateGhost {
+    field_name: String,
+    start_local: chrono::NaiveDateTime,
+    length_min: i64,
 }
 
 /// Payload emitted by the edit-page timeline when a drag-to-move gesture commits.
@@ -628,10 +639,19 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
     let mut bulk_length_input = use_signal(|| 30u32);
     // Inline error affordance for drag-move / bulk failures (dismissible alert near the toolbar).
     let mut edit_error = use_signal(|| None::<String>);
-    // Prefill for the create-match modal when opened from a drag-to-create gesture.
+    // Prefill for the create-match card when opened from a drag-to-create gesture.
     let mut create_prefill = use_signal(|| None::<DragCreatePayload>);
-    // Bumped per drag-create so the modal remounts with fresh prefill state.
+    // Bumped per drag-create so the card remounts with fresh prefill state.
     let mut create_prefill_nonce = use_signal(|| 0u32);
+    // Default schedule type for newly created matches (toolbar dropdown; not persisted).
+    let mut default_match_type = use_signal(|| "STATIC".to_string());
+    // Placeholder on the timeline while the create card is open, kept in sync with
+    // the card's field/start/length values (the card writes it via this signal).
+    let mut create_ghost = use_signal(|| None::<PendingCreateGhost>);
+    // Last-focused team-ish input in the open editor card ("team1" | "team2" | "refs").
+    let mut team_field_focus = use_signal(|| None::<String>);
+    // Winner/Loser chip clicks queue a `<Match>::winner|loser` token for the open card.
+    let mut insert_team_ref = use_signal(|| None::<String>);
 
     // Pull schedule warnings in parallel so we can surface a cycle banner at the top
     // of the page. Re-runs whenever refresh_trigger bumps so the banner stays in sync
@@ -665,8 +685,8 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                 view_mode.set("timeline".to_string());
                 return;
             }
-            // "All fields" and "Table" are TO-only; coerce stray values (e.g. from URL).
-            if !data.is_to && matches!(v.as_str(), "timeline" | "table") {
+            // The public page only has "team" and "field"; coerce stray values (e.g. from URL).
+            if !editor && !matches!(v.as_str(), "team" | "field") {
                 view_mode.set("team".to_string());
                 return;
             }
@@ -831,7 +851,6 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
             let url_for_recompute = url.clone();
             let url_for_export_key = url_for_export.clone();
             let url_for_recompute_key = url_for_recompute.clone();
-            let url_for_edit_link_key = url.clone();
             let handle_keydown = move |ev: Event<KeyboardData>| {
                 let key_str = ev.key().to_string();
                 let modal_open = active_modal() != "none";
@@ -868,7 +887,7 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                         }
                         "t" | "T" => {
                             ev.prevent_default();
-                            if edit_mode && is_to {
+                            if editor {
                                 active_modal.set("tags".to_string());
                             } else if matches!(view_mode().as_str(), "team" | "field" | "timeline")
                             {
@@ -877,13 +896,13 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                         }
                         "a" | "A" => {
                             ev.prevent_default();
-                            if is_to {
+                            if editor {
                                 view_mode.set("table".to_string());
                             }
                         }
                         "l" | "L" => {
                             ev.prevent_default();
-                            if is_to {
+                            if editor {
                                 view_mode.set("timeline".to_string());
                             }
                         }
@@ -893,25 +912,8 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                 view_mode.set("team".to_string());
                             }
                         }
-                        "e" | "E" => {
-                            ev.prevent_default();
-                            // Public page: jump a TO to the dedicated edit page.
-                            if !editor && is_to {
-                                navigator.push(Route::ScheduleEdit {
-                                    url: url_for_edit_link_key.clone(),
-                                });
-                            }
-                        }
-                        "m" | "M" => {
-                            if edit_mode && is_to {
-                                ev.prevent_default();
-                                create_prefill.set(None);
-                                create_prefill_nonce.set(create_prefill_nonce().wrapping_add(1));
-                                active_modal.set("match_create".to_string());
-                            }
-                        }
                         "f" | "F" => {
-                            if edit_mode && is_to {
+                            if editor {
                                 ev.prevent_default();
                                 active_modal.set("fields".to_string());
                             } else if !edit_mode {
@@ -920,7 +922,7 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                             }
                         }
                         "x" | "X" => {
-                            if edit_mode && is_to {
+                            if editor {
                                 ev.prevent_default();
                                 let u = url_for_export_key.clone();
                                 spawn(async move {
@@ -962,13 +964,13 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                             }
                         }
                         "i" | "I" => {
-                            if edit_mode && is_to {
+                            if editor {
                                 ev.prevent_default();
                                 active_modal.set("toml_import".to_string());
                             }
                         }
                         "r" | "R" => {
-                            if edit_mode && is_to {
+                            if editor {
                                 ev.prevent_default();
                                 let u = url_for_recompute_key.clone();
                                 let mut trigger = refresh_trigger;
@@ -987,7 +989,9 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
             rsx! {
                 style { {SCHEDULE_PAGE_CSS} }
                 div {
-                    class: "container-fluid mt-3 position-relative schedule-keyboard-focus",
+                    // The editor gets the full viewport width (escapes the layout's
+                    // centered max-width container via the full-bleed class).
+                    class: if editor { "container-fluid mt-3 position-relative schedule-keyboard-focus schedule-editor-fullbleed" } else { "container-fluid mt-3 position-relative schedule-keyboard-focus" },
                     tabindex: 0,
                     onkeydown: handle_keydown,
                     onmounted: move |ev| {
@@ -1034,14 +1038,24 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                     span { class: "me-2", "⚠" }
                                     span { class: "flex-grow-1",
                                         strong { "Schedule failed to solve: " }
-                                        "circular dependency detected. See "
-                                        button {
-                                            r#type: "button",
-                                            class: "btn btn-link p-0 align-baseline",
-                                            onclick: move |_| active_modal.set("schedule_warnings".to_string()),
-                                            "Warnings"
+                                        "circular dependency detected."
+                                        if editor {
+                                            " See "
+                                            button {
+                                                r#type: "button",
+                                                class: "btn btn-link p-0 align-baseline",
+                                                onclick: move |_| active_modal.set("schedule_warnings".to_string()),
+                                                "Warnings"
+                                            }
+                                            " for more info."
+                                        } else if is_to {
+                                            " See the "
+                                            Link {
+                                                to: Route::ScheduleEdit { url: url.clone() },
+                                                "schedule editor"
+                                            }
+                                            " for more info."
                                         }
-                                        " for more info."
                                     }
                                 }
                             }
@@ -1138,7 +1152,7 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                                 "By field"
                                             }
                                         }
-                                        if is_to {
+                                        if editor {
                                             button {
                                                 class: if view_mode() == "timeline" { "btn btn-primary" } else { "btn btn-outline-primary" },
                                                 onclick: move |_| view_mode.set("timeline".to_string()),
@@ -1152,16 +1166,24 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                         }
                                     }
                                 }
-                                if data.is_to {
+                                if editor {
                                     div { class: "d-flex flex-wrap align-items-center gap-1",
-                                        if editor {
                                             button { class: "btn btn-sm btn-outline-secondary", onclick: move |_| active_modal.set("tags".to_string()), "Tags" }
                                             button { class: "btn btn-sm btn-outline-secondary", onclick: move |_| active_modal.set("fields".to_string()), "Fields" }
-                                            button { class: "btn btn-sm btn-outline-success", onclick: move |_| {
-                                                create_prefill.set(None);
-                                                create_prefill_nonce.set(create_prefill_nonce().wrapping_add(1));
-                                                active_modal.set("match_create".to_string());
-                                            }, "+ Match" }
+                                            div {
+                                                class: "d-flex align-items-center gap-1 ms-1",
+                                                title: "Schedule type new matches start with (click or drag on the schedule to create one)",
+                                                label { class: "small text-muted mb-0", r#for: "defaultMatchTypeSelect", "New match type" }
+                                                select {
+                                                    id: "defaultMatchTypeSelect",
+                                                    class: "form-select form-select-sm w-auto",
+                                                    value: "{default_match_type}",
+                                                    onchange: move |e| default_match_type.set(e.value()),
+                                                    option { value: "STATIC", "Static" }
+                                                    option { value: "SAFE", "Safe" }
+                                                    option { value: "FAST", "Fast" }
+                                                }
+                                            }
                                             button { class: "btn btn-sm btn-outline-secondary", onclick: move |_| {
                                                 let u = url_for_export.clone();
                                                 spawn(async move {
@@ -1250,20 +1272,6 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                                     "Show times as they happened"
                                                 }
                                             }
-                                        } else {
-                                            // Public page: read-only warnings + a link to the edit page.
-                                            button {
-                                                class: "btn btn-sm btn-outline-warning",
-                                                title: "Show schedule warnings (unknown teams, cycles, missing match refs, double-bookings)",
-                                                onclick: move |_| active_modal.set("schedule_warnings".to_string()),
-                                                "⚠ Warnings"
-                                            }
-                                            Link {
-                                                to: Route::ScheduleEdit { url: url.clone() },
-                                                class: "btn btn-sm btn-primary",
-                                                "Edit schedule"
-                                            }
-                                        }
                                     }
                                 }
                             }
@@ -1354,6 +1362,10 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                         }
                     }
 
+                    // Editor: schedule + docked editor card side by side on wide screens
+                    // (card above the schedule on narrow ones). Public: plain block.
+                    div { class: if editor { "schedule-editor-split" } else { "" },
+                    div { class: if editor { "schedule-editor-main" } else { "" },
                     if view_mode() == "team" && focus_team_id().is_empty() {
                         div { class: "alert alert-info",
                             "Choose your team above to see only the matches you play or ref."
@@ -1387,6 +1399,20 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                             editor: editor && view_mode() == "timeline",
                             bulk_select_active: bulk_mode(),
                             selected_ids: bulk_selected(),
+                            // Pending-create placeholder: stays visible while the create card
+                            // is open, mirroring the card's field/start/length.
+                            pending_create: if editor && active_modal() == "match_create" {
+                                create_ghost()
+                            } else {
+                                None
+                            },
+                            // Winner/Loser chips: only while a create/edit card is open and a
+                            // team-ish input was the last-focused field (and not bulk-selecting).
+                            result_pick_active: editor
+                                && !bulk_mode()
+                                && matches!(active_modal().as_str(), "match_create" | "match_edit")
+                                && team_field_focus().is_some(),
+                            on_pick_result: move |tok: String| insert_team_ref.set(Some(tok)),
                             on_edit_match: {
                                 let matches_for_edit = data.matches.clone();
                                 move |id: String| {
@@ -1402,6 +1428,7 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                         return;
                                     }
                                     // Structural blocks (breaks/joins) are edited as a same-name group.
+                                    team_field_focus.set(None);
                                     if let Some(m) = matches_for_edit.iter().find(|m| m.uuid == id) {
                                         if is_structural_match(m) {
                                             selected_break_group.set(m.name.clone());
@@ -1416,6 +1443,7 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                             on_drag_create: move |p: DragCreatePayload| {
                                 create_prefill.set(Some(p));
                                 create_prefill_nonce.set(create_prefill_nonce().wrapping_add(1));
+                                team_field_focus.set(None);
                                 active_modal.set("match_create".to_string());
                             },
                             on_move_match: {
@@ -1461,7 +1489,6 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                                 let req = UpdateBreakGroupRequest {
                                                     schedule_type: None,
                                                     length: None,
-                                                    teams: None,
                                                     start_time: mc.new_start_utc.clone(),
                                                     fields: None,
                                                 };
@@ -1506,6 +1533,7 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                             on_edit_match: {
                                 let matches_for_edit = data.matches.clone();
                                 move |id: String| {
+                                    team_field_focus.set(None);
                                     if let Some(m) = matches_for_edit.iter().find(|m| m.uuid == id) {
                                         if is_structural_match(m) {
                                             selected_break_group.set(m.name.clone());
@@ -1520,23 +1548,32 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                         }
                     }
 
-                    // Modals (key forces remount so Edit modal gets fresh state from match)
-                    if active_modal() == "match_edit" {
-                        div { key: "{selected_match_id()}",
+                    } // schedule-editor-main
+
+                    // Docked editor card (editor only): create / edit / break-group forms.
+                    // The schedule stays visible and interactive next to (or below) it.
+                    if editor && active_modal() == "match_edit" {
+                        div { class: "schedule-editor-panel", key: "edit-{selected_match_id()}",
                             EditMatchModal {
                                 tournament_url: url.clone(),
                                 match_id: selected_match_id(),
                                 data: data.clone(),
-                                on_close: move |_| active_modal.set("none".to_string()),
+                                team_field_focus: team_field_focus,
+                                insert_team_ref: insert_team_ref,
+                                on_close: move |_| {
+                                    team_field_focus.set(None);
+                                    active_modal.set("none".to_string());
+                                },
                                 on_save: move |_| {
+                                    team_field_focus.set(None);
                                     active_modal.set("none".to_string());
                                     refresh();
                                 }
                             }
                         }
                     }
-                    if active_modal() == "match_create" {
-                        div { key: "create-{create_prefill_nonce()}",
+                    if editor && active_modal() == "match_create" {
+                        div { class: "schedule-editor-panel", key: "create-{create_prefill_nonce()}",
                             CreateMatchModal {
                                 tournament_url: url.clone(),
                                 data: data.clone(),
@@ -1546,20 +1583,29 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                 prefill_length: create_prefill().and_then(|p| p.length_min),
                                 prefill_prev_match_id: create_prefill()
                                     .and_then(|p| p.prev_match_id.clone()),
+                                default_schedule_type: default_match_type(),
+                                show_as_happened: show_as_happened(),
+                                create_ghost: create_ghost,
+                                team_field_focus: team_field_focus,
+                                insert_team_ref: insert_team_ref,
                                 on_close: move |_| {
                                     create_prefill.set(None);
+                                    create_ghost.set(None);
+                                    team_field_focus.set(None);
                                     active_modal.set("none".to_string());
                                 },
                                 on_save: move |_| {
                                     create_prefill.set(None);
+                                    create_ghost.set(None);
+                                    team_field_focus.set(None);
                                     active_modal.set("none".to_string());
                                     refresh();
                                 }
                             }
                         }
                     }
-                    if active_modal() == "break_group" {
-                        div { key: "{selected_break_group()}",
+                    if editor && active_modal() == "break_group" {
+                        div { class: "schedule-editor-panel", key: "group-{selected_break_group()}",
                             BreakGroupModal {
                                 tournament_url: url.clone(),
                                 group_name: selected_break_group(),
@@ -1572,6 +1618,9 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                             }
                         }
                     }
+                    } // schedule-editor-split
+
+                    // Modals that don't need the schedule visible stay as real modals.
                     if active_modal() == "tags" {
                         TagsModal {
                             tournament_url: url.clone(),
@@ -1707,25 +1756,53 @@ fn CreateMatchModal(
     /// Drag-to-create prefill: chain-position default for dynamic types.
     #[props(default)]
     prefill_prev_match_id: Option<String>,
+    /// Toolbar "New match type" default (STATIC/SAFE/FAST).
+    #[props(default)]
+    default_schedule_type: Option<String>,
+    /// Page-level "show times as they happened" toggle (for previous-match lookup).
+    #[props(default = false)]
+    show_as_happened: bool,
+    /// Pending-create placeholder on the timeline; the card keeps it in sync
+    /// with its field/start/length values.
+    create_ghost: Signal<Option<PendingCreateGhost>>,
+    /// Last-focused team-ish input ("team1" | "team2" | "refs").
+    team_field_focus: Signal<Option<String>>,
+    /// Winner/Loser token queued by the timeline chips for insertion.
+    insert_team_ref: Signal<Option<String>>,
 ) -> Element {
     let name = use_signal(|| "".to_string());
     let mut field = use_signal({
         let f = prefill_field.clone();
         move || f.unwrap_or_default()
     });
-    let schedule_type = use_signal(|| "STATIC".to_string());
-    let mut length = use_signal(move || prefill_length.unwrap_or(60));
-    let mut start_time = use_signal({
+    let initial_type = default_schedule_type
+        .clone()
+        .filter(|t| matches!(t.as_str(), "STATIC" | "SAFE" | "FAST"))
+        .unwrap_or_else(|| "STATIC".to_string());
+    let schedule_type = use_signal({
+        let t = initial_type.clone();
+        move || t
+    });
+    let length = use_signal(move || prefill_length.unwrap_or(60));
+    let start_time = use_signal({
         let s = prefill_start_time.clone();
         move || s.unwrap_or_default()
     });
-    let mut previous_match_id = use_signal(|| "".to_string());
+    // Dynamic default types start with the drag-derived previous match preselected.
+    let mut previous_match_id = use_signal({
+        let init = if matches!(initial_type.as_str(), "SAFE" | "FAST") {
+            prefill_prev_match_id.clone().unwrap_or_default()
+        } else {
+            String::new()
+        };
+        move || init
+    });
     let mut refs = use_signal(|| "".to_string());
     let mut team1 = use_signal(|| "".to_string());
     let mut team2 = use_signal(|| "".to_string());
-    let mut set_type = use_signal(|| "SETS".to_string());
-    let mut nsets = use_signal(|| 3u32);
-    let mut stones_per_set = use_signal(|| 100u32);
+    let set_type = use_signal(|| "SETS".to_string());
+    let nsets = use_signal(|| 3u32);
+    let stones_per_set = use_signal(|| 100u32);
     let ribbon = use_signal(|| false);
     let mut skip_condition = use_signal(|| "".to_string());
     let mut skip_condition_help_open = use_signal(|| false);
@@ -1739,6 +1816,65 @@ fn CreateMatchModal(
 
     let mut error = use_signal(|| None::<String>);
     let mut saving = use_signal(|| false);
+
+    // Keep the timeline's pending-create placeholder in sync with the card's
+    // field / start-time / length. Cleared by the page on save/cancel.
+    {
+        let mut create_ghost = create_ghost;
+        use_effect(move || {
+            let st = schedule_type();
+            let field_name = if matches!(st.as_str(), "BREAK" | "STATBREAK" | "JOIN") {
+                break_fields().first().cloned().unwrap_or_default()
+            } else {
+                field()
+            };
+            let parsed = chrono::NaiveDateTime::parse_from_str(
+                start_time().trim(),
+                "%Y-%m-%dT%H:%M",
+            )
+            .ok();
+            let next = match (field_name.is_empty(), parsed) {
+                (false, Some(start_local)) => Some(PendingCreateGhost {
+                    field_name,
+                    start_local,
+                    length_min: (length() as i64).max(10),
+                }),
+                _ => None,
+            };
+            if *create_ghost.peek() != next {
+                create_ghost.set(next);
+            }
+        });
+    }
+
+    // Consume Winner/Loser tokens queued by the timeline chips into whichever
+    // team-ish input was focused last (refs appends; team1/team2 replace).
+    {
+        let mut insert_team_ref = insert_team_ref;
+        use_effect(move || {
+            if let Some(tok) = insert_team_ref() {
+                match team_field_focus.peek().as_deref() {
+                    Some("team1") => team1.set(tok.clone()),
+                    Some("team2") => team2.set(tok.clone()),
+                    Some("refs") => {
+                        let cur = refs
+                            .peek()
+                            .trim()
+                            .trim_end_matches(',')
+                            .trim()
+                            .to_string();
+                        refs.set(if cur.is_empty() {
+                            tok.clone()
+                        } else {
+                            format!("{cur}, {tok}")
+                        });
+                    }
+                    _ => {}
+                }
+                insert_team_ref.set(None);
+            }
+        });
+    }
 
     #[cfg(target_arch = "wasm32")]
     use_effect(move || {
@@ -1758,38 +1894,37 @@ fn CreateMatchModal(
 
     let matches_on_field = matches_on_field_sorted(&data.matches, &field(), None);
 
-    let data_field = data.clone();
+    // Previous match derived from the card's start time: the match on `field_name`
+    // whose displayed interval most closely precedes it (same rule as drag-create).
+    let compute_prev_from_start = {
+        let data_prev = data.clone();
+        move |field_name: &str, start_local_str: &str| -> Option<String> {
+            let start_local =
+                chrono::NaiveDateTime::parse_from_str(start_local_str.trim(), "%Y-%m-%dT%H:%M")
+                    .ok()?;
+            latest_match_before(
+                &data_prev.matches,
+                field_name,
+                start_local,
+                "",
+                show_as_happened,
+                schedule_tz_offset_minutes(),
+            )
+            .map(|(u, _, _)| u)
+        }
+    };
+
+    // Note: never auto-assign length / format from the previous match — the
+    // drag-derived (or default) length stays unless the user types a new one.
+    let compute_prev_for_field = compute_prev_from_start.clone();
     let mut on_field_change = move |new_field: String| {
         field.set(new_field.clone());
         previous_match_id.set("".to_string());
-        if !new_field.is_empty() {
-            let list = matches_on_field_sorted(&data_field.matches, &new_field, None);
-            if schedule_type() != "STATIC" {
-                if let Some(m) = list.first() {
-                    previous_match_id.set(m.uuid.clone());
-                }
-                if let Some(m) = list.first() {
-                    length.set(m.nominal_length.unwrap_or(60));
-                    set_type.set(m.set_type.clone().unwrap_or_else(|| "SETS".to_string()));
-                    nsets.set(m.nsets.unwrap_or(3));
-                    stones_per_set.set(m.stones_per_set.unwrap_or(100));
-                }
-            } else if let Some(m) = list.first().and_then(|x| x.nominal_start_time.as_ref()) {
-                if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(m) {
-                    start_time.set(dt.format("%Y-%m-%dT%H:%M").to_string());
-                }
-            }
-        }
-    };
-    let data_prev = data.clone();
-    let mut on_previous_match_change = move |new_prev_id: String| {
-        previous_match_id.set(new_prev_id.clone());
-        if !new_prev_id.is_empty() {
-            if let Some(prev) = data_prev.matches.iter().find(|m| m.uuid == new_prev_id) {
-                length.set(prev.nominal_length.unwrap_or(60));
-                set_type.set(prev.set_type.clone().unwrap_or_else(|| "SETS".to_string()));
-                nsets.set(prev.nsets.unwrap_or(3));
-                stones_per_set.set(prev.stones_per_set.unwrap_or(100));
+        // Dynamic types: recompute the previous match on the new field from the
+        // card's start time.
+        if !new_field.is_empty() && matches!(schedule_type().as_str(), "SAFE" | "FAST" | "JOIN") {
+            if let Some(prev) = compute_prev_for_field(&new_field, &start_time()) {
+                previous_match_id.set(prev);
             }
         }
     };
@@ -2130,17 +2265,22 @@ fn CreateMatchModal(
 
     rsx! {
         div {
+            // Docked editor card (not a modal): the schedule stays visible and
+            // interactive beside/below it.
             div {
-                class: "modal d-block",
+                class: "card schedule-editor-card",
                 tabindex: -1,
-                style: "background: rgba(0,0,0,0.5)",
                 onkeydown: modal_keydown,
-                div { class: "modal-dialog modal-lg",
-                    div { class: "modal-content",
-                        div { class: "modal-header",
-                            h5 { class: "modal-title", "New Match" }
-                        }
-                    div { class: "modal-body",
+                div { class: "card-header d-flex justify-content-between align-items-center",
+                    h5 { class: "mb-0", "New Match" }
+                    button {
+                        class: "btn-close",
+                        r#type: "button",
+                        "aria-label": "Close",
+                        onclick: move |_| on_close.call(()),
+                    }
+                }
+                    div { class: "card-body",
                         if let Some(err) = error() {
                             div { class: "alert alert-danger", "{err}" }
                         }
@@ -2186,18 +2326,19 @@ fn CreateMatchModal(
                                         label { class: "form-label", "Type" }
                                         select { class: "form-select", value: "{schedule_type}", onchange: {
                                             let prefill_prev = prefill_prev_match_id.clone();
+                                            let compute_prev = compute_prev_from_start.clone();
                                             move |e: Event<FormData>| {
                                                 let mut schedule_type = schedule_type;
                                                 let v = e.value();
                                                 schedule_type.set(v.clone());
-                                                // Drag-to-create: switching to a dynamic type defaults the
-                                                // previous match to the chain position of the drag start.
-                                                if matches!(v.as_str(), "SAFE" | "FAST" | "JOIN")
-                                                    && previous_match_id().is_empty()
-                                                {
-                                                    if let Some(p) = prefill_prev.clone() {
-                                                        previous_match_id.set(p);
-                                                    }
+                                                // Switching to a dynamic type: auto-select the previous
+                                                // match on the card's field from the card's start time
+                                                // (i.e. the clicked/dragged position), falling back to
+                                                // the drag-derived default.
+                                                if matches!(v.as_str(), "SAFE" | "FAST" | "JOIN") {
+                                                    let prev = compute_prev(&field(), &start_time())
+                                                        .or_else(|| prefill_prev.clone());
+                                                    previous_match_id.set(prev.unwrap_or_default());
                                                 }
                                             }
                                         },
@@ -2228,7 +2369,7 @@ fn CreateMatchModal(
                             } else if schedule_type() == "SAFE" || schedule_type() == "FAST" {
                                 div { class: "mb-3",
                                     label { class: "form-label", "Previous Match" }
-                                    select { class: "form-select", value: "{previous_match_id}", onchange: move |e| on_previous_match_change(e.value()),
+                                    select { class: "form-select", value: "{previous_match_id}", onchange: move |e| previous_match_id.set(e.value()),
                                         option { value: "", "None" }
                                         for m in &matches_on_field {
                                             option { value: "{m.uuid}", "{m.name}" }
@@ -2299,7 +2440,12 @@ fn CreateMatchModal(
 
                             if schedule_type() == "STATIC" || schedule_type() == "SAFE" || schedule_type() == "FAST" {
                                 div { class: "row",
+                                    // Focus tracking feeds the timeline's Winner/Loser hover chips.
                                     div { class: "col-md-6",
+                                        onfocusin: move |_| {
+                                            let mut t = team_field_focus;
+                                            t.set(Some("team1".to_string()));
+                                        },
                                         TeamSelectionField {
                                             label: "Team 1".to_string(),
                                             team_options: data.team_options.clone(),
@@ -2313,6 +2459,10 @@ fn CreateMatchModal(
                                         }
                                     }
                                     div { class: "col-md-6",
+                                        onfocusin: move |_| {
+                                            let mut t = team_field_focus;
+                                            t.set(Some("team2".to_string()));
+                                        },
                                         TeamSelectionField {
                                             label: "Team 2".to_string(),
                                             team_options: data.team_options.clone(),
@@ -2326,16 +2476,22 @@ fn CreateMatchModal(
                                         }
                                     }
                                 }
-                                TeamSelectionField {
-                                    label: "Referees".to_string(),
-                                    team_options: data.team_options.clone(),
-                                    tags: data.tags.clone(),
-                                    matches: data.matches.clone(),
-                                    value: refs(),
-                                    on_change: move |s| refs.set(s),
-                                    multiple: true,
-                                    placeholder: "(optional) teams, match winners/losers, or tags".to_string(),
-                                    help_text: Some("(optional) teams, match winners/losers, or tags".to_string()),
+                                div {
+                                    onfocusin: move |_| {
+                                        let mut t = team_field_focus;
+                                        t.set(Some("refs".to_string()));
+                                    },
+                                    TeamSelectionField {
+                                        label: "Referees".to_string(),
+                                        team_options: data.team_options.clone(),
+                                        tags: data.tags.clone(),
+                                        matches: data.matches.clone(),
+                                        value: refs(),
+                                        on_change: move |s| refs.set(s),
+                                        multiple: true,
+                                        placeholder: "(optional) teams, match winners/losers, or tags".to_string(),
+                                        help_text: Some("(optional) teams, match winners/losers, or tags".to_string()),
+                                    }
                                 }
                                 div { class: "row",
                                     div { class: "col-md-4",
@@ -2408,8 +2564,6 @@ fn CreateMatchModal(
                             }
                         }
                     }
-                }
-                }
             }
             if skip_condition_help_open() {
                 SkipConditionHelpModal { on_close: move |_| skip_condition_help_open.set(false) }
@@ -2568,17 +2722,22 @@ fn BreakGroupModal(
     };
 
     rsx! {
+        // Docked editor card (not a modal): the schedule stays visible and
+        // interactive beside/below it.
         div {
-            class: "modal d-block",
+            class: "card schedule-editor-card",
             tabindex: -1,
-            style: "background: rgba(0,0,0,0.5)",
             onkeydown: modal_keydown,
-            div { class: "modal-dialog modal-lg",
-                div { class: "modal-content",
-                    div { class: "modal-header",
-                        h5 { class: "modal-title", "Edit {type_label}: {group_name}" }
-                    }
-                    div { class: "modal-body",
+            div { class: "card-header d-flex justify-content-between align-items-center",
+                h5 { class: "mb-0", "Edit {type_label}: {group_name}" }
+                button {
+                    class: "btn-close",
+                    r#type: "button",
+                    "aria-label": "Close",
+                    onclick: move |_| on_close.call(()),
+                }
+            }
+                    div { class: "card-body",
                         if let Some(err) = error() {
                             div { class: "alert alert-danger", "{err}" }
                         }
@@ -2694,8 +2853,6 @@ fn BreakGroupModal(
                             }
                         }
                     }
-                }
-            }
         }
     }
 }
@@ -3749,7 +3906,8 @@ fn TableView(
                             .collect();
                         let schedule_type_display = m.schedule_type.as_deref().unwrap_or("-");
                         let structural = is_structural_match(m);
-                        let (status_color, status_label) = if structural {
+                        // Editor table: structural rows show real statuses like matches.
+                        let (status_color, status_label) = if structural && !edit_mode {
                             ("#e9ecef".to_string(), "—".to_string())
                         } else if m.status.is_empty() {
                             ("#e9ecef".to_string(), "-".to_string())
@@ -3773,7 +3931,7 @@ fn TableView(
                                 }
                                 td { "{schedule_type_display}" }
                                 td { class: "align-middle",
-                                    if !structural {
+                                    if !structural || edit_mode {
                                         span {
                                             class: "schedule-timeline-status-tag",
                                             style: "background-color: {status_color};",
@@ -3851,23 +4009,12 @@ fn TableView(
                                 }
                                 if edit_mode {
                                     td {
-                                        // Editing is locked once a match has started — surface a
-                                        // disabled pencil with a tooltip so the row layout doesn't shift.
-                                        // Structural rows (breaks/joins) stay editable (group modal);
-                                        // their status is solver-derived, never user-started.
-                                        if !is_structural_match(m) && matches!(m.status.as_str(), "IN_PROGRESS" | "COMPLETED" | "SKIPPED") {
-                                            button {
-                                                class: "btn btn-sm btn-link text-muted",
-                                                disabled: true,
-                                                title: "Match has started — editing is disabled.",
-                                                "✎"
-                                            }
-                                        } else {
-                                            button {
-                                                class: "btn btn-sm btn-link",
-                                                onclick: move |_| on_edit_match.call(match_id.clone()),
-                                                "✎"
-                                            }
+                                        // Started/completed rows stay editable too: the edit card
+                                        // surfaces the lock and the server rejects disallowed changes.
+                                        button {
+                                            class: "btn btn-sm btn-link",
+                                            onclick: move |_| on_edit_match.call(match_id.clone()),
+                                            "✎"
                                         }
                                     }
                                 }
@@ -3964,12 +4111,22 @@ fn TimelineEventCard(
     /// Alt-hover dependency highlight class (source / chain / team / ref).
     #[props(default)]
     dep_class: Option<String>,
+    /// Alt-hover: nested outline rings for the hovered source block (one ring
+    /// per dependency edge, colored like its line). Inline `box-shadow: …;`.
+    #[props(default)]
+    dep_shadow: Option<String>,
     /// Pointerdown on the block (id, client_x, client_y) → may start a move drag.
     #[props(default)]
     on_move_pointer_down: EventHandler<(String, f64, f64)>,
     /// Hover tracking for the alt-dependency view: (id, entered, alt_held).
     #[props(default)]
     on_hover: EventHandler<(String, bool, bool)>,
+    /// Show Winner/Loser overlay chips on hover (editor card open, team input focused).
+    #[props(default = false)]
+    result_pick_active: bool,
+    /// Fired with `<MatchName>::winner|loser` when a chip is clicked.
+    #[props(default)]
+    on_pick_result: EventHandler<String>,
 ) -> Element {
     let navigator = use_navigator();
     let event_id_clone = event.id.clone();
@@ -4000,7 +4157,8 @@ fn TimelineEventCard(
         } else {
             ""
         },
-        if is_structural {
+        // Editor: structural blocks drop the neutral chrome and show statuses.
+        if is_structural && !editor {
             " schedule-timeline-event--structural"
         } else {
             ""
@@ -4025,16 +4183,17 @@ fn TimelineEventCard(
             (d.clone(), p.clone(), k, l)
         })
         .collect();
-    // Break-like blocks stay clickable in edit mode even when COMPLETED: their
-    // status is solver-derived (never user-started) and the break-group modal
-    // handles what may actually change.
+    // Started/completed matches stay fully interactive on the editor (click,
+    // drag, bulk-select); the server rejects disallowed changes and the
+    // existing error alert + refetch handles it. The lock is surfaced as a
+    // hint here and as a warning in the edit card.
     let edit_locked = !is_break
         && matches!(
             event.status.as_str(),
             "IN_PROGRESS" | "COMPLETED" | "SKIPPED"
         );
     let timeline_title = if edit_mode && edit_locked {
-        format!("{event_title} — match has started, editing disabled")
+        format!("{event_title} — match has started; the server will reject most changes")
     } else {
         event_title.clone()
     };
@@ -4052,13 +4211,18 @@ fn TimelineEventCard(
     let event_id_for_drag = event.id.clone();
     let event_id_for_enter = event.id.clone();
     let event_id_for_leave = event.id.clone();
-    let can_drag = editor && !edit_locked;
+    let can_drag = editor;
+    // Hovered dependency source: append the per-edge outline rings.
+    let event_style = match dep_shadow.as_deref() {
+        Some(shadow) => format!("{event_style} {shadow}"),
+        None => event_style.clone(),
+    };
     rsx! {
         div {
             class: "{event_class}",
             style: "{event_style}",
             title: "{timeline_title}",
-            cursor: if can_drag { "grab" } else if (is_break && !edit_mode) || (edit_mode && edit_locked) { "default" } else { "pointer" },
+            cursor: if can_drag { "grab" } else if is_break && !edit_mode { "default" } else { "pointer" },
             onpointerdown: move |ev: Event<PointerData>| {
                 if !editor {
                     return;
@@ -4084,9 +4248,7 @@ fn TimelineEventCard(
             onclick: move |_| {
                 if is_break && !edit_mode {
                 } else if edit_mode {
-                    if !edit_locked {
-                        on_edit_match.call(event_id_clone.clone());
-                    }
+                    on_edit_match.call(event_id_clone.clone());
                 } else {
                     navigator.push(Route::MatchPageById {
                         url: url_clone.clone(),
@@ -4094,11 +4256,44 @@ fn TimelineEventCard(
                     });
                 }
             },
-            if !is_structural {
+            if !is_structural || editor {
                 span {
                     class: "schedule-timeline-status-tag schedule-timeline-status-tag--corner",
                     style: "background-color: {event.color};",
                     "{status_label}"
+                }
+            }
+            // Winner/Loser insertion chips: shown on hover while an editor card has a
+            // team-ish input focused. Structural blocks (breaks/joins) have no winner.
+            if editor && result_pick_active && !is_structural {
+                div {
+                    class: "schedule-result-chips",
+                    // Never start a move drag from a chip press.
+                    onpointerdown: move |ev: Event<PointerData>| ev.stop_propagation(),
+                    button {
+                        r#type: "button",
+                        class: "schedule-result-chip schedule-result-chip--winner",
+                        onclick: {
+                            let name = event.name.clone();
+                            move |ev: Event<MouseData>| {
+                                ev.stop_propagation();
+                                on_pick_result.call(format!("{name}::winner"));
+                            }
+                        },
+                        "Winner"
+                    }
+                    button {
+                        r#type: "button",
+                        class: "schedule-result-chip schedule-result-chip--loser",
+                        onclick: {
+                            let name = event.name.clone();
+                            move |ev: Event<MouseData>| {
+                                ev.stop_propagation();
+                                on_pick_result.call(format!("{name}::loser"));
+                            }
+                        },
+                        "Loser"
+                    }
                 }
             }
             if team_view && !is_break {
@@ -4362,6 +4557,16 @@ fn ScheduleTimeline(
     /// Blocks currently selected by the bulk-length tool.
     #[props(default)]
     selected_ids: Vec<String>,
+    /// Pending-create placeholder shown while the create card is open (editor only).
+    #[props(default)]
+    pending_create: Option<PendingCreateGhost>,
+    /// Show Winner/Loser chips on hovered match blocks (editor card is open with
+    /// a team-ish input focused last).
+    #[props(default = false)]
+    result_pick_active: bool,
+    /// Fired with a `<MatchName>::winner|loser` token when a chip is clicked.
+    #[props(default)]
+    on_pick_result: EventHandler<String>,
     /// Fired when a drag-to-create gesture (or plain empty-space click) completes.
     #[props(default)]
     on_drag_create: EventHandler<DragCreatePayload>,
@@ -4756,8 +4961,9 @@ fn ScheduleTimeline(
                 .collect::<Vec<_>>()
                 .join(", ");
 
-            // Status tag palette only (never overwritten for highlight; highlight is on the block)
-            let (color, _) = if is_structural_match(m) {
+            // Status tag palette only (never overwritten for highlight; highlight is on the block).
+            // Editor: structural blocks (breaks/joins) show real statuses like matches.
+            let (color, _) = if is_structural_match(m) && !editor {
                 ("#e9ecef".to_string(), "—".to_string())
             } else {
                 status_color_and_label(&m.status)
@@ -5269,6 +5475,32 @@ fn ScheduleTimeline(
             }
         }
         map
+    };
+    // Nested outline rings on the hovered block: one ring per dependency edge,
+    // colored like its line (3px ring + 1px white separator each), so the
+    // number of dependencies is countable at a glance.
+    let dep_source_shadow: Option<String> = if dep_edges.is_empty() {
+        None
+    } else {
+        let shadows: Vec<String> = dep_edges
+            .iter()
+            .enumerate()
+            .map(|(i, (_, _, kind))| {
+                let color = match kind {
+                    0 => "#0d6efd",
+                    1 | 2 => "#d63384",
+                    _ => "#fd7e14",
+                };
+                let inner = (i as u32) * 4;
+                format!(
+                    "0 0 0 {}px {}, 0 0 0 {}px rgba(255,255,255,0.9)",
+                    inner + 3,
+                    color,
+                    inner + 4
+                )
+            })
+            .collect();
+        Some(format!("box-shadow: {};", shadows.join(", ")))
     };
 
     // Ghost placement for the in-flight drag:
@@ -5847,7 +6079,8 @@ fn ScheduleTimeline(
                             let width = (lane_w / 100.0) * col_w;
                             geom_by_id.insert(e.id.clone(), (left, width, start_slots, duration_slots));
                             let is_structural = is_structural_type(e.schedule_type.as_deref());
-                            let bg = if is_structural { "#f1f3f5" } else { "#ffffff" };
+                            // Editor: structural blocks look like matches (statuses shown).
+                            let bg = if is_structural && !editor { "#f1f3f5" } else { "#ffffff" };
                             let style = format!(
                                 "background-color: {bg}; position: absolute; box-sizing: border-box; \
                                  left: calc({left}% + 1px); width: calc({width}% - 2px); \
@@ -5859,12 +6092,24 @@ fn ScheduleTimeline(
                         .collect();
                     // Dependency lines: only edges whose target is visible in the current day/filter.
                     // Endpoints in overlay percentages (x: both axes % of the layer box).
+                    // At the hovered block, parallel edges fan out with small lateral
+                    // offsets along its edge instead of stacking on the midpoint.
+                    let n_dep_edges = dep_edges.len();
                     let dep_lines: Vec<(f64, f64, f64, f64, u8)> = dep_edges
                         .iter()
-                        .filter_map(|(from, to, kind)| {
+                        .enumerate()
+                        .filter_map(|(i, (from, to, kind))| {
                             let (fl, fw, ft, fh) = *geom_by_id.get(from)?;
                             let (tl, tw, tt, th) = *geom_by_id.get(to)?;
-                            let fx = fl + fw / 2.0;
+                            // ~0.6% of the layer width (a few px) per edge, clamped so
+                            // the fan stays within the hovered block's width.
+                            let step = if n_dep_edges > 1 {
+                                (0.6_f64).min(fw * 0.8 / (n_dep_edges as f64 - 1.0))
+                            } else {
+                                0.0
+                            };
+                            let offset = (i as f64 - (n_dep_edges as f64 - 1.0) / 2.0) * step;
+                            let fx = fl + fw / 2.0 + offset;
                             let tx = tl + tw / 2.0;
                             let fcy = (ft + fh / 2.0) / slots_per_day as f64 * 100.0;
                             let tcy = (tt + th / 2.0) / slots_per_day as f64 * 100.0;
@@ -5908,6 +6153,29 @@ fn ScheduleTimeline(
                             (style, title.clone(), sub.clone(), *blocked, gap_style)
                         },
                     );
+                    // Pending-create placeholder: mirrors the open create card's
+                    // field/start/length so the drag target stays visible.
+                    let pending_block = pending_create.as_ref().and_then(|g| {
+                        if g.start_local.date() != current_visible_date {
+                            return None;
+                        }
+                        let col = field_names.iter().position(|n| n == &g.field_name)?;
+                        let col_w = 100.0 / num_fields as f64;
+                        let left = col as f64 * col_w;
+                        let start_min =
+                            (g.start_local.hour() as i64) * 60 + g.start_local.minute() as i64;
+                        let dur = g.length_min.max(10);
+                        let top_slots = start_min as f64 / SLOT_MINUTES as f64;
+                        let height_slots = dur as f64 / SLOT_MINUTES as f64;
+                        let style = format!(
+                            "left: calc({left}% + 1px); width: calc({col_w}% - 2px); \
+                             top: calc(var(--slot-height) * {top_slots}); \
+                             height: calc(var(--slot-height) * {height_slots});"
+                        );
+                        let title =
+                            format!("{} – {}", fmt_minutes(start_min), fmt_minutes(start_min + dur));
+                        Some((style, title))
+                    });
                     let base_url = base_url.clone();
                     let tournament_url = tournament_url.clone();
                     rsx! {
@@ -5935,9 +6203,26 @@ fn ScheduleTimeline(
                                         editor: editor,
                                         selected: selected_ids.contains(&ev.id),
                                         dep_class: dep_class_map.get(&ev.id).map(|c| c.to_string()),
+                                        dep_shadow: if dep_class_map.get(&ev.id).copied()
+                                            == Some("schedule-timeline-event--dep-source")
+                                        {
+                                            dep_source_shadow.clone()
+                                        } else {
+                                            None
+                                        },
                                         on_move_pointer_down: on_block_drag_start,
                                         on_hover: on_block_hover,
+                                        result_pick_active: result_pick_active,
+                                        on_pick_result: on_pick_result,
                                     }
+                                }
+                            }
+                            if let Some((pending_style, pending_title)) = pending_block {
+                                div {
+                                    class: "schedule-drag-ghost schedule-drag-ghost--pending",
+                                    style: "{pending_style}",
+                                    div { class: "schedule-drag-ghost-title", "{pending_title}" }
+                                    div { class: "schedule-drag-ghost-sub", "new match" }
                                 }
                             }
                             if let Some((ghost_style, ghost_title, ghost_sub, ghost_blocked, gap_style)) = ghost_block {
@@ -6022,6 +6307,10 @@ fn EditMatchModal(
     data: ScheduleSetupResponse,
     on_close: EventHandler<()>,
     on_save: EventHandler<()>,
+    /// Last-focused team-ish input ("team1" | "team2" | "refs").
+    team_field_focus: Signal<Option<String>>,
+    /// Winner/Loser token queued by the timeline chips for insertion.
+    insert_team_ref: Signal<Option<String>>,
 ) -> Element {
     let match_data = data.matches.iter().find(|m| m.uuid == match_id).cloned();
 
@@ -6031,13 +6320,20 @@ fn EditMatchModal(
 
     let m = match_data.unwrap();
 
+    // Started/completed/skipped: still fully editable in the UI; the server
+    // rejects disallowed changes (surfaced via the warning + error alerts).
+    let match_locked = matches!(
+        m.status.as_str(),
+        "IN_PROGRESS" | "COMPLETED" | "SKIPPED"
+    );
+
     // Original schedule type for edit: only allow transitions STATIC→SAFE/FAST, SAFE→FAST
     let original_schedule_type = m.schedule_type.as_deref().unwrap_or("STATIC");
 
     let name = use_signal(|| m.name.clone());
     let mut field = use_signal(|| m.field.clone().unwrap_or_default());
     let schedule_type = use_signal(|| m.schedule_type.clone().unwrap_or("STATIC".to_string()));
-    let mut length = use_signal(|| m.nominal_length.unwrap_or(60));
+    let length = use_signal(|| m.nominal_length.unwrap_or(60));
 
     let start_time_init = if let Some(t) = &m.nominal_start_time {
         utc_iso_to_local_datetime_input(t).unwrap_or_else(|| t.chars().take(16).collect::<String>())
@@ -6065,9 +6361,9 @@ fn EditMatchModal(
             .or(m.team2.clone())
             .unwrap_or_default()
     });
-    let mut set_type = use_signal(|| m.set_type.clone().unwrap_or("SETS".to_string()));
-    let mut nsets = use_signal(|| m.nsets.unwrap_or(3));
-    let mut stones_per_set = use_signal(|| m.stones_per_set.unwrap_or(100));
+    let set_type = use_signal(|| m.set_type.clone().unwrap_or("SETS".to_string()));
+    let nsets = use_signal(|| m.nsets.unwrap_or(3));
+    let stones_per_set = use_signal(|| m.stones_per_set.unwrap_or(100));
     let ribbon = use_signal(|| m.ribbon);
     let mut skip_condition = use_signal(|| m.skip_condition.clone().unwrap_or_default());
     let mut skip_condition_help_open = use_signal(|| false);
@@ -6093,26 +6389,42 @@ fn EditMatchModal(
 
     let matches_on_field_edit = matches_on_field_sorted(&data.matches, &field(), Some(&match_id));
 
-    // When field changes, clear previous match so user must pick one on the new field
-    let data_field_edit = data.clone();
-    let match_id_for_field = match_id.clone();
+    // When field changes, clear previous match so user must pick one on the new
+    // field. Never auto-assign length/format from another match — the current
+    // values stay unless the user types new ones.
     let mut on_field_change_edit = move |new_field: String| {
-        field.set(new_field.clone());
+        field.set(new_field);
         previous_match_id.set("".to_string());
-        if !new_field.is_empty() {
-            let list = matches_on_field_sorted(
-                &data_field_edit.matches,
-                &new_field,
-                Some(&match_id_for_field),
-            );
-            if let Some(prev) = list.first() {
-                length.set(prev.nominal_length.unwrap_or(60));
-                set_type.set(prev.set_type.clone().unwrap_or_else(|| "SETS".to_string()));
-                nsets.set(prev.nsets.unwrap_or(3));
-                stones_per_set.set(prev.stones_per_set.unwrap_or(100));
-            }
-        }
     };
+
+    // Consume Winner/Loser tokens queued by the timeline chips into whichever
+    // team-ish input was focused last (refs appends; team1/team2 replace).
+    {
+        let mut insert_team_ref = insert_team_ref;
+        use_effect(move || {
+            if let Some(tok) = insert_team_ref() {
+                match team_field_focus.peek().as_deref() {
+                    Some("team1") => team1.set(tok.clone()),
+                    Some("team2") => team2.set(tok.clone()),
+                    Some("refs") => {
+                        let cur = refs
+                            .peek()
+                            .trim()
+                            .trim_end_matches(',')
+                            .trim()
+                            .to_string();
+                        refs.set(if cur.is_empty() {
+                            tok.clone()
+                        } else {
+                            format!("{cur}, {tok}")
+                        });
+                    }
+                    _ => {}
+                }
+                insert_team_ref.set(None);
+            }
+        });
+    }
 
     let u_save = tournament_url.clone();
     let m_id_save = match_id.clone();
@@ -6260,17 +6572,29 @@ fn EditMatchModal(
 
     rsx! {
         div {
+            // Docked editor card (not a modal): the schedule stays visible and
+            // interactive beside/below it.
             div {
-                class: "modal d-block",
+                class: "card schedule-editor-card",
                 tabindex: -1,
-                style: "background: rgba(0,0,0,0.5)",
                 onkeydown: modal_keydown,
-                div { class: "modal-dialog modal-lg",
-                    div { class: "modal-content",
-                        div { class: "modal-header",
-                            h5 { class: "modal-title", "Edit Match: {name}" }
+                div { class: "card-header d-flex justify-content-between align-items-center",
+                    h5 { class: "mb-0", "Edit Match: {name}" }
+                    button {
+                        class: "btn-close",
+                        r#type: "button",
+                        "aria-label": "Close",
+                        onclick: move |_| on_close.call(()),
+                    }
+                }
+                        div { class: "card-body",
+                        // Locked matches stay editable client-side; the server decides
+                        // what (if anything) it will accept and the error shows here.
+                        if match_locked {
+                            div { class: "alert alert-warning py-2",
+                                "This match has started or finished — changes will be rejected by the server."
+                            }
                         }
-                        div { class: "modal-body",
                         if let Some(err) = error() {
                             div { class: "alert alert-danger", "{err}" }
                         }
@@ -6359,7 +6683,12 @@ fn EditMatchModal(
 
                             if schedule_type() == "STATIC" || schedule_type() == "SAFE" || schedule_type() == "FAST" {
                                 div { class: "row",
+                                    // Focus tracking feeds the timeline's Winner/Loser hover chips.
                                     div { class: "col-md-6",
+                                        onfocusin: move |_| {
+                                            let mut t = team_field_focus;
+                                            t.set(Some("team1".to_string()));
+                                        },
                                         TeamSelectionField {
                                             label: "Team 1".to_string(),
                                             team_options: data.team_options.clone(),
@@ -6373,6 +6702,10 @@ fn EditMatchModal(
                                         }
                                     }
                                     div { class: "col-md-6",
+                                        onfocusin: move |_| {
+                                            let mut t = team_field_focus;
+                                            t.set(Some("team2".to_string()));
+                                        },
                                         TeamSelectionField {
                                             label: "Team 2".to_string(),
                                             team_options: data.team_options.clone(),
@@ -6386,16 +6719,22 @@ fn EditMatchModal(
                                         }
                                     }
                                 }
-                                TeamSelectionField {
-                                    label: "Referees".to_string(),
-                                    team_options: data.team_options.clone(),
-                                    tags: data.tags.clone(),
-                                    matches: data.matches.clone(),
-                                    value: refs(),
-                                    on_change: move |s| refs.set(s),
-                                    multiple: true,
-                                    placeholder: "(optional) teams, match winners/losers, or tags".to_string(),
-                                    help_text: Some("(optional) teams, match winners/losers, or tags".to_string()),
+                                div {
+                                    onfocusin: move |_| {
+                                        let mut t = team_field_focus;
+                                        t.set(Some("refs".to_string()));
+                                    },
+                                    TeamSelectionField {
+                                        label: "Referees".to_string(),
+                                        team_options: data.team_options.clone(),
+                                        tags: data.tags.clone(),
+                                        matches: data.matches.clone(),
+                                        value: refs(),
+                                        on_change: move |s| refs.set(s),
+                                        multiple: true,
+                                        placeholder: "(optional) teams, match winners/losers, or tags".to_string(),
+                                        help_text: Some("(optional) teams, match winners/losers, or tags".to_string()),
+                                    }
                                 }
                                 div { class: "row",
                                     div { class: "col-md-4",
@@ -6482,8 +6821,6 @@ fn EditMatchModal(
                             }
                         }
                     }
-                }
-            }
             }
             if skip_condition_help_open() {
                 SkipConditionHelpModal { on_close: move |_| skip_condition_help_open.set(false) }

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -4556,10 +4556,11 @@ fn ref_token_match_name(token: &str) -> Option<&str> {
 
 /// Line color for a dependency edge kind
 /// (0 = chain / previous match, 1 = team1 result, 2 = team2 result, _ = ref result).
+/// kind: 0 = chain (blue), 1 = team supplier (green), 2 = ref supplier (orange).
 fn dep_edge_color(kind: u8) -> &'static str {
     match kind {
         0 => "#0d6efd",
-        1 | 2 => "#d63384",
+        1 => "#198754",
         _ => "#fd7e14",
     }
 }
@@ -4604,48 +4605,46 @@ struct DepBlockGeom {
     height_slots: f64,
 }
 
-/// Endpoints for the `index`-th of `n_lines` visible dependency lines leaving
-/// the hovered block `from` toward `to`, in events-layer percentages
-/// (x: % of width, y: % of height).
-///
-/// - The line leaves the vertical edge of `from` facing `to` (top edge if the
-///   target's center is above, else bottom edge) and arrives at the opposing
-///   edge of `to`, both at the blocks' horizontal midpoints.
-/// - When several lines leave the hovered block, their origins fan out around
-///   its midpoint in ~0.6%-of-layer steps, clamped so the whole fan stays
-///   within the middle 80% of the block's width. `index`/`n_lines` must count
-///   only *visible* lines, otherwise a lone line gets a spurious offset.
-fn dep_line_endpoints(
-    index: usize,
-    n_lines: usize,
-    from: DepBlockGeom,
-    to: DepBlockGeom,
-    slots_per_day: usize,
-) -> (f64, f64, f64, f64) {
-    let step = if n_lines > 1 {
-        (0.6_f64).min(from.width * 0.8 / (n_lines as f64 - 1.0))
+/// Fan offset for the `index`-th of `n` line endpoints sharing a block edge:
+/// centered on the midpoint, ~0.6%-of-layer steps, clamped so the whole fan
+/// stays within the middle 80% of the block's width. Counts must cover only
+/// *visible* lines, otherwise a lone line gets a spurious offset.
+fn dep_fan_offset(index: usize, n: usize, block_width: f64) -> f64 {
+    let step = if n > 1 {
+        (0.6_f64).min(block_width * 0.8 / (n as f64 - 1.0))
     } else {
         0.0
     };
-    let offset = (index as f64 - (n_lines as f64 - 1.0) / 2.0) * step;
-    let fx = from.left + from.width / 2.0 + offset;
-    let tx = to.left + to.width / 2.0;
+    (index as f64 - (n as f64 - 1.0) / 2.0) * step
+}
+
+/// Endpoints for one dependency line, in events-layer percentages
+/// (x: % of width, y: % of height).
+///
+/// Lines always flow supply → demand: they LEAVE the BOTTOM edge of the
+/// dependency block `dep` and ENTER the TOP edge of the hovered (dependent)
+/// block `hovered`, each at the block's horizontal midpoint plus a fan offset.
+///
+/// - `exit_index`/`n_exit`: this line's position among the visible lines
+///   leaving `dep` (fans the bottom-edge exits when one dependency supplies
+///   several distinct things).
+/// - `entry_index`/`n_entry`: this line's position among ALL visible lines
+///   entering `hovered` (fans the top-edge entries).
+fn dep_line_endpoints(
+    exit_index: usize,
+    n_exit: usize,
+    entry_index: usize,
+    n_entry: usize,
+    dep: DepBlockGeom,
+    hovered: DepBlockGeom,
+    slots_per_day: usize,
+) -> (f64, f64, f64, f64) {
     let slot_pct = |slots: f64| slots / slots_per_day as f64 * 100.0;
-    let fcy = slot_pct(from.top_slots + from.height_slots / 2.0);
-    let tcy = slot_pct(to.top_slots + to.height_slots / 2.0);
-    let (fy, ty) = if tcy < fcy {
-        // Target above: leave from the top edge, arrive at the target's bottom.
-        (
-            slot_pct(from.top_slots),
-            slot_pct(to.top_slots + to.height_slots),
-        )
-    } else {
-        (
-            slot_pct(from.top_slots + from.height_slots),
-            slot_pct(to.top_slots),
-        )
-    };
-    (fx, fy, tx, ty)
+    let x1 = dep.left + dep.width / 2.0 + dep_fan_offset(exit_index, n_exit, dep.width);
+    let y1 = slot_pct(dep.top_slots + dep.height_slots);
+    let x2 = hovered.left + hovered.width / 2.0 + dep_fan_offset(entry_index, n_entry, hovered.width);
+    let y2 = slot_pct(hovered.top_slots);
+    (x1, y1, x2, y2)
 }
 
 #[cfg(test)]
@@ -4664,53 +4663,64 @@ mod dep_geometry_tests {
     }
 
     #[test]
-    fn single_line_starts_at_block_edge_midpoint() {
-        // Hovered block: second of four field columns (25% wide), 10:00–11:00.
-        let from = geom(25.0, 25.0, 20.0, 2.0);
-        // Target above it, first column, 08:00–09:00.
-        let to = geom(0.0, 25.0, 16.0, 2.0);
-        let (fx, fy, tx, ty) = dep_line_endpoints(0, 1, from, to, SLOTS);
-        assert_eq!(fx, 25.0 + 12.5); // exact horizontal midpoint, no fan offset
-        assert_eq!(fy, 20.0 / 48.0 * 100.0); // top edge (target is above)
-        assert_eq!(tx, 12.5);
-        assert_eq!(ty, (16.0 + 2.0) / 48.0 * 100.0); // target bottom edge
+    fn single_line_flows_dep_bottom_to_hovered_top() {
+        // Dependency: first column (25% wide), 08:00–09:00.
+        let dep = geom(0.0, 25.0, 16.0, 2.0);
+        // Hovered block below it, second column, 10:00–11:00.
+        let hovered = geom(25.0, 25.0, 20.0, 2.0);
+        let (x1, y1, x2, y2) = dep_line_endpoints(0, 1, 0, 1, dep, hovered, SLOTS);
+        assert_eq!(x1, 12.5); // dependency horizontal midpoint, no fan offset
+        assert_eq!(y1, (16.0 + 2.0) / 48.0 * 100.0); // dependency BOTTOM edge
+        assert_eq!(x2, 25.0 + 12.5); // hovered horizontal midpoint
+        assert_eq!(y2, 20.0 / 48.0 * 100.0); // hovered TOP edge
     }
 
     #[test]
-    fn single_line_respects_lane_inset() {
-        // Hovered block in the right lane of a two-lane column: lane-adjusted
-        // left/width, so the midpoint is the lane's center, not the column's.
-        let from = geom(37.5, 12.5, 20.0, 2.0);
-        let to = geom(0.0, 25.0, 30.0, 2.0);
-        let (fx, fy, _, ty) = dep_line_endpoints(0, 1, from, to, SLOTS);
-        assert_eq!(fx, 37.5 + 6.25);
-        assert_eq!(fy, (20.0 + 2.0) / 48.0 * 100.0); // bottom edge (target below)
-        assert_eq!(ty, 30.0 / 48.0 * 100.0);
+    fn direction_fixed_even_when_dep_is_below() {
+        // Even a dependency later in the day exits its bottom and enters the
+        // hovered block's top (the flow direction is semantic, not spatial).
+        let dep = geom(0.0, 25.0, 30.0, 2.0);
+        let hovered = geom(37.5, 12.5, 20.0, 2.0);
+        let (x1, y1, _, y2) = dep_line_endpoints(0, 1, 0, 1, dep, hovered, SLOTS);
+        assert_eq!(x1, 12.5);
+        assert_eq!(y1, (30.0 + 2.0) / 48.0 * 100.0); // dep bottom
+        assert_eq!(y2, 20.0 / 48.0 * 100.0); // hovered top (lane-inset midpoint on x2)
     }
 
     #[test]
-    fn fan_is_centered_and_stays_inside_block() {
-        let from = geom(0.0, 25.0, 20.0, 2.0);
-        let to = geom(50.0, 25.0, 16.0, 2.0);
+    fn entry_fan_is_centered_and_stays_inside_block() {
+        let dep = geom(50.0, 25.0, 16.0, 2.0);
+        let hovered = geom(0.0, 25.0, 20.0, 2.0);
         let n = 3;
         let xs: Vec<f64> = (0..n)
-            .map(|i| dep_line_endpoints(i, n, from, to, SLOTS).0)
+            .map(|i| dep_line_endpoints(0, 1, i, n, dep, hovered, SLOTS).2)
             .collect();
-        // Centered on the midpoint, symmetric, evenly spaced.
+        // Centered on the hovered block's midpoint, symmetric, evenly spaced.
         assert_eq!(xs[1], 12.5);
         assert!((xs[1] - xs[0] - (xs[2] - xs[1])).abs() < 1e-9);
-        // Whole fan within the block's width.
+        // Whole fan within the hovered block's width.
         assert!(xs[0] > 0.0 && xs[2] < 25.0);
     }
 
     #[test]
-    fn ring_shadow_one_ring_per_edge_in_order() {
-        let css = dep_ring_shadow(&[0, 1, 3]);
+    fn exit_fan_separates_lines_leaving_one_dependency() {
+        // A dependency supplying a team AND a ref: two exits, side by side.
+        let dep = geom(0.0, 25.0, 16.0, 2.0);
+        let hovered = geom(25.0, 25.0, 20.0, 2.0);
+        let (xa, ..) = dep_line_endpoints(0, 2, 0, 2, dep, hovered, SLOTS);
+        let (xb, ..) = dep_line_endpoints(1, 2, 1, 2, dep, hovered, SLOTS);
+        assert!(xa < 12.5 && 12.5 < xb); // straddle the midpoint
+        assert!((12.5 - xa - (xb - 12.5)).abs() < 1e-9); // symmetric
+    }
+
+    #[test]
+    fn ring_shadow_one_ring_per_distinct_edge_in_order() {
+        let css = dep_ring_shadow(&[0, 1, 2]);
         assert!(css.starts_with("box-shadow: "));
         assert_eq!(css.matches("rgba(255,255,255,0.9)").count(), 3);
         // Ring order (inner→outer) follows edge order; colors match the lines.
         let chain = css.find("#0d6efd").unwrap();
-        let team = css.find("#d63384").unwrap();
+        let team = css.find("#198754").unwrap();
         let refc = css.find("#fd7e14").unwrap();
         assert!(chain < team && team < refc);
     }
@@ -5622,8 +5632,12 @@ fn ScheduleTimeline(
         on_edit_match.call(id);
     });
 
-    // Alt-hover dependency edges for the hovered block: (from, to, kind)
-    // kind: 0 = chain (previous_match), 1 = team1 result, 2 = team2 result, 3 = ref result.
+    // Alt-hover dependency edges for the hovered block: (hovered, dependency, kind)
+    // kind: 0 = chain (previous_match), 1 = team supplier (team1 OR team2 —
+    // both render identically), 2 = ref supplier. Duplicate (dependency, kind)
+    // pairs are collapsed: a match supplying both teams draws ONE green line
+    // and one green ring, but supplying a team AND a ref draws two distinct
+    // edges.
     let dep_edges: Vec<(String, String, u8)> = if editor && alt_down() {
         if let Some(hid) = hovered_block() {
             let name_to_uuid: HashMap<&str, &str> = data
@@ -5633,23 +5647,29 @@ fn ScheduleTimeline(
                 .map(|m| (m.name.as_str(), m.uuid.as_str()))
                 .collect();
             let mut edges: Vec<(String, String, u8)> = Vec::new();
+            let mut seen: std::collections::HashSet<(String, u8)> = std::collections::HashSet::new();
+            let mut push_edge = |edges: &mut Vec<(String, String, u8)>, to: String, kind: u8| {
+                if seen.insert((to.clone(), kind)) {
+                    edges.push((hid.clone(), to, kind));
+                }
+            };
             if let Some(m) = data.matches.iter().find(|m| m.uuid == hid) {
                 if let Some(prev) = m.previous_match.as_deref() {
                     if !prev.is_empty() {
-                        edges.push((hid.clone(), prev.to_string(), 0));
+                        push_edge(&mut edges, prev.to_string(), 0);
                     }
                 }
-                for (tok, kind) in [(m.team1_initial.as_deref(), 1u8), (m.team2_initial.as_deref(), 2u8)] {
+                for tok in [m.team1_initial.as_deref(), m.team2_initial.as_deref()] {
                     if let Some(name) = tok.and_then(ref_token_match_name) {
                         if let Some(&uuid) = name_to_uuid.get(name) {
-                            edges.push((hid.clone(), uuid.to_string(), kind));
+                            push_edge(&mut edges, uuid.to_string(), 1);
                         }
                     }
                 }
                 for tok in m.refs_initial.as_deref().unwrap_or("").split(',') {
                     if let Some(name) = ref_token_match_name(tok) {
                         if let Some(&uuid) = name_to_uuid.get(name) {
-                            edges.push((hid.clone(), uuid.to_string(), 3));
+                            push_edge(&mut edges, uuid.to_string(), 2);
                         }
                     }
                 }
@@ -5661,7 +5681,9 @@ fn ScheduleTimeline(
     } else {
         Vec::new()
     };
-    // Highlight classes for dependency targets (and the hovered source).
+    // Highlight classes: the hovered block only gets a z-lift (its identity is
+    // obvious — it's under the cursor); dependency blocks get a light tint by
+    // their primary incoming edge kind.
     let dep_class_map: HashMap<String, &'static str> = {
         let mut map = HashMap::new();
         if !dep_edges.is_empty() {
@@ -5669,7 +5691,7 @@ fn ScheduleTimeline(
                 map.insert(from.clone(), "schedule-timeline-event--dep-source");
                 let class = match kind {
                     0 => "schedule-timeline-event--dep-chain",
-                    1 | 2 => "schedule-timeline-event--dep-team",
+                    1 => "schedule-timeline-event--dep-team",
                     _ => "schedule-timeline-event--dep-ref",
                 };
                 // Chain highlight wins if a block is referenced multiple ways.
@@ -5678,19 +5700,22 @@ fn ScheduleTimeline(
         }
         map
     };
-    // Nested outline rings, one ring per edge, colored like its line: the
-    // hovered source gets a ring per OUTGOING edge, and every dependency
-    // target gets a ring per INCOMING edge from the hovered match (e.g. a
-    // match used as `A::winner` team and `A::loser` ref shows two rings on A).
+    // Outline rings on DEPENDENCY blocks only: one ring per distinct incoming
+    // edge kind, colored like the corresponding line — "this match supplies a
+    // team (green) and the field slot (blue)" reads directly off the rings.
+    // The hovered match itself gets no rings. Kinds are already deduped in
+    // dep_edges; sort so ring order is stable (chain, team, ref).
     let dep_shadow_by_id: HashMap<String, String> = {
         let mut kinds_by_id: HashMap<String, Vec<u8>> = HashMap::new();
-        for (from, to, kind) in &dep_edges {
-            kinds_by_id.entry(from.clone()).or_default().push(*kind);
+        for (_, to, kind) in &dep_edges {
             kinds_by_id.entry(to.clone()).or_default().push(*kind);
         }
         kinds_by_id
             .into_iter()
-            .map(|(id, kinds)| (id, dep_ring_shadow(&kinds)))
+            .map(|(id, mut kinds)| {
+                kinds.sort_unstable();
+                (id, dep_ring_shadow(&kinds))
+            })
             .collect()
     };
 
@@ -6322,41 +6347,64 @@ fn ScheduleTimeline(
                     // the index among visible lines — indexing over all edges gave a
                     // lone visible line a spurious offset whenever a sibling edge's
                     // target was hidden (other day / other field filter).
-                    let visible_dep_edges: Vec<(DepBlockGeom, DepBlockGeom, u8)> = dep_edges
+                    // (dep id, dep geom, hovered geom, kind) for edges whose
+                    // both blocks are visible on the current day/filter.
+                    let visible_dep_edges: Vec<(String, DepBlockGeom, DepBlockGeom, u8)> = dep_edges
                         .iter()
                         .filter_map(|(from, to, kind)| {
-                            let (fl, fw, ft, fh) = *geom_by_id.get(from)?;
-                            let (tl, tw, tt, th) = *geom_by_id.get(to)?;
+                            let (hl, hw, ht, hh) = *geom_by_id.get(from)?;
+                            let (dl, dw, dt, dh) = *geom_by_id.get(to)?;
                             Some((
+                                to.clone(),
                                 DepBlockGeom {
-                                    left: fl,
-                                    width: fw,
-                                    top_slots: ft,
-                                    height_slots: fh,
+                                    left: dl,
+                                    width: dw,
+                                    top_slots: dt,
+                                    height_slots: dh,
                                 },
                                 DepBlockGeom {
-                                    left: tl,
-                                    width: tw,
-                                    top_slots: tt,
-                                    height_slots: th,
+                                    left: hl,
+                                    width: hw,
+                                    top_slots: ht,
+                                    height_slots: hh,
                                 },
                                 *kind,
                             ))
                         })
                         .collect();
-                    let n_dep_lines = visible_dep_edges.len();
+                    // Lines flow dependency-bottom → hovered-top. Entries fan
+                    // by position among ALL visible lines; exits fan by
+                    // position among the lines leaving that same dependency.
+                    let n_entry = visible_dep_edges.len();
+                    let n_exit_by_dep: HashMap<&str, usize> = {
+                        let mut m: HashMap<&str, usize> = HashMap::new();
+                        for (dep_id, ..) in &visible_dep_edges {
+                            *m.entry(dep_id.as_str()).or_insert(0) += 1;
+                        }
+                        m
+                    };
+                    let mut exit_seen: HashMap<&str, usize> = HashMap::new();
                     let dep_lines: Vec<(f64, f64, f64, f64, u8)> = visible_dep_edges
                         .iter()
                         .enumerate()
-                        .map(|(i, (from_geom, to_geom, kind))| {
-                            let (fx, fy, tx, ty) = dep_line_endpoints(
-                                i,
-                                n_dep_lines,
-                                *from_geom,
-                                *to_geom,
+                        .map(|(entry_index, (dep_id, dep_geom, hovered_geom, kind))| {
+                            let exit_index = {
+                                let e = exit_seen.entry(dep_id.as_str()).or_insert(0);
+                                let i = *e;
+                                *e += 1;
+                                i
+                            };
+                            let n_exit = *n_exit_by_dep.get(dep_id.as_str()).unwrap_or(&1);
+                            let (x1, y1, x2, y2) = dep_line_endpoints(
+                                exit_index,
+                                n_exit,
+                                entry_index,
+                                n_entry,
+                                *dep_geom,
+                                *hovered_geom,
                                 slots_per_day,
                             );
-                            (fx, fy, tx, ty, *kind)
+                            (x1, y1, x2, y2, *kind)
                         })
                         .collect();
                     let dep_lines_active = !dep_lines.is_empty();
@@ -6508,28 +6556,20 @@ fn ScheduleTimeline(
                                             y1: "{y1}%",
                                             x2: "{x2}%",
                                             y2: "{y2}%",
-                                            stroke: match kind {
-                                                0 => "#0d6efd",
-                                                1 | 2 => "#d63384",
-                                                _ => "#fd7e14",
-                                            },
+                                            stroke: dep_edge_color(*kind),
                                             stroke_width: "2.5",
                                             stroke_dasharray: match kind {
-                                                0 => "none",
-                                                1 => "none",
-                                                2 => "7 4",
+                                                0 | 1 => "none",
                                                 _ => "3 3",
                                             },
                                         }
+                                        // Dot at the supply end (the dependency's
+                                        // bottom edge, where the line leaves).
                                         circle {
-                                            cx: "{x2}%",
-                                            cy: "{y2}%",
+                                            cx: "{x1}%",
+                                            cy: "{y1}%",
                                             r: "3.5",
-                                            fill: match kind {
-                                                0 => "#0d6efd",
-                                                1 | 2 => "#d63384",
-                                                _ => "#fd7e14",
-                                            },
+                                            fill: dep_edge_color(*kind),
                                         }
                                         }
                                     }
@@ -6540,12 +6580,12 @@ fn ScheduleTimeline(
                                         "previous match"
                                     }
                                     span { class: "schedule-dep-legend-item",
-                                        span { class: "schedule-dep-legend-swatch", style: "background:#d63384;" }
-                                        "team result (dashed = team 2)"
+                                        span { class: "schedule-dep-legend-swatch", style: "background:#198754;" }
+                                        "supplies a team"
                                     }
                                     span { class: "schedule-dep-legend-item",
                                         span { class: "schedule-dep-legend-swatch", style: "background:#fd7e14;" }
-                                        "ref result"
+                                        "supplies a ref"
                                     }
                                 }
                             }

--- a/frontend/src/pages/schedule_timeline.css
+++ b/frontend/src/pages/schedule_timeline.css
@@ -1067,7 +1067,7 @@
 }
 
 .schedule-timeline-event--dep-team {
-    background-color: rgba(214, 51, 132, 0.12) !important;
+    background-color: rgba(25, 135, 84, 0.12) !important;
     z-index: 19 !important;
 }
 

--- a/frontend/src/pages/schedule_timeline.css
+++ b/frontend/src/pages/schedule_timeline.css
@@ -1053,30 +1053,25 @@
     box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.25);
 }
 
-/* Alt-hover dependency view: source + per-edge-kind target highlights.
-   The source block's rings come from an inline box-shadow stack (one ring per
-   dependency edge, colored like its line); this class only lifts it. */
+/* Alt-hover dependency view. Both the hovered source and every dependency
+   target get their outline rings from an inline box-shadow stack (one ring per
+   edge, colored like its line); these classes only lift the blocks and tint
+   targets by their primary (first) incoming edge kind. */
 .schedule-timeline-event--dep-source {
     z-index: 20 !important;
 }
 
 .schedule-timeline-event--dep-chain {
-    outline: 2px solid #0d6efd;
-    outline-offset: -1px;
     background-color: rgba(13, 110, 253, 0.12) !important;
     z-index: 19 !important;
 }
 
 .schedule-timeline-event--dep-team {
-    outline: 2px solid #d63384;
-    outline-offset: -1px;
     background-color: rgba(214, 51, 132, 0.12) !important;
     z-index: 19 !important;
 }
 
 .schedule-timeline-event--dep-ref {
-    outline: 2px solid #fd7e14;
-    outline-offset: -1px;
     background-color: rgba(253, 126, 20, 0.12) !important;
     z-index: 19 !important;
 }

--- a/frontend/src/pages/schedule_timeline.css
+++ b/frontend/src/pages/schedule_timeline.css
@@ -988,3 +988,134 @@
     );
     box-shadow: inset 5px 0 0 #9575cd;
 }
+
+/* ------------------------------------------------------------------ */
+/* Schedule edit page: drag-to-create / drag-to-move / bulk select /   */
+/* alt-hover dependency view.                                           */
+/* ------------------------------------------------------------------ */
+
+/* Live-growing placeholder while drag-creating, and the move ghost. */
+.schedule-drag-ghost {
+    position: absolute;
+    box-sizing: border-box;
+    border: 2px dashed #0d6efd;
+    border-radius: 6px;
+    background: rgba(13, 110, 253, 0.12);
+    color: #0d6efd;
+    font-size: 0.85em;
+    font-weight: 600;
+    padding: 0.25rem 0.4rem;
+    pointer-events: none;
+    z-index: 28;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+}
+
+.schedule-drag-ghost--blocked {
+    border-color: #dc3545;
+    background: rgba(220, 53, 69, 0.12);
+    color: #dc3545;
+}
+
+.schedule-drag-ghost-title {
+    line-height: 1.2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.schedule-drag-ghost-sub {
+    font-weight: 400;
+    font-size: 0.9em;
+    opacity: 0.85;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Snap-target indicator for dynamic moves: the gap after the would-be previous match. */
+.schedule-drag-gap-line {
+    position: absolute;
+    height: 0;
+    border-top: 3px solid #0d6efd;
+    box-shadow: 0 0 4px rgba(13, 110, 253, 0.6);
+    pointer-events: none;
+    z-index: 27;
+}
+
+/* Bulk-length tool: selected blocks. */
+.schedule-timeline-event--bulk-selected {
+    outline: 3px solid #0d6efd;
+    outline-offset: -1px;
+    background-color: rgba(13, 110, 253, 0.10) !important;
+    box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.25);
+}
+
+/* Alt-hover dependency view: source + per-edge-kind target highlights. */
+.schedule-timeline-event--dep-source {
+    outline: 2px solid #212529;
+    outline-offset: -1px;
+    z-index: 20 !important;
+}
+
+.schedule-timeline-event--dep-chain {
+    outline: 2px solid #0d6efd;
+    outline-offset: -1px;
+    background-color: rgba(13, 110, 253, 0.12) !important;
+    z-index: 19 !important;
+}
+
+.schedule-timeline-event--dep-team {
+    outline: 2px solid #d63384;
+    outline-offset: -1px;
+    background-color: rgba(214, 51, 132, 0.12) !important;
+    z-index: 19 !important;
+}
+
+.schedule-timeline-event--dep-ref {
+    outline: 2px solid #fd7e14;
+    outline-offset: -1px;
+    background-color: rgba(253, 126, 20, 0.12) !important;
+    z-index: 19 !important;
+}
+
+/* Legend chip shown while the alt-dependency view is active. */
+.schedule-dep-legend {
+    position: sticky;
+    top: 0.25rem;
+    margin: 0.25rem;
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    align-items: center;
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    z-index: 31;
+    pointer-events: none;
+    width: fit-content;
+}
+
+.schedule-dep-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    white-space: nowrap;
+}
+
+.schedule-dep-legend-swatch {
+    display: inline-block;
+    width: 0.85em;
+    height: 0.85em;
+    border-radius: 2px;
+}
+
+/* While a drag is in flight, don't let text in blocks get selected. */
+.schedule-timeline {
+    user-select: none;
+    -webkit-user-select: none;
+}

--- a/frontend/src/pages/schedule_timeline.css
+++ b/frontend/src/pages/schedule_timeline.css
@@ -1076,6 +1076,17 @@
     z-index: 19 !important;
 }
 
+/* Ring carrier for the alt-dependency view: hugs its block and paints the
+ * per-edge box-shadow rings; mounted/unmounted with the view so no stale
+ * inline style can ever linger on the block itself. */
+.schedule-dep-rings {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    z-index: 1;
+}
+
 /* Legend chip shown while the alt-dependency view is active. */
 .schedule-dep-legend {
     position: sticky;

--- a/frontend/src/pages/schedule_timeline.css
+++ b/frontend/src/pages/schedule_timeline.css
@@ -1053,10 +1053,10 @@
     box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.25);
 }
 
-/* Alt-hover dependency view: source + per-edge-kind target highlights. */
+/* Alt-hover dependency view: source + per-edge-kind target highlights.
+   The source block's rings come from an inline box-shadow stack (one ring per
+   dependency edge, colored like its line); this class only lifts it. */
 .schedule-timeline-event--dep-source {
-    outline: 2px solid #212529;
-    outline-offset: -1px;
     z-index: 20 !important;
 }
 
@@ -1118,4 +1118,103 @@
 .schedule-timeline {
     user-select: none;
     -webkit-user-select: none;
+}
+
+/* ------------------------------------------------------------------ */
+/* Editor layout: full-bleed page + docked editor card.                 */
+/* ------------------------------------------------------------------ */
+
+/* Escape the layout's centered max-width container (editor page only). */
+.schedule-editor-fullbleed {
+    width: 100vw;
+    max-width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+}
+
+/* Schedule + docked editor card. Narrow screens: card above the schedule
+   (column-reverse); wide screens: card docked to the right, schedule shrinks. */
+.schedule-editor-split {
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 1rem;
+    align-items: stretch;
+}
+
+.schedule-editor-main {
+    min-width: 0;
+}
+
+@media (min-width: 992px) {
+    .schedule-editor-split {
+        flex-direction: row;
+        align-items: flex-start;
+    }
+
+    .schedule-editor-split > .schedule-editor-main {
+        flex: 1 1 auto;
+    }
+
+    .schedule-editor-panel {
+        flex: 0 0 400px;
+        width: 400px;
+        position: sticky;
+        top: 0.75rem;
+        max-height: calc(100vh - 1.5rem);
+        overflow-y: auto;
+    }
+
+    /* The card is far narrower than the old modal: stack its form columns. */
+    .schedule-editor-panel .col-md-4,
+    .schedule-editor-panel .col-md-6 {
+        width: 100%;
+    }
+}
+
+.schedule-editor-card {
+    box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.12);
+}
+
+/* Pending-create placeholder: stays visible while the create card is open. */
+.schedule-drag-ghost--pending {
+    border-color: #198754;
+    background: rgba(25, 135, 84, 0.10);
+    color: #198754;
+}
+
+/* Winner/Loser insertion chips: shown on block hover while an editor card has
+   a team-ish input focused. */
+.schedule-result-chips {
+    position: absolute;
+    top: 2px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: none;
+    gap: 0.3rem;
+    z-index: 7;
+}
+
+.schedule-timeline-event:hover .schedule-result-chips {
+    display: inline-flex;
+}
+
+.schedule-result-chip {
+    border: none;
+    border-radius: 999px;
+    font-size: 0.7em;
+    font-weight: 700;
+    line-height: 1.2;
+    padding: 0.15rem 0.5rem;
+    color: #fff;
+    cursor: pointer;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+    pointer-events: auto;
+}
+
+.schedule-result-chip--winner {
+    background: #198754;
+}
+
+.schedule-result-chip--loser {
+    background: #dc3545;
 }

--- a/frontend/src/pages/tournament_home.rs
+++ b/frontend/src/pages/tournament_home.rs
@@ -676,6 +676,7 @@ fn TournamentHomeContent(url: String, initial_tab: Option<String>) -> Element {
                                             div { class: "card-body",
                                                 div { class: "d-grid gap-2",
                                                     Link { to: Route::TournamentSettings { url: url.clone() }, class: "btn btn-outline-secondary", "Settings" }
+                                                    Link { to: Route::ScheduleEdit { url: url.clone() }, class: "btn btn-outline-primary", "Edit Schedule" }
                                                     if let Some(ref l) = d.tournament.league {
                                                         Link { to: Route::LeagueManage { league_url: l.league_url.clone() }, class: "btn btn-outline-warning", "Registration Management" }
                                                     } else {

--- a/frontend/src/types.rs
+++ b/frontend/src/types.rs
@@ -1537,6 +1537,29 @@ pub struct CreateBreakGroupRequest {
 
 /// Edit every same-name break row at once. `None` fields are left unchanged.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BulkMatchLengthRequest {
+    pub match_ids: Vec<String>,
+    pub length: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BulkMatchLengthResultEntry {
+    pub match_id: String,
+    pub status: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BulkMatchLengthResponse {
+    pub success: bool,
+    #[serde(default)]
+    pub updated: u32,
+    #[serde(default)]
+    pub results: Vec<BulkMatchLengthResultEntry>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UpdateBreakGroupRequest {
     /// Whole-group conversion; only BREAK↔JOIN is accepted by the server.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/frontend/src/types.rs
+++ b/frontend/src/types.rs
@@ -1634,7 +1634,6 @@ pub struct CreateTagResponse {
     pub id: u32,
 }
 
-#[allow(dead_code)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PushBackRequest {
     pub minutes: i32,

--- a/tests/test_bulk_match_length.py
+++ b/tests/test_bulk_match_length.py
@@ -1,0 +1,198 @@
+"""Integration tests for the bulk match-length endpoint.
+
+POST /_api/tournaments/<url>/matches/bulk-length sets nominal_length on many
+matches at once, skipping JOINs and started (locked) matches.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.domain.enums import MatchStatus, ScheduleType
+from models import TO, Match, Tournament, db
+from tests.utils import login_as, make_registrable_config
+
+
+@pytest.fixture
+def to_player(test_db, tournament, player):
+    """Register the default player as TO of the default tournament."""
+    db.session.add(TO(event=tournament.url, user_id=player.id, user_type="player"))
+    db.session.commit()
+    return player
+
+
+def _make_match(event, name, schedule_type=ScheduleType.STATIC, status=MatchStatus.NOT_STARTED, length=30):
+    m = Match(
+        name=name,
+        event=event,
+        field="Field 1",
+        schedule_type=schedule_type,
+        status=status,
+        nominal_length=length,
+        nominal_start_time=datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+    db.session.add(m)
+    db.session.flush()
+    return m
+
+
+@pytest.mark.integration
+def test_bulk_length_happy_path(app, client, tournament, to_player):
+    """All editable matches get the shared length; response reports each as updated."""
+    with app.app_context():
+        t = db.session.merge(tournament)
+        t_url = t.url
+        m1 = _make_match(t.url, "Bulk A")
+        m2 = _make_match(t.url, "Bulk B", schedule_type=ScheduleType.SAFE)
+        m2.previous_match = m1.uuid
+        m1.next_match = m2.uuid
+        db.session.commit()
+        ids = [m1.uuid, m2.uuid]
+        login_as(client, db.session.merge(to_player))
+
+    resp = client.post(
+        f"/_api/tournaments/{t_url}/matches/bulk-length",
+        json={"match_ids": ids, "length": 45},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert data["updated"] == 2
+    assert all(r["status"] == "updated" for r in data["results"])
+
+    with app.app_context():
+        for mid in ids:
+            m = Match.query.filter_by(uuid=mid).first()
+            assert m.nominal_length == 45
+
+
+@pytest.mark.integration
+def test_bulk_length_skips_locked_but_updates_statbreak(app, client, tournament, to_player):
+    """Started matches are skipped; a COMPLETED STATBREAK is still editable."""
+    with app.app_context():
+        t = db.session.merge(tournament)
+        t_url = t.url
+        locked = _make_match(t.url, "Locked", status=MatchStatus.COMPLETED)
+        statbreak = _make_match(
+            t.url,
+            "Lunch",
+            schedule_type=ScheduleType.STATBREAK,
+            status=MatchStatus.COMPLETED,
+        )
+        db.session.commit()
+        locked_id, statbreak_id = locked.uuid, statbreak.uuid
+        login_as(client, db.session.merge(to_player))
+
+    resp = client.post(
+        f"/_api/tournaments/{t_url}/matches/bulk-length",
+        json={"match_ids": [locked_id, statbreak_id], "length": 20},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["updated"] == 1
+    statuses = {r["match_id"]: r["status"] for r in data["results"]}
+    assert statuses[locked_id] == "skipped_locked"
+    assert statuses[statbreak_id] == "updated"
+
+    with app.app_context():
+        assert Match.query.filter_by(uuid=locked_id).first().nominal_length == 30
+        assert Match.query.filter_by(uuid=statbreak_id).first().nominal_length == 20
+
+
+@pytest.mark.integration
+def test_bulk_length_skips_join(app, client, tournament, to_player):
+    """JOIN matches are structurally zero-length and reported as skipped."""
+    with app.app_context():
+        t = db.session.merge(tournament)
+        t_url = t.url
+        anchor = _make_match(t.url, "Anchor")
+        join = _make_match(t.url, "JoinPoint", schedule_type=ScheduleType.JOIN, length=0)
+        join.previous_match = anchor.uuid
+        anchor.next_match = join.uuid
+        db.session.commit()
+        join_id = join.uuid
+        login_as(client, db.session.merge(to_player))
+
+    resp = client.post(
+        f"/_api/tournaments/{t_url}/matches/bulk-length",
+        json={"match_ids": [join_id], "length": 25},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["updated"] == 0
+    assert data["results"][0]["status"] == "skipped_join"
+
+    with app.app_context():
+        assert Match.query.filter_by(uuid=join_id).first().nominal_length == 0
+
+
+@pytest.mark.integration
+def test_bulk_length_foreign_tournament_match_not_touched(app, client, tournament, to_player):
+    """A match belonging to another tournament is reported not_found and left unchanged."""
+    with app.app_context():
+        t = db.session.merge(tournament)
+        t_url = t.url
+        cfg = make_registrable_config()
+        other = Tournament(
+            url="other-bulk-tournament",
+            name="Other Tournament",
+            start_date=datetime.now(timezone.utc),
+            published=True,
+            registrable_config_id=cfg.id,
+        )
+        db.session.add(other)
+        db.session.flush()
+        foreign = _make_match(other.url, "Foreign Match")
+        db.session.commit()
+        foreign_id = foreign.uuid
+        login_as(client, db.session.merge(to_player))
+
+    resp = client.post(
+        f"/_api/tournaments/{t_url}/matches/bulk-length",
+        json={"match_ids": [foreign_id], "length": 90},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["updated"] == 0
+    assert data["results"][0]["status"] == "not_found"
+
+    with app.app_context():
+        assert Match.query.filter_by(uuid=foreign_id).first().nominal_length == 30
+
+
+@pytest.mark.integration
+def test_bulk_length_requires_to(app, client, tournament, player):
+    """Non-TOs get a 403."""
+    with app.app_context():
+        t = db.session.merge(tournament)
+        t_url = t.url
+        m = _make_match(t.url, "NoAuth Match")
+        db.session.commit()
+        mid = m.uuid
+        login_as(client, db.session.merge(player))
+
+    resp = client.post(
+        f"/_api/tournaments/{t_url}/matches/bulk-length",
+        json={"match_ids": [mid], "length": 45},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.integration
+def test_bulk_length_validates_input(app, client, tournament, to_player):
+    """Bad lengths and empty id lists are rejected with 400."""
+    with app.app_context():
+        t = db.session.merge(tournament)
+        t_url = t.url
+        m = _make_match(t.url, "Validate Match")
+        db.session.commit()
+        mid = m.uuid
+        login_as(client, db.session.merge(to_player))
+
+    url = f"/_api/tournaments/{t_url}/matches/bulk-length"
+    assert client.post(url, json={"match_ids": [mid], "length": 0}).status_code == 400
+    assert client.post(url, json={"match_ids": [mid], "length": "abc"}).status_code == 400
+    assert client.post(url, json={"match_ids": [], "length": 30}).status_code == 400
+    assert client.post(url, json={"match_ids": "not-a-list", "length": 30}).status_code == 400

--- a/tests/test_chain_splice.py
+++ b/tests/test_chain_splice.py
@@ -1,0 +1,135 @@
+"""Regression tests for per-field chain splicing (previous_match/next_match).
+
+Covers the "half-linked chain" bug: a successor points at its predecessor via
+``previous_match`` while the predecessor's ``next_match`` is unset. This state
+arises around STATIC matches (deliberately detached on edit) and TOML imports
+(which only populate ``previous_match``). Inserting a match after the
+predecessor used to leave the old successor still pointing at it, so both
+matches shared a dependency and solved to the same start time.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from app.domain.enums import MatchStatus, ScheduleType
+from app.routes.tournaments import update_match_previous_link
+from app.utils.scheduling import recompute_scheduled_and_nominal_times
+from models import Match, db
+
+pytestmark = pytest.mark.unit
+
+
+def _mk(name, event, sched, start=None, length=30):
+    m = Match(
+        name=name,
+        event=event,
+        field="Field 1",
+        schedule_type=sched,
+        nominal_length=length,
+        status=MatchStatus.NOT_STARTED,
+        skip_condition="false",
+    )
+    if start is not None:
+        m.nominal_start_time = start
+        m.scheduled_start_time = start
+    db.session.add(m)
+    db.session.flush()
+    return m
+
+
+class TestHalfLinkedChainSplice:
+    def test_insert_after_half_linked_static_repoints_successor(self, app, test_db, tournament):
+        """Moving A in front of B (both after a detached STATIC) must re-point B at A."""
+        url = tournament.url
+        with app.app_context():
+            s = _mk("S", url, ScheduleType.STATIC, start=datetime(2026, 8, 20, 9, 0))
+            b = _mk("B", url, ScheduleType.SAFE)
+            a = _mk("A", url, ScheduleType.SAFE)
+            # Half-linked: B points back at S, but S.next_match is unset
+            # (exactly what a STATIC edit's detach leaves behind).
+            b.previous_match = s.uuid
+            a.previous_match = b.uuid
+            b.next_match = a.uuid
+            db.session.commit()
+            recompute_scheduled_and_nominal_times(url)
+
+            # Drag-move: A in front of B == insert A after S.
+            a = Match.query.filter_by(name="A", event=url).first()
+            update_match_previous_link(a, s.uuid, url)
+            db.session.commit()
+            recompute_scheduled_and_nominal_times(url)
+
+            s = Match.query.filter_by(name="S", event=url).first()
+            a = Match.query.filter_by(name="A", event=url).first()
+            b = Match.query.filter_by(name="B", event=url).first()
+
+            # Chain is S -> A -> B.
+            assert s.next_match == a.uuid
+            assert a.previous_match == s.uuid
+            assert a.next_match == b.uuid
+            assert b.previous_match == a.uuid
+            assert b.next_match is None
+
+            # And the solved times are strictly ordered, not identical.
+            assert a.nominal_start_time == datetime(2026, 8, 20, 9, 30)
+            assert b.nominal_start_time == datetime(2026, 8, 20, 10, 0)
+            assert a.scheduled_start_time < b.scheduled_start_time
+
+    def test_fully_linked_reorder_still_works(self, app, test_db, tournament):
+        """The normal fully-linked reorder path is unchanged by the fallback."""
+        url = tournament.url
+        with app.app_context():
+            s = _mk("S", url, ScheduleType.STATIC, start=datetime(2026, 8, 20, 9, 0))
+            b = _mk("B", url, ScheduleType.SAFE)
+            c = _mk("C", url, ScheduleType.SAFE)
+            a = _mk("A", url, ScheduleType.SAFE)
+            for prev, nxt in ((s, b), (b, c), (c, a)):
+                nxt.previous_match = prev.uuid
+                prev.next_match = nxt.uuid
+            db.session.commit()
+            recompute_scheduled_and_nominal_times(url)
+
+            a = Match.query.filter_by(name="A", event=url).first()
+            update_match_previous_link(a, s.uuid, url)
+            db.session.commit()
+            recompute_scheduled_and_nominal_times(url)
+
+            names_in_chain = []
+            cur = Match.query.filter_by(name="S", event=url).first()
+            while cur is not None:
+                names_in_chain.append(cur.name)
+                cur = Match.query.filter_by(uuid=cur.next_match, event=url).first() if cur.next_match else None
+            assert names_in_chain == ["S", "A", "B", "C"]
+
+            starts = {m.name: m.nominal_start_time for m in Match.query.filter_by(event=url).all()}
+            assert len(set(starts.values())) == 4, f"duplicate start times: {starts}"
+
+    def test_ambiguous_back_pointers_do_not_guess(self, app, test_db, tournament):
+        """Two matches pointing back at the same predecessor: no arbitrary re-pointing."""
+        url = tournament.url
+        with app.app_context():
+            s = _mk("S", url, ScheduleType.STATIC, start=datetime(2026, 8, 20, 9, 0))
+            b = _mk("B", url, ScheduleType.SAFE)
+            c = _mk("C", url, ScheduleType.SAFE)
+            a = _mk("A", url, ScheduleType.SAFE)
+            # Already-degenerate: B and C both claim S as previous.
+            b.previous_match = s.uuid
+            c.previous_match = s.uuid
+            a.previous_match = c.uuid
+            c.next_match = a.uuid
+            db.session.commit()
+
+            a = Match.query.filter_by(name="A", event=url).first()
+            update_match_previous_link(a, s.uuid, url)
+            db.session.commit()
+
+            a = Match.query.filter_by(name="A", event=url).first()
+            b = Match.query.filter_by(name="B", event=url).first()
+            c = Match.query.filter_by(name="C", event=url).first()
+            # A is spliced in after S with no successor adopted (ambiguous),
+            # and the pre-existing degenerate pointers are left alone.
+            assert a.previous_match == s.uuid
+            assert a.next_match is None
+            assert b.previous_match == s.uuid
+            assert c.previous_match == s.uuid

--- a/tests/test_status_downgrade.py
+++ b/tests/test_status_downgrade.py
@@ -1,0 +1,169 @@
+"""Solver statuses must be re-earned on every solve.
+
+Regression tests for stale statuses after schedule edits: reordering (or any
+dependency change) used to leave TIME_FINALIZED / READY_TO_START / structural
+COMPLETED in place because the live PROCEDURE only ever upgraded statuses.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.domain.enums import MatchStatus, ScheduleType
+from app.routes.tournaments import update_match_previous_link
+from app.utils.scheduling import recompute_all_match_times, recompute_scheduled_and_nominal_times
+from models import Match, db
+
+pytestmark = pytest.mark.unit
+
+BASE = datetime(2026, 8, 20, 9, 0)
+
+
+def _mk(name, event, sched, status=MatchStatus.NOT_STARTED, start=None, length=30, prev=None):
+    m = Match(
+        name=name,
+        event=event,
+        field="Field 1",
+        schedule_type=sched,
+        nominal_length=length,
+        status=status,
+        skip_condition="false",
+    )
+    if start is not None:
+        m.nominal_start_time = start
+        m.scheduled_start_time = start
+    db.session.add(m)
+    db.session.flush()
+    if prev is not None:
+        m.previous_match = prev.uuid
+        prev.next_match = m.uuid
+    return m
+
+
+def _get(name, event):
+    return Match.query.filter_by(name=name, event=event).first()
+
+
+class TestStatusDowngradeOnReorder:
+    def test_reorder_downgrades_ready_to_start(self, app, test_db, tournament):
+        """A(completed) -> B -> C; moving C in front of B strips B's earned status."""
+        url = tournament.url
+        with app.app_context():
+            a = _mk("A", url, ScheduleType.STATIC, status=MatchStatus.COMPLETED, start=BASE)
+            a.completed_time = BASE + timedelta(minutes=30)
+            b = _mk("B", url, ScheduleType.SAFE, prev=a)
+            c = _mk("C", url, ScheduleType.SAFE, prev=b)
+            db.session.commit()
+            recompute_scheduled_and_nominal_times(url)
+
+            # B earned READY_TO_START (dep A complete, no team slots to resolve).
+            assert _get("B", url).status == MatchStatus.READY_TO_START
+            assert _get("C", url).status == MatchStatus.NOT_STARTED
+
+            # TO moves C in front of B.
+            c = _get("C", url)
+            update_match_previous_link(c, a.uuid, url)
+            db.session.commit()
+            recompute_scheduled_and_nominal_times(url)
+
+            # C is now the ready one; B's status was re-earned from its new
+            # dependency (C, unfinished) and downgraded.
+            assert _get("C", url).status == MatchStatus.READY_TO_START
+            assert _get("B", url).status == MatchStatus.NOT_STARTED
+            # And B's nominal moved after C's end.
+            assert _get("B", url).nominal_start_time == _get("C", url).nominal_start_time + timedelta(minutes=30)
+
+    def test_reorder_downgrades_safe_time_finalized(self, app, test_db, tournament):
+        """SAFE TIME_FINALIZED (deps started) resets when a NOT_STARTED match is inserted before it."""
+        url = tournament.url
+        with app.app_context():
+            a = _mk("A", url, ScheduleType.STATIC, status=MatchStatus.IN_PROGRESS, start=BASE)
+            a.confirmed_start_time = BASE
+            b = _mk("B", url, ScheduleType.SAFE, prev=a)
+            c = _mk("C", url, ScheduleType.SAFE, prev=b)
+            db.session.commit()
+            recompute_all_match_times(url)
+
+            # Dep A is in progress -> B's start time freezes.
+            assert _get("B", url).status == MatchStatus.TIME_FINALIZED
+
+            c = _get("C", url)
+            update_match_previous_link(c, a.uuid, url)
+            db.session.commit()
+            recompute_all_match_times(url)
+
+            # B now depends on C (not started): the freeze is no longer justified.
+            assert _get("B", url).status == MatchStatus.NOT_STARTED
+            # C inherits the freeze instead (its dep A is in progress).
+            assert _get("C", url).status == MatchStatus.TIME_FINALIZED
+
+    def test_reorder_uncompletes_break(self, app, test_db, tournament):
+        """A solver-COMPLETED break re-opens when an unfinished match is inserted before it."""
+        url = tournament.url
+        with app.app_context():
+            a = _mk("A", url, ScheduleType.STATIC, status=MatchStatus.COMPLETED, start=BASE)
+            a.completed_time = BASE + timedelta(minutes=30)
+            brk = _mk("Lunch", url, ScheduleType.BREAK, prev=a, length=60)
+            db.session.commit()
+            recompute_all_match_times(url)
+
+            # Break's dep is complete -> solver marks it COMPLETED.
+            assert _get("Lunch", url).status == MatchStatus.COMPLETED
+
+            # Insert a new SAFE match between A and the break.
+            d = _mk("D", url, ScheduleType.SAFE)
+            db.session.commit()
+            update_match_previous_link(d, a.uuid, url)
+            db.session.commit()
+            recompute_all_match_times(url)
+
+            # The break is no longer "done": its dependency changed under it.
+            assert _get("Lunch", url).status == MatchStatus.NOT_STARTED
+            # And it moved after D.
+            assert _get("Lunch", url).nominal_start_time == _get("D", url).nominal_start_time + timedelta(minutes=30)
+
+    def test_tag_unassignment_downgrades_ready(self, app, test_db, tournament, team):
+        """READY_TO_START falls back to TIME_FINALIZED when a team slot unresolves."""
+        from models import Tag
+
+        url = tournament.url
+        with app.app_context():
+            tag = Tag(event=url, name="Seed 1", team=team.id)
+            db.session.add(tag)
+            a = _mk("A", url, ScheduleType.STATIC, start=BASE)
+            a.team1_initial = "tag::Seed 1"
+            a.team1 = team.id
+            db.session.commit()
+            recompute_all_match_times(url)
+            assert _get("A", url).status == MatchStatus.READY_TO_START
+
+            # TO unassigns the tag (and the slot's resolved team).
+            tag = Tag.query.filter_by(event=url, name="Seed 1").first()
+            tag.team = None
+            a = _get("A", url)
+            a.team1 = None
+            db.session.commit()
+            recompute_all_match_times(url)
+
+            # STATIC's floor is TIME_FINALIZED, not NOT_STARTED.
+            assert _get("A", url).status == MatchStatus.TIME_FINALIZED
+
+    def test_real_world_statuses_never_downgrade(self, app, test_db, tournament):
+        """IN_PROGRESS / COMPLETED / SKIPPED matches are untouched by reordering."""
+        url = tournament.url
+        with app.app_context():
+            a = _mk("A", url, ScheduleType.STATIC, status=MatchStatus.COMPLETED, start=BASE)
+            a.completed_time = BASE + timedelta(minutes=30)
+            b = _mk("B", url, ScheduleType.SAFE, status=MatchStatus.IN_PROGRESS, prev=a)
+            b.confirmed_start_time = BASE + timedelta(minutes=30)
+            c = _mk("C", url, ScheduleType.SAFE, prev=b)
+            db.session.commit()
+            recompute_all_match_times(url)
+
+            c = _get("C", url)
+            update_match_previous_link(c, a.uuid, url)
+            db.session.commit()
+            recompute_all_match_times(url)
+
+            assert _get("A", url).status == MatchStatus.COMPLETED
+            assert _get("B", url).status == MatchStatus.IN_PROGRESS


### PR DESCRIPTION
## Summary

schedule editing moves off the public page onto its own full-width editor at `/:url/schedule/edit` (linked from the admin card), where you build the schedule by direct manipulation instead of forms-first. generally should be far more intuitive and easy to make changes, especially when it comes to reordering matches.

also fixes two old solver-adjacent bugs that editing kept running into

## What changed

The editor page:

- full viewport width; the match/break/join forms are a **docked card** (right of the schedule on wide screens, above on narrow) instead of modals, so the schedule stays visible and interactive while you edit.
- **drag empty space to create** (gcal style): placeholder follows the drag, releases into the create card prefilled with field/start/length. the placeholder stays on the timeline while the card is open (all checked fields, for break/join groups) and tracks your edits. the "+ Match" button is gone — the schedule *is* the input.
- **drag blocks to move**: STATIC places freely, STATBREAK groups shift their start, dynamic matches snap into the gap after their new previous match with the insertion point highlighted. bad drops error and snap back.
- "Default new match type" dropdown seeds the create card (all six types; structural types open the group form).
- **bulk change length**: click-select blocks, apply one length (new endpoint; locked/join rows reported as skipped).
- **push back day** tool: shift the plan of everything not-yet-started by N minutes (negative pulls forward). the endpoint existed with zero UI; now it has one. the manual "Recompute Times" button and its endpoints are *removed* — the solver re-derives everything on every edit now, so the button had nothing left to fix.
- locked (started/finished) matches of every type stay clickable/draggable/selectable and just fail with a clear message, instead of mysteriously ignoring you. breaks show their real statuses here (public views keep the neutral look).
- with a team input focused, hovering a match shows **Winner/Loser chips** that insert `Name::winner`/`::loser` into the field.
- Alt-hover dependency view: hold alt while hovering a match to see lines to the matches it depends on. only includes previous match, team1, team2, and refs when they're specified as references; no skip condition and no "other match with higher priority is using this team" display. perhaps that can be added later. especially in pod schedules that's nice, but it could be confusing since if you move a match before one of those dependencies it's fine and the matches just reorder. (then again same with prev/next). idk. i digress. that's for later.

The public page:

- identical for TOs and players now: by-team and by-field only, no warnings button, no edit anything. TOs get to the editor through the admin card.

Bugfixes (the editing work surfaced both):

- **reorder chain splice**: moving A in front of B could leave both at the same time. half-linked chains (successor points back, predecessor's `next_match` unset — the normal state around STATIC matches and TOML imports) made the splice helper miss the old successor, so both matches shared a dependency. successor is now derived from back-pointers as a fallback.
- **stale solver statuses**: the live PROCEDURE only ever *upgraded* statuses, so with A(done)→B→C, moving C in front of B left B READY_TO_START forever. solver-earned statuses (READY_TO_START / TIME_FINALIZED / structural COMPLETED) are now re-earned on every solve and downgraded to the type's floor when their justification disappears. real-world statuses (in progress / finalized / skipped) are never touched. topological order makes downgrades cascade in one pass.

## Test plan

- [x] `just test` passes
- [x] `cargo check` clean; dep-line geometry unit tests pass natively
- [x] Manual verification:
  - [x] built a day from scratch by dragging only
  - [x] reordered mid-tournament (some matches done): statuses and times follow correctly
  - [x] alt-hover on a bracket-heavy schedule: rings/lines appear and *disappear* (yes, really — the sticky-outline bug was an inline box-shadow that survived style diffing; rings are a mounted/unmounted child element now)

## Linked issues

Closes #199, #246, #247

---

### Pre-review checklist

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [x] Targeting `dev`, not `main` (unless this is a release PR).
- [x] `just lint` and `just format` are clean.
- [x] Tests added or updated for the new behavior.
- ~~If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated.~~
- ~~If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.~~
- [x] No merge conflicts with the base branch.
