### PR TITLE
[Feature] ass tag definitions & global variables.

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -14,7 +14,7 @@ from app.models import (
 from app.models.user import Player, Team
 from app.models.registrable_config import RegistrableConfig
 from app.models.league import League
-from app.models.tournament import Tournament, TO, Field, Tag
+from app.models.tournament import Tournament, TO, Field, Tag, ScriptVariable
 from app.models.registration import TeamRegistration, PlayerRegistration
 from app.models.match import Match, Point, MatchNote
 from app.models.bracket import BracketImage, BracketLabeledTeam, BracketPlacement, BracketText
@@ -40,6 +40,7 @@ __all__ = [
     "TO",
     "Field",
     "Tag",
+    "ScriptVariable",
     "TeamRegistration",
     "PlayerRegistration",
     "Match",

--- a/app/models/tournament.py
+++ b/app/models/tournament.py
@@ -150,11 +150,20 @@ class Tag(db.Model):
     Tags allow Arctos Schedule Script expressions to refer to a team
     symbolically (e.g. ``[GroupA::winner]``) rather than by their ID.
 
+    A tag resolves to a team in this order:
+
+    1. The manually assigned ``team`` column (an override).
+    2. Evaluating ``expression`` (an ASS expression whose result type must
+       include TEAM, e.g. ``(winner {Semi A})``) to a concrete team.
+    3. Otherwise the tag is unresolved.
+
     Attributes:
         id: Auto-increment primary key.
         event: Tournament URL slug this tag belongs to.
         name: Tag name used in ASS expressions.
-        team: ID of the team assigned to this tag, or ``None`` if unresolved.
+        team: ID of the team manually assigned to this tag (overrides
+            ``expression``), or ``None``.
+        expression: Optional ASS expression that resolves to a team.
     """
 
     __tablename__ = "tags"
@@ -163,3 +172,31 @@ class Tag(db.Model):
     event = db.Column(db.String(URL_SLUG_LEN), db.ForeignKey("tournaments.url"), nullable=False)
     name = db.Column(db.String(SHORT_NAME_LEN), nullable=False)
     team = db.Column(db.String(USER_ID_LEN), db.ForeignKey("teams.id"), nullable=True)
+    expression = db.Column(db.Text, nullable=True)
+
+
+class ScriptVariable(db.Model):
+    """A tournament-scoped Arctos Schedule Script variable.
+
+    Variables are usable as identifiers in any ASS expression evaluated within
+    the tournament (skip conditions, tag expressions, other variables). Each
+    variable's ``expression`` is evaluated when a tournament-bound parser is
+    built and its value is bound to ``name`` in the interpreter environment.
+
+    Attributes:
+        id: Auto-increment primary key.
+        event: Tournament URL slug this variable belongs to.
+        name: Identifier name (must match the ASS ``IDENTIFIER`` token rules
+            and must not collide with builtin functions/special forms).
+            Unique per event.
+        expression: ASS expression that defines the variable's value.
+    """
+
+    __tablename__ = "script_variables"
+
+    id = db.Column(db.Integer, primary_key=True)
+    event = db.Column(db.String(URL_SLUG_LEN), db.ForeignKey("tournaments.url"), nullable=False)
+    name = db.Column(db.String(SHORT_NAME_LEN), nullable=False)
+    expression = db.Column(db.Text, nullable=False)
+
+    __table_args__ = (db.UniqueConstraint("event", "name", name="uq_script_variables_event_name"),)

--- a/app/routes/tournaments/matches_admin.py
+++ b/app/routes/tournaments/matches_admin.py
@@ -44,6 +44,7 @@ from models import (
     Field,
     Match,
     Point,
+    ScriptVariable,
     Tag,
     db,
 )
@@ -1206,6 +1207,33 @@ def delete_field_api(tournament_url, field_id):
     return jsonify({"success": True})
 
 
+def validate_tag_expression(tournament_url, expression):
+    """Validate an ASS tag expression: parse + type check (must include TEAM).
+
+    Returns ``(normalized_expression_or_None, error_or_None)``. An empty or
+    None expression normalizes to None (clears the tag's expression).
+    """
+    from app.utils.parser import DSLValidationError, _human_type_name, _infer_types, get_parser
+
+    expression = (expression or "").strip()
+    if not expression:
+        return None, None
+    try:
+        parser = get_parser(tournament_url)
+        warnings = parser.static_check(expression)
+        if warnings:
+            return None, "; ".join(warnings)
+        result = parser.parse(expression)
+    except DSLValidationError as e:
+        return None, str(e)
+    except Exception as e:
+        return None, f"Parse error: {e}"
+    types = _infer_types(result)
+    if "TEAM" not in types:
+        return None, f"Tag expression must resolve to a TEAM, got {_human_type_name(types)}."
+    return expression, None
+
+
 @bp.route("/tournaments/<tournament_url>/tags", methods=["POST"])
 @login_required
 def create_tag_api(tournament_url):
@@ -1225,7 +1253,11 @@ def create_tag_api(tournament_url):
     if Tag.query.filter_by(event=tournament_url, name=name).first():
         return jsonify({"error": "Tag already exists"}), 400
 
-    tag = Tag(event=tournament_url, name=name)
+    expression, err = validate_tag_expression(tournament_url, data.get("expression"))
+    if err:
+        return jsonify({"error": err}), 400
+
+    tag = Tag(event=tournament_url, name=name, expression=expression)
     db.session.add(tag)
     db.session.commit()
     return jsonify({"success": True, "id": tag.id})
@@ -1268,6 +1300,142 @@ def update_tag_api(tournament_url, tag_id):
     data = request.get_json()
     if not data or "name" not in data:
         return jsonify({"error": "Name required"}), 400
+    if "expression" in data:
+        expression, err = validate_tag_expression(tournament_url, data.get("expression"))
+        if err:
+            return jsonify({"error": err}), 400
+        tag.expression = expression
     tag.name = data["name"]
+    db.session.commit()
+    return jsonify({"success": True})
+
+
+def _validate_script_variable(tournament_url, name, expression, exclude_id=None):
+    """Validate a script variable's name and expression. Returns an error string or None."""
+    from app.utils.parser import (
+        RESERVED_IDENTIFIERS,
+        DSLValidationError,
+        extract_variable_references,
+        get_parser,
+        is_valid_identifier,
+    )
+
+    if not name:
+        return "Name required"
+    if not is_valid_identifier(name):
+        return f"'{name}' is not a valid identifier."
+    if name in RESERVED_IDENTIFIERS:
+        return f"'{name}' is a builtin function or reserved word."
+    query = ScriptVariable.query.filter_by(event=tournament_url, name=name)
+    if exclude_id is not None:
+        query = query.filter(ScriptVariable.id != exclude_id)
+    if query.first():
+        return f"Variable '{name}' already exists."
+    if not expression:
+        return "Expression required"
+
+    # Static cycle check over variable-to-variable references, with this
+    # variable's (new) expression substituted in.
+    graph = {name: extract_variable_references(expression)}
+    for row in ScriptVariable.query.filter_by(event=tournament_url).all():
+        if exclude_id is not None and row.id == exclude_id:
+            continue
+        if row.name == name:
+            continue
+        graph[row.name] = extract_variable_references(row.expression)
+    # Iterative DFS with colors, only following edges to defined variables.
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {n: WHITE for n in graph}
+
+    def _has_cycle_from(start):
+        stack = [(start, iter(sorted(graph[start] & set(graph))))]
+        color[start] = GRAY
+        while stack:
+            node, it = stack[-1]
+            advanced = False
+            for nxt in it:
+                if color[nxt] == GRAY:
+                    return True
+                if color[nxt] == WHITE:
+                    color[nxt] = GRAY
+                    stack.append((nxt, iter(sorted(graph[nxt] & set(graph)))))
+                    advanced = True
+                    break
+            if not advanced:
+                color[node] = BLACK
+                stack.pop()
+        return False
+
+    if _has_cycle_from(name):
+        return f"Cyclic variable reference involving '{name}'."
+
+    # The expression must parse and evaluate cleanly (other variables are
+    # available in the environment; the candidate itself is not).
+    try:
+        parser = get_parser(tournament_url)
+        warnings = parser.static_check(expression)
+        if warnings:
+            return "; ".join(warnings)
+        parser.parse(expression)
+    except DSLValidationError as e:
+        return str(e)
+    except Exception as e:
+        return f"Parse error: {e}"
+    return None
+
+
+def _script_variable_to_dict(var):
+    return {"id": var.id, "name": var.name, "expression": var.expression}
+
+
+@bp.route("/tournaments/<tournament_url>/script-variables", methods=["POST"])
+@login_required
+def create_script_variable_api(tournament_url):
+    if not _check_to(tournament_url):
+        return jsonify({"error": "Forbidden"}), 403
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Name required"}), 400
+    name = (data.get("name") or "").strip()
+    expression = (data.get("expression") or "").strip()
+    err = _validate_script_variable(tournament_url, name, expression)
+    if err:
+        return jsonify({"error": err}), 400
+
+    var = ScriptVariable(event=tournament_url, name=name, expression=expression)
+    db.session.add(var)
+    db.session.commit()
+    return jsonify({"success": True, "id": var.id})
+
+
+@bp.route("/tournaments/<tournament_url>/script-variables/<int:var_id>", methods=["PUT"])
+@login_required
+def update_script_variable_api(tournament_url, var_id):
+    if not _check_to(tournament_url):
+        return jsonify({"error": "Forbidden"}), 403
+
+    var = ScriptVariable.query.filter_by(id=var_id, event=tournament_url).first_or_404()
+    data = request.get_json() or {}
+    name = (data.get("name") or var.name).strip()
+    expression = (data.get("expression") or var.expression).strip()
+    err = _validate_script_variable(tournament_url, name, expression, exclude_id=var.id)
+    if err:
+        return jsonify({"error": err}), 400
+
+    var.name = name
+    var.expression = expression
+    db.session.commit()
+    return jsonify({"success": True})
+
+
+@bp.route("/tournaments/<tournament_url>/script-variables/<int:var_id>", methods=["DELETE"])
+@login_required
+def delete_script_variable_api(tournament_url, var_id):
+    if not _check_to(tournament_url):
+        return jsonify({"error": "Forbidden"}), 403
+
+    var = ScriptVariable.query.filter_by(id=var_id, event=tournament_url).first_or_404()
+    db.session.delete(var)
     db.session.commit()
     return jsonify({"success": True})

--- a/app/routes/tournaments/read.py
+++ b/app/routes/tournaments/read.py
@@ -73,6 +73,7 @@ from models import (
     Player,
     PlayerRegistration,
     Point,
+    ScriptVariable,
     Tag,
     Team,
     TeamRegistration,
@@ -780,9 +781,27 @@ def tournament_schedule_setup(tournament_url):
                 camera_urls = [f.camera]
         fields_data.append({"id": f.id, "name": f.name, "camera_urls": camera_urls})
 
-    # Tags
+    # Tags. `resolved_team` is the effective resolution: manual override if
+    # set, else the tag's ASS expression evaluated to a concrete team.
+    from app.utils.helpers import resolve_tag_to_team
+
     tags_query = Tag.query.filter_by(event=tournament_url).order_by(Tag.name).all()
-    tags_data = [{"id": t.id, "name": t.name, "team": t.team} for t in tags_query]
+    tags_data = [
+        {
+            "id": t.id,
+            "name": t.name,
+            "team": t.team,
+            "expression": t.expression,
+            "resolved_team": resolve_tag_to_team(f"tag::{t.name}", tournament_url),
+        }
+        for t in tags_query
+    ]
+
+    # Tournament-scoped ASS script variables (for the Scripting modal).
+    script_variables_data = [
+        {"id": v.id, "name": v.name, "expression": v.expression}
+        for v in ScriptVariable.query.filter_by(event=tournament_url).order_by(ScriptVariable.name).all()
+    ]
 
     # Matches
     matches_query = Match.query.filter_by(event=tournament_url).order_by(Match.nominal_start_time).all()
@@ -844,6 +863,7 @@ def tournament_schedule_setup(tournament_url):
             "matches": match_list,
             "fields": fields_data,
             "tags": tags_data,
+            "script_variables": script_variables_data,
             "team_options": team_options,
             "is_to": is_to,
         }
@@ -1371,4 +1391,13 @@ def list_tags(tournament_url):
     if not _check_to(tournament_url):
         return jsonify({"error": "Forbidden"}), 403
     tags = Tag.query.filter_by(event=tournament_url).order_by(Tag.name).all()
-    return jsonify({"tags": [{"id": t.id, "name": t.name, "team": t.team} for t in tags]})
+    return jsonify({"tags": [{"id": t.id, "name": t.name, "team": t.team, "expression": t.expression} for t in tags]})
+
+
+@bp.route("/tournaments/<tournament_url>/script-variables", methods=["GET"])
+@login_required
+def list_script_variables(tournament_url):
+    if not _check_to(tournament_url):
+        return jsonify({"error": "Forbidden"}), 403
+    variables = ScriptVariable.query.filter_by(event=tournament_url).order_by(ScriptVariable.name).all()
+    return jsonify({"script_variables": [{"id": v.id, "name": v.name, "expression": v.expression} for v in variables]})

--- a/app/routes/tournaments/scheduling.py
+++ b/app/routes/tournaments/scheduling.py
@@ -1343,14 +1343,25 @@ def update_tags_api(tournament_url):
 
     data = request.get_json()
     tag_id = data.get("tag_id")
-    team_id = data.get("team_id")
 
     if not tag_id:
         return jsonify({"error": "Tag required"}), 400
 
     tag = Tag.query.filter_by(id=tag_id, event=tournament_url).first_or_404()
-    tag.team = team_id if team_id else None
+    if "expression" in data:
+        from app.routes.tournaments.matches_admin import validate_tag_expression
+
+        expression, err = validate_tag_expression(tournament_url, data.get("expression"))
+        if err:
+            return jsonify({"error": err}), 400
+        tag.expression = expression
+    if "team_id" in data:
+        team_id = data.get("team_id")
+        tag.team = team_id if team_id else None
     db.session.commit()
+
+    # Effective resolution: manual override if set, else the tag's expression.
+    effective_team = resolve_tag_to_team(f"tag::{tag.name}", tournament_url)
 
     # Update matches
     matches = Match.query.filter_by(event=tournament_url).all()
@@ -1364,13 +1375,13 @@ def update_tags_api(tournament_url):
         ):
             continue
         if m.team1_initial == tag_ref:
-            m.team1 = team_id
+            m.team1 = effective_team
         if m.team2_initial == tag_ref:
-            m.team2 = team_id
+            m.team2 = effective_team
 
         for row in get_match_referee_rows(m):
             if (row.initial or "").strip() == tag_ref:
-                row.team_id = team_id
+                row.team_id = effective_team
 
     db.session.commit()
     recompute_all_match_times(tournament_url)

--- a/app/serializers/match_schedule_serializer.py
+++ b/app/serializers/match_schedule_serializer.py
@@ -44,6 +44,54 @@ class MatchScheduleSerializer:
         return result
 
     @staticmethod
+    def script_variable_to_dict(variable) -> dict[str, Any]:
+        """Serialise a :class:`~app.models.tournament.ScriptVariable` to a TOML-compatible dict.
+
+        Variables are reconciled by name on import (unique per event), so no
+        ``id`` is exported.
+
+        Args:
+            variable: The :class:`~app.models.tournament.ScriptVariable` ORM
+                instance.
+
+        Returns:
+            Dict with ``name`` and ``expression`` keys.
+        """
+        result = {}
+        if variable.name:
+            result["name"] = variable.name
+        if variable.expression:
+            result["expression"] = variable.expression
+        return result
+
+    @staticmethod
+    def script_variable_from_dict(data: dict[str, Any], tournament_url: str) -> Result[dict[str, Any], ValidationError]:
+        """Convert a TOML ``[[variables]]`` dict to ScriptVariable creation data.
+
+        Only checks presence / non-emptiness of ``name`` and ``expression``;
+        identifier, reserved-name, cycle, and expression validation happen in
+        the import service (mirroring the CRUD endpoint's rules).
+        """
+        if "name" not in data:
+            return Err(ValidationError("Script variable missing required field: name"))
+
+        name = str(data["name"]).strip()
+        if not name:
+            return Err(ValidationError("Script variable name cannot be empty"))
+
+        expression = str(data.get("expression", "")).strip()
+        if not expression:
+            return Err(ValidationError(f"Script variable '{name}' missing required field: expression"))
+
+        return Ok(
+            {
+                "event": tournament_url,
+                "name": name,
+                "expression": expression,
+            }
+        )
+
+    @staticmethod
     def field_to_dict(field) -> dict[str, Any]:
         """Serialise a :class:`~app.models.tournament.Field` to a TOML-compatible dict.
 

--- a/app/serializers/match_schedule_serializer.py
+++ b/app/serializers/match_schedule_serializer.py
@@ -30,7 +30,7 @@ class MatchScheduleSerializer:
             tag: The :class:`~app.models.tournament.Tag` ORM instance.
 
         Returns:
-            Dict with up to three keys: ``id``, ``name``, ``team``.
+            Dict with up to four keys: ``id``, ``name``, ``team``, ``expression``.
         """
         result = {}
         if tag.id is not None:
@@ -39,6 +39,8 @@ class MatchScheduleSerializer:
             result["name"] = tag.name
         if getattr(tag, "team", None):
             result["team"] = tag.team
+        if getattr(tag, "expression", None):
+            result["expression"] = tag.expression
         return result
 
     @staticmethod
@@ -168,6 +170,7 @@ class MatchScheduleSerializer:
             "event": tournament_url,
             "name": name,
             "team": str(data.get("team", "")).strip() or None,
+            "expression": str(data.get("expression", "")).strip() or None,
         }
 
         # Include id if present (for same-tournament updates)

--- a/app/services/schedule_import_export_service.py
+++ b/app/services/schedule_import_export_service.py
@@ -79,13 +79,15 @@ def rewrite_unknown_team_token(token: str, known_teams: set[str]) -> tuple[str, 
     return new_tok, f"Team '{tok}' not found; imported as tag reference '{new_tok}'"
 
 
-def _rewrite_skip_condition(expression: str, known_teams: set[str]) -> tuple[str, list[str], list[str]]:
+def _rewrite_expression_team_literals(expression: str, known_teams: set[str]) -> tuple[str, list[str], list[str]]:
     """Rewrite unknown team literals ``[Foo]`` in an ASS expression to ``[tag::Foo]``.
 
-    Literals containing ``::`` (match ``[X::winner]`` / ``[X::loser]`` refs and
-    ``[tag::X]`` refs) are left untouched, as are literals naming a registered
-    team. Works textually so expressions referencing not-yet-imported matches
-    stay valid.
+    Applies to any ASS expression arriving in the TOML (skip conditions, tag
+    expressions, script-variable expressions). Literals containing ``::``
+    (match ``[X::winner]`` / ``[X::loser]`` refs and ``[tag::X]`` refs) are
+    left untouched — which also makes the rewrite idempotent — as are literals
+    naming a registered team. Works textually so expressions referencing
+    not-yet-imported matches stay valid.
 
     Returns:
         ``(new_expression, warnings, rewritten_tokens)``.
@@ -153,6 +155,9 @@ class ImportResult:
         matches_created: Number of new :class:`~app.models.match.Match`
             records created.
         matches_updated: Number of existing match records updated.
+        variables_created: Number of new
+            :class:`~app.models.tournament.ScriptVariable` records created.
+        variables_updated: Number of existing script-variable records updated.
         errors: List of human-readable error strings encountered during
             import.  Non-empty indicates a partial or failed import.
         warnings: List of human-readable, non-fatal warnings (e.g. unknown
@@ -165,6 +170,8 @@ class ImportResult:
     fields_updated: int = 0
     matches_created: int = 0
     matches_updated: int = 0
+    variables_created: int = 0
+    variables_updated: int = 0
     errors: list[str] = None
     warnings: list[str] = None
 
@@ -304,30 +311,169 @@ class ScheduleImportExportService:
         return errors
 
     @staticmethod
+    def _validate_variables_static(variables_data: list[dict]) -> list[str]:
+        """Pre-import (textual) validation of the ``[[variables]]`` section.
+
+        Mirrors the name / cycle rules of the script-variable CRUD endpoint
+        (``_validate_script_variable``): valid ASS identifier, no reserved /
+        builtin names, unique per file, and no reference cycles. Cycle
+        detection runs over the uploaded set only — the import is
+        authoritative, so variables not in the file will not exist afterwards.
+
+        The expression static check + parse needs the file's tags / matches /
+        variables in the DB and therefore runs post-flush via
+        :meth:`_validate_expressions_against_db`.
+        """
+        from app.utils.parser import (
+            RESERVED_IDENTIFIERS,
+            extract_variable_references,
+            is_valid_identifier,
+        )
+
+        errors: list[str] = []
+        seen: set[str] = set()
+        graph: dict[str, set[str]] = {}
+        for variable in variables_data:
+            name = str(variable.get("name", "")).strip()
+            if not name:
+                # Missing name is reported by script_variable_from_dict.
+                continue
+            if not is_valid_identifier(name):
+                errors.append(f"Script variable '{name}' is not a valid identifier.")
+                continue
+            if name in RESERVED_IDENTIFIERS:
+                errors.append(f"Script variable '{name}' is a builtin function or reserved word.")
+                continue
+            if name in seen:
+                errors.append(f"Duplicate script variable '{name}' in [[variables]] section.")
+                continue
+            seen.add(name)
+            graph[name] = extract_variable_references(str(variable.get("expression", "")).strip())
+
+        # Iterative DFS with colors, only following edges to defined variables
+        # (same shape as the CRUD endpoint's cycle check).
+        WHITE, GRAY, BLACK = 0, 1, 2
+        color = {n: WHITE for n in graph}
+
+        def _has_cycle_from(start: str) -> bool:
+            stack = [(start, iter(sorted(graph[start] & set(graph))))]
+            color[start] = GRAY
+            while stack:
+                node, it = stack[-1]
+                advanced = False
+                for nxt in it:
+                    if color[nxt] == GRAY:
+                        return True
+                    if color[nxt] == WHITE:
+                        color[nxt] = GRAY
+                        stack.append((nxt, iter(sorted(graph[nxt] & set(graph)))))
+                        advanced = True
+                        break
+                if not advanced:
+                    color[node] = BLACK
+                    stack.pop()
+            return False
+
+        for name in sorted(graph):
+            if color[name] == WHITE and _has_cycle_from(name):
+                errors.append(f"Cyclic script-variable reference involving '{name}'.")
+
+        return errors
+
+    @staticmethod
+    def _validate_expressions_against_db(
+        tournament_url: str,
+        variables_data: list[dict],
+        tags_data: list[dict],
+    ) -> list[str]:
+        """Validate variable and tag expressions against the imported DB state.
+
+        Runs after all rows from the file have been flushed (and stale rows
+        deleted), so ``static_check`` / ``parse`` see exactly the schedule the
+        import produces — expressions may reference tags, matches, and
+        variables that only exist in the uploaded file. Mirrors the CRUD
+        endpoints: variables must static-check and parse
+        (``_validate_script_variable``); tag expressions must additionally
+        resolve to a TEAM (``validate_tag_expression``).
+        """
+        from app.utils.parser import (
+            DSLValidationError,
+            _human_type_name,
+            _infer_types,
+            get_parser,
+        )
+
+        errors: list[str] = []
+        parser = get_parser(tournament_url)
+
+        def _check(expression: str, context: str, require_team: bool) -> None:
+            try:
+                warnings = parser.static_check(expression)
+                if warnings:
+                    errors.append(f"{context}: " + "; ".join(warnings))
+                    return
+                result = parser.parse(expression)
+            except DSLValidationError as e:
+                errors.append(f"{context}: {e}")
+                return
+            except Exception as e:
+                errors.append(f"{context}: Parse error: {e}")
+                return
+            if require_team:
+                types = _infer_types(result)
+                if "TEAM" not in types:
+                    errors.append(f"{context}: tag expression must resolve to a TEAM, got {_human_type_name(types)}.")
+
+        for variable in variables_data:
+            name = str(variable.get("name", "")).strip() or "<unnamed variable>"
+            expression = str(variable.get("expression", "")).strip()
+            if expression:
+                _check(expression, f"Script variable '{name}'", require_team=False)
+
+        for tag in tags_data:
+            name = str(tag.get("name", "")).strip() or "<unnamed tag>"
+            expression = str(tag.get("expression", "")).strip()
+            if expression:
+                _check(expression, f"Tag '{name}'", require_team=True)
+
+        return errors
+
+    @staticmethod
     def _rewrite_unknown_team_refs(
         tournament,
         tags_data: list[dict],
         matches_data: list[dict],
-    ) -> tuple[list[dict], list[dict], list[str], set[str]]:
+        variables_data: list[dict] | None = None,
+    ) -> tuple[list[dict], list[dict], list[dict], list[str], set[str]]:
         """Rewrite references to unknown teams into ``tag::`` references.
 
         Applies :func:`rewrite_unknown_team_token` to ``team1_initial`` /
         ``team2_initial`` / ``refs_initial`` slots and
-        :func:`_rewrite_skip_condition` to ``skip_condition`` expressions.
+        :func:`_rewrite_expression_team_literals` to ``skip_condition``, tag
+        ``expression``, and script-variable ``expression`` ASS expressions.
         Tag rows assigning an unknown team ID are imported unassigned instead
         of failing. Only the uploaded data is rewritten — existing DB rows are
         never touched here.
 
         Returns:
-            ``(tags_data, matches_data, warnings, auto_tag_names)`` where
-            *warnings* is deduplicated (one per rewritten token) and
-            *auto_tag_names* lists tag names that must exist for the rewritten
-            references to resolve (created idempotently during import).
+            ``(tags_data, matches_data, variables_data, warnings,
+            auto_tag_names)`` where *warnings* is deduplicated (one per
+            rewritten token) and *auto_tag_names* lists tag names that must
+            exist for the rewritten references to resolve (created
+            idempotently during import).
         """
         known_teams = _known_team_tokens(tournament)
 
         warnings: dict[str, str] = {}  # token -> warning (dedup, insertion-ordered)
         auto_tag_names: set[str] = set()
+
+        def _rewrite_expression(expr: str) -> str:
+            """Rewrite one ASS expression, recording warnings / auto tags."""
+            new_expr, expr_warnings, rewritten = _rewrite_expression_team_literals(expr, known_teams)
+            for tok, warning in zip(rewritten, expr_warnings):
+                warnings.setdefault(tok, warning)
+                auto_tag_names.add(tok)
+            return new_expr
 
         new_tags: list[dict] = []
         for tag in tags_data:
@@ -339,7 +485,21 @@ class ScheduleImportExportService:
                     f"tag-team::{team_val}",
                     f"Team '{team_val}' not found; tag '{tag_name}' imported unassigned",
                 )
+            expr_raw = str(tag.get("expression", "")).strip()
+            if expr_raw:
+                new_expr = _rewrite_expression(expr_raw)
+                if new_expr != expr_raw:
+                    tag = {**tag, "expression": new_expr}
             new_tags.append(tag)
+
+        new_variables: list[dict] = []
+        for variable in variables_data or []:
+            expr_raw = str(variable.get("expression", "")).strip()
+            if expr_raw:
+                new_expr = _rewrite_expression(expr_raw)
+                if new_expr != expr_raw:
+                    variable = {**variable, "expression": new_expr}
+            new_variables.append(variable)
 
         new_matches: list[dict] = []
         for m in matches_data:
@@ -372,22 +532,19 @@ class ScheduleImportExportService:
 
             skip_raw = str(m.get("skip_condition", "")).strip()
             if skip_raw:
-                new_expr, skip_warnings, rewritten = _rewrite_skip_condition(skip_raw, known_teams)
-                if rewritten:
+                new_expr = _rewrite_expression(skip_raw)
+                if new_expr != skip_raw:
                     m["skip_condition"] = new_expr
-                    for tok, warning in zip(rewritten, skip_warnings):
-                        warnings.setdefault(tok, warning)
-                        auto_tag_names.add(tok)
 
             new_matches.append(m)
 
-        return new_tags, new_matches, list(warnings.values()), auto_tag_names
+        return new_tags, new_matches, new_variables, list(warnings.values()), auto_tag_names
 
     @staticmethod
     @allow_Q
     def export_schedule(tournament_url: str) -> Result[str, ArctosError]:
         """
-        Export schedule (tags, fields, matches) to TOML string.
+        Export schedule (script variables, tags, fields, matches) to TOML string.
 
         Args:
             tournament_url: Tournament to export
@@ -395,19 +552,21 @@ class ScheduleImportExportService:
         Returns:
             Result containing TOML string
         """
-        from models import Field, Match, Tag
+        from models import Field, Match, ScriptVariable, Tag
 
         # Verify tournament exists
         from app.services._common import get_tournament_or_err
 
         tournament = get_tournament_or_err(tournament_url).Q()
 
-        # Fetch all tags, fields, and matches
+        # Fetch all script variables, tags, fields, and matches
+        variables = ScriptVariable.query.filter_by(event=tournament_url).order_by(ScriptVariable.name).all()
         tags = Tag.query.filter_by(event=tournament_url).all()
         fields = Field.query.filter_by(event=tournament_url).all()
         matches = Match.query.filter_by(event=tournament_url).order_by(Match.nominal_start_time).all()
 
         # Serialize to dicts
+        variable_dicts = [MatchScheduleSerializer.script_variable_to_dict(v) for v in variables]
         tag_dicts = [MatchScheduleSerializer.tag_to_dict(tag) for tag in tags]
         field_dicts = [MatchScheduleSerializer.field_to_dict(field) for field in fields]
         match_dicts = [MatchScheduleSerializer.match_to_dict(match) for match in matches]
@@ -420,11 +579,14 @@ class ScheduleImportExportService:
             "fields_count": len(field_dicts),
             "matches_count": len(match_dicts),
         }
+        if variable_dicts:
+            metadata["variables_count"] = len(variable_dicts)
 
         toml_content = write_toml_schedule(
             tags=tag_dicts,
             fields=field_dicts,
             matches=match_dicts,
+            variables=variable_dicts,
             metadata=metadata,
         )
 
@@ -450,11 +612,12 @@ class ScheduleImportExportService:
         Returns:
             Result containing ImportResult with counts and errors
         """
-        from models import Field, Match, Tag, db
+        from models import Field, Match, ScriptVariable, Tag, db
 
         # Parse TOML
         parsed = parse_toml_schedule(toml_content).Q()
         source_event = parsed["event"]
+        variables_data = parsed["variables"]
         tags_data = parsed["tags"]
         fields_data = parsed["fields"]
         matches_data = parsed["matches"]
@@ -473,9 +636,10 @@ class ScheduleImportExportService:
         (
             tags_data,
             matches_data,
+            variables_data,
             warnings,
             auto_tag_names,
-        ) = ScheduleImportExportService._rewrite_unknown_team_refs(tournament, tags_data, matches_data)
+        ) = ScheduleImportExportService._rewrite_unknown_team_refs(tournament, tags_data, matches_data, variables_data)
 
         tags_created = 0
         tags_updated = 0
@@ -483,6 +647,8 @@ class ScheduleImportExportService:
         fields_updated = 0
         matches_created = 0
         matches_updated = 0
+        variables_created = 0
+        variables_updated = 0
         errors: list[str] = []
 
         # Perform all validation before making any database changes
@@ -492,23 +658,36 @@ class ScheduleImportExportService:
         )
         errors.extend(semantic_errors)
 
+        # 2. Validate all script variables (structure, then the textual
+        # identifier / reserved-name / cycle rules mirrored from the CRUD
+        # endpoint; the expression static check runs post-flush, once the
+        # file's variables / tags / matches are visible in the DB).
+        for variable_data in variables_data:
+            res = MatchScheduleSerializer.script_variable_from_dict(variable_data, tournament_url)
+            if isinstance(res, Err):
+                errors.append(f"Script variable validation error: {res.val.message}")
+        errors.extend(
+            f"Script variable validation error: {msg}"
+            for msg in ScheduleImportExportService._validate_variables_static(variables_data)
+        )
+
         # 2. Validate all tags
         for tag_data in tags_data:
             res = MatchScheduleSerializer.tag_from_dict(tag_data, tournament_url)
             if isinstance(res, Err):
-                errors.append(f"Tag validation error: {res.value.message}")
+                errors.append(f"Tag validation error: {res.val.message}")
 
         # 3. Validate all fields
         for field_data in fields_data:
             res = MatchScheduleSerializer.field_from_dict(field_data, tournament_url)
             if isinstance(res, Err):
-                errors.append(f"Field validation error: {res.value.message}")
+                errors.append(f"Field validation error: {res.val.message}")
 
         # 4. Validate all matches
         for match_data in matches_data:
             res = MatchScheduleSerializer.match_from_dict(match_data, tournament_url)
             if isinstance(res, Err):
-                errors.append(f"Match validation error: {res.value.message}")
+                errors.append(f"Match validation error: {res.val.message}")
 
         # If any validation errors, abort before making any changes
         if errors:
@@ -531,6 +710,7 @@ class ScheduleImportExportService:
             kept_tag_names: set[str] = set()
             kept_field_names: set[str] = set()
             kept_match_uuids: set[str] = set()
+            kept_variable_names: set[str] = set()
 
             # Build UUID mapping for matches (old_uuid -> new_uuid for different tournament)
             match_uuid_map: dict[str, str] = {}  # old_uuid -> new_uuid
@@ -543,6 +723,35 @@ class ScheduleImportExportService:
                     if old_uuid:
                         new_uuid = str(uuid.uuid4())
                         match_uuid_map[old_uuid] = new_uuid
+
+            # Import script variables first: tag expressions, skip conditions,
+            # and tag-expression resolution during match creation may all
+            # reference them, so they must be in the session before tags /
+            # matches are written. Variables are reconciled by name (unique
+            # per event; exports carry no id).
+            for variable_data in variables_data:
+                variable_dict = MatchScheduleSerializer.script_variable_from_dict(variable_data, tournament_url).Q()
+                kept_variable_names.add(variable_dict["name"])
+                variable = ScriptVariable.query.filter_by(event=tournament_url, name=variable_dict["name"]).first()
+                if variable:
+                    variable.expression = variable_dict["expression"]
+                    variables_updated += 1
+                else:
+                    db.session.add(ScriptVariable(**variable_dict))
+                    variables_created += 1
+
+            # Variables not in the file are deleted — the uploaded schedule is
+            # authoritative, matching the tag / field / match semantics. Done
+            # before the flush so tag-expression resolution below never sees
+            # stale variables.
+            if kept_variable_names:
+                ScriptVariable.query.filter_by(event=tournament_url).filter(
+                    ~ScriptVariable.name.in_(kept_variable_names)
+                ).delete(synchronize_session=False)
+            else:
+                ScriptVariable.query.filter_by(event=tournament_url).delete(synchronize_session=False)
+
+            db.session.flush()
 
             # Import tags
             for tag_data in tags_data:
@@ -820,6 +1029,24 @@ class ScheduleImportExportService:
                 # No matches in file -> delete all matches for this event
                 Match.query.filter_by(event=tournament_url).delete(synchronize_session=False)
 
+            db.session.flush()
+
+            # Deferred expression validation: variable and tag expressions may
+            # reference tags / matches / variables that only exist in the
+            # uploaded file, so static-check + parse them against the imported
+            # (flushed, post-deletion) state. Any error aborts the import.
+            expression_errors = ScheduleImportExportService._validate_expressions_against_db(
+                tournament_url, variables_data, tags_data
+            )
+            if expression_errors:
+                db.session.rollback()
+                if len(expression_errors) == 1:
+                    error_message = f"Validation failed: {expression_errors[0]}"
+                else:
+                    error_list = "\n".join(f"• {err}" for err in expression_errors)
+                    error_message = f"Validation failed with {len(expression_errors)} errors:\n{error_list}"
+                return Err(ValidationError(error_message))
+
             db.session.commit()
 
             result = ImportResult(
@@ -829,6 +1056,8 @@ class ScheduleImportExportService:
                 fields_updated=fields_updated,
                 matches_created=matches_created,
                 matches_updated=matches_updated,
+                variables_created=variables_created,
+                variables_updated=variables_updated,
                 errors=errors,
                 warnings=warnings,
             )

--- a/app/services/schedule_import_export_service.py
+++ b/app/services/schedule_import_export_service.py
@@ -559,6 +559,7 @@ class ScheduleImportExportService:
                     if tag:
                         tag.name = tag_dict["name"]
                         tag.team = tag_dict.get("team")
+                        tag.expression = tag_dict.get("expression")
                         tags_updated += 1
                     else:
                         # ID doesn't exist, create new (don't include id in creation)

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -5,6 +5,8 @@ module is the home for small, generally-applicable helpers that don't.
 """
 
 import re
+import threading
+
 from flask_login import current_user
 from app.domain.enums import RegistrationStatus
 from app.services._common import current_user_type
@@ -216,15 +218,68 @@ def get_team_display_name_for_event(tournament_url: str, team_id: str) -> str:
     return team_id
 
 
+# Per-thread state for tag-expression resolution: an in-progress set guards
+# against cyclic tag references ([tag::A] whose expression references
+# [tag::B] whose expression references [tag::A]); a memo cache avoids
+# re-evaluating the same tag repeatedly within one outermost resolution call.
+_tag_resolution_state = threading.local()
+
+
+def _resolve_tag_expression_to_team(tag_name: str, expression: str, tournament_url: str) -> str | None:
+    """Evaluate a tag's ASS expression to a concrete team id, or None.
+
+    A result that is not a concrete Team (symbolic team, wrong type) or any
+    evaluation error resolves to None (unresolved). Cyclic tag references are
+    detected via a thread-local in-progress set and resolve to None instead of
+    recursing forever.
+    """
+    state = _tag_resolution_state
+    stack = getattr(state, "stack", None)
+    if stack is None:
+        stack = state.stack = set()
+        state.cache = {}
+    key = (tournament_url, tag_name)
+    if key in stack:
+        return None  # Cyclic tag reference — unresolved.
+    cache = state.cache
+    if key in cache:
+        return cache[key]
+    outermost = not stack
+    stack.add(key)
+    try:
+        from app.utils.parser import Team, get_parser
+
+        try:
+            parser = get_parser(tournament_url)
+            result = parser.parse(expression)
+        except Exception:
+            result = None
+        team_id = result.obj.id if isinstance(result, Team) else None
+        cache[key] = team_id
+        return team_id
+    finally:
+        stack.discard(key)
+        if outermost:
+            cache.clear()
+
+
 def resolve_tag_to_team(tag_ref: str, tournament_url: str) -> str | None:
-    """Resolve a tag reference (tag::TAG_NAME) to a team ID by querying the Tag table.
+    """Resolve a tag reference (tag::TAG_NAME) to a team ID.
+
+    Resolution order:
+
+    1. The tag's manually assigned ``team`` column (an override).
+    2. Evaluating the tag's ASS ``expression`` to a concrete team.
+    3. Otherwise unresolved (``None``) — includes expressions that are still
+       symbolic (e.g. ``(winner {Semi A})`` before the match completes),
+       evaluation errors, and cyclic tag references.
 
     Args:
         tag_ref: Tag reference string (e.g., "tag::Pool A")
         tournament_url: Tournament URL
 
     Returns:
-        Team ID if tag exists and has a team assigned, None otherwise
+        Team ID if the tag resolves to a team, None otherwise
     """
     from models import Tag
 
@@ -236,9 +291,14 @@ def resolve_tag_to_team(tag_ref: str, tournament_url: str) -> str | None:
         return None
 
     tag = Tag.query.filter_by(event=tournament_url, name=tag_name).first()
-    if tag and tag.team:
+    if not tag:
+        return None
+    if tag.team:
         return tag.team
-    return None
+    expression = (getattr(tag, "expression", None) or "").strip()
+    if not expression:
+        return None
+    return _resolve_tag_expression_to_team(tag.name, expression, tournament_url)
 
 
 def resolve_match_winner_loser_ref(initial: str, tournament_url: str) -> str | None:

--- a/app/utils/parser.py
+++ b/app/utils/parser.py
@@ -43,6 +43,7 @@ Types: INT, NIL, BOOL, MATCH, TEAM, LIST, FUNC
 RANGE_MAX = 10_000
 
 import difflib
+import re
 
 from lark import Lark, Tree
 from lark.exceptions import LarkError, UnexpectedInput
@@ -492,10 +493,15 @@ def parse_team_literal(literal: str, event: str):
                 suggestion = _suggest_function(qualifier, known)
                 hint = f" Did you mean 'tag::{suggestion}'?" if suggestion else ""
                 raise DSLValidationError(f"Tag '{qualifier}' does not exist.{hint}")
-            if not tag.team:
-                # Tag exists but its team isn't assigned yet — stay symbolic.
+            # Effective resolution: manual team override, else the tag's ASS
+            # expression (cycle-guarded), else unresolved.
+            from app.utils.helpers import resolve_tag_to_team
+
+            team_id = resolve_tag_to_team(f"tag::{qualifier}", event)
+            if not team_id:
+                # Tag exists but doesn't resolve to a team yet — stay symbolic.
                 return SymbolicTeam(literal, event)
-            team_obj = TeamDB.query.filter_by(id=tag.team).first()
+            team_obj = TeamDB.query.filter_by(id=team_id).first()
             if team_obj:
                 return Team(team_obj, event)
             # Tag's team id refers to a deleted team — stay symbolic.
@@ -1700,6 +1706,126 @@ class Simplifier:
         return min_elem
 
 
+# --------------------------------------------------------------------------
+# Script variables (tournament-scoped ASS variables)
+# --------------------------------------------------------------------------
+
+# Identifier names that can never be used as script-variable names: builtin
+# functions, special forms, and the keyword literals.
+RESERVED_IDENTIFIERS = frozenset(Simplifier.BUILTINS) | {"true", "false", "nil"}
+
+# Mirrors the IDENTIFIER terminal in grammar.lark.
+_IDENTIFIER_RE = re.compile(
+    r"-(?![0-9])$"
+    r"|-[a-zA-Z_+*/=><!&][a-zA-Z0-9_\-+*/=><!&]*$"
+    r"|[a-zA-Z_+*/=><!&][a-zA-Z0-9_\-+*/=><!&]*$"
+)
+
+_LARK_PARSER: Lark | None = None
+
+
+def _get_lark() -> Lark:
+    """Shared Lark instance for utility parsing (identifier extraction, env building)."""
+    global _LARK_PARSER
+    if _LARK_PARSER is None:
+        import os
+
+        grammar_path = os.path.join(os.path.dirname(__file__), "grammar.lark")
+        with open(grammar_path, "r") as g:
+            _LARK_PARSER = Lark(g, parser="lalr")
+    return _LARK_PARSER
+
+
+def is_valid_identifier(name: str) -> bool:
+    """True when `name` matches the ASS IDENTIFIER token exactly."""
+    return bool(name) and _IDENTIFIER_RE.fullmatch(name) is not None
+
+
+def _extract_identifier_names(tree) -> set[str]:
+    """Collect every identifier_atom name in a parse tree (minus keyword literals)."""
+    names: set[str] = set()
+    if not isinstance(tree, Tree):
+        return names
+    if tree.data == "identifier_atom" and tree.children:
+        name = tree.children[0].value
+        if name not in ("true", "false", "nil"):
+            names.add(name)
+        return names
+    for child in tree.children:
+        names |= _extract_identifier_names(child)
+    return names
+
+
+def extract_variable_references(text: str) -> set[str]:
+    """Names of identifiers in `text` that could reference script variables.
+
+    Builtins and keyword literals are excluded. Lambda parameter names are NOT
+    excluded — a shadowed name is conservatively treated as a reference (this
+    only matters for the write-time cycle check, where it errs on rejection).
+    Returns an empty set when the expression doesn't parse; the caller
+    validates parseability separately.
+    """
+    try:
+        tree = _get_lark().parse((text or "").strip())
+    except Exception:
+        return set()
+    return _extract_identifier_names(tree) - RESERVED_IDENTIFIERS
+
+
+def build_variable_env(event: str, parse_team, parse_match) -> dict:
+    """Evaluate this tournament's script variables into an interpreter env.
+
+    Variables may reference other variables, so they're evaluated eagerly in
+    topological order (Kahn). Variables that don't parse, participate in a
+    reference cycle, or fail evaluation are simply left unbound — using them
+    then behaves like any unknown identifier. Write-time validation is what
+    rejects cycles/bad expressions; this function just needs to never blow up.
+    """
+    from app.models import ScriptVariable
+
+    rows = ScriptVariable.query.filter_by(event=event).all()
+    if not rows:
+        return {}
+    lark = _get_lark()
+    trees: dict[str, Tree] = {}
+    deps: dict[str, set[str]] = {}
+    for row in rows:
+        expr = (row.expression or "").strip()
+        if not expr:
+            continue
+        try:
+            tree = lark.parse(expr)
+        except Exception:
+            continue
+        trees[row.name] = tree
+        deps[row.name] = _extract_identifier_names(tree) - RESERVED_IDENTIFIERS
+
+    # Kahn's algorithm over references to other *defined* variables. Nodes in a
+    # cycle (including self-loops) never reach in-degree 0 and stay unbound.
+    indegree: dict[str, int] = {}
+    dependents: dict[str, set[str]] = {}
+    for name in trees:
+        refs = {d for d in deps[name] if d in trees}
+        indegree[name] = len(refs)
+        for d in refs:
+            dependents.setdefault(d, set()).add(name)
+    queue = [n for n, d in indegree.items() if d == 0]
+    env: dict = {}
+    while queue:
+        name = queue.pop()
+        try:
+            env[name] = Simplifier(parse_team, parse_match, env=env).visit(trees[name])
+        except Exception:
+            # Leave unbound; downstream dependents still get evaluated (their
+            # reference to this name then stays an unresolved identifier).
+            pass
+        for m in dependents.get(name, ()):
+            indegree[m] -= 1
+            if indegree[m] == 0:
+                queue.append(m)
+    return env
+
+
 def _collect_literals(text: str):
     """Pull out raw team and match literals for a quick reference-existence check.
 
@@ -1791,7 +1917,7 @@ def _check_references(text: str, event: str) -> list[str]:
     return warnings
 
 
-def get_parser(event: str, match_resolver=None, env=None):
+def get_parser(event: str, match_resolver=None, env=None, include_variables: bool = True):
     """
     Create a parser for the given event (tournament URL).
 
@@ -1800,7 +1926,12 @@ def get_parser(event: str, match_resolver=None, env=None):
     or SymbolicMatch. This avoids DB reads when matches are already in memory.
 
     ``env`` is an optional dict of pre-bound identifiers (e.g. future
-    per-tournament globals like ``teamlist`` / ``matchlist``).
+    per-tournament globals like ``teamlist`` / ``matchlist``); it takes
+    precedence over same-named script variables.
+
+    Unless ``include_variables`` is False, the tournament's script variables
+    are evaluated (lazily, on the first parse) and bound into the interpreter
+    environment so any expression can reference them by name.
     """
     import os
 
@@ -1810,6 +1941,24 @@ def get_parser(event: str, match_resolver=None, env=None):
 
         parse_match = match_resolver if match_resolver is not None else (lambda x: parse_match_literal(x, event))
         base_env = dict(env) if env is not None else {}
+
+        parse_team = lambda x: parse_team_literal(x, event)  # noqa: E731
+
+        # Script-variable env, built once per parser on first use. Building it
+        # runs DB queries and evaluates every variable, so skip it for
+        # parsers that never parse (static_check-only use).
+        env_cache: dict = {}
+
+        def variable_env() -> dict:
+            if "env" not in env_cache:
+                if include_variables:
+                    try:
+                        env_cache["env"] = build_variable_env(event, parse_team, parse_match)
+                    except Exception:
+                        env_cache["env"] = {}
+                else:
+                    env_cache["env"] = {}
+            return env_cache["env"]
 
         def parse(text):
             # Cheap structural check first — gives clean position-aware errors before Lark tries.
@@ -1835,9 +1984,11 @@ def get_parser(event: str, match_resolver=None, env=None):
             except LarkError as e:
                 raise DSLValidationError(f"Parse error: {e}") from e
             interpreter = Simplifier(
-                lambda x: parse_team_literal(x, event),
+                parse_team,
                 parse_match,
-                env=dict(base_env),
+                # Script variables first, explicit caller env on top (callers
+                # binding globals shouldn't be shadowed by user variables).
+                env={**variable_env(), **base_env},
             )
             return interpreter.visit(tree)
 

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -160,7 +160,15 @@ def _slot_resolved(
             tag = tag_by_name.get(tag_name)
         else:
             tag = Tag.query.filter_by(event=tournament_url, name=tag_name).first()
-        return bool(tag and getattr(tag, "team", None))
+        if tag is None:
+            return False
+        if getattr(tag, "team", None):
+            return True
+        if (getattr(tag, "expression", None) or "").strip():
+            from app.utils.helpers import resolve_tag_to_team
+
+            return resolve_tag_to_team(f"tag::{tag_name}", tournament_url) is not None
+        return False
     if "::winner" in initial or "::loser" in initial:
         base = initial.split("::")[0].strip()
         dep = name_to_match.get(base)

--- a/app/utils/toml_helpers.py
+++ b/app/utils/toml_helpers.py
@@ -21,6 +21,8 @@ def parse_toml_schedule(content: str) -> Result[dict[str, Any], ArctosError]:
     * ``event`` (str, optional, deprecated) — tournament URL slug. Accepted
       for backward compatibility with older exports; the importing route
       determines the target tournament.
+    * ``variables`` (array of tables, optional) — tournament script
+      variables (``name`` + ``expression``).
     * ``tags`` (array of tables, optional).
     * ``fields`` (array of tables, optional).
     * ``matches`` (array of tables, optional).
@@ -30,9 +32,10 @@ def parse_toml_schedule(content: str) -> Result[dict[str, Any], ArctosError]:
 
     Returns:
         :class:`~app.error_values.Ok` wrapping a dict with keys
-        ``"event"`` (str or ``None``), ``"tags"``, ``"fields"``,
-        ``"matches"``; or :class:`~app.error_values.Err` wrapping a
-        :class:`~app.exceptions.ValidationError` on parse / structure error.
+        ``"event"`` (str or ``None``), ``"variables"``, ``"tags"``,
+        ``"fields"``, ``"matches"``; or :class:`~app.error_values.Err`
+        wrapping a :class:`~app.exceptions.ValidationError` on parse /
+        structure error.
     """
     try:
         data = tomli.loads(content)
@@ -47,6 +50,11 @@ def parse_toml_schedule(content: str) -> Result[dict[str, Any], ArctosError]:
     event = data.get("event")
     if not isinstance(event, str) or not event:
         event = None
+
+    # Extract script variables (optional, defaults to empty list)
+    variables = data.get("variables", [])
+    if not isinstance(variables, list):
+        return Err(ValidationError("'variables' must be an array of tables"))
 
     # Extract tags (optional, defaults to empty list)
     tags = data.get("tags", [])
@@ -66,6 +74,7 @@ def parse_toml_schedule(content: str) -> Result[dict[str, Any], ArctosError]:
     return Ok(
         {
             "event": event,
+            "variables": variables,
             "tags": tags,
             "fields": fields,
             "matches": matches,
@@ -78,6 +87,7 @@ def write_toml_schedule(
     fields: list[dict[str, Any]],
     matches: list[dict[str, Any]],
     *,
+    variables: list[dict[str, Any]] | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> str:
     """Serialise a tournament schedule to a TOML string.
@@ -89,9 +99,12 @@ def write_toml_schedule(
 
     Args:
         tags: List of tag dicts with ``id``, ``name``, and optional
-            ``team`` (team ID).
+            ``team`` (team ID) and ``expression`` (ASS expression).
         fields: List of field dicts with ``id``, ``name``, and ``camera``.
         matches: List of match attribute dicts.
+        variables: Optional list of script-variable dicts with ``name`` and
+            ``expression``. Written before the tags section (tag / match
+            expressions may reference variables) and omitted when empty.
         metadata: Optional key-value pairs written as TOML comments at the
             top (e.g. ``{"export_date": "2024-06-01", "version": "1"}``)
 
@@ -107,6 +120,17 @@ def write_toml_schedule(
             lines.append(f"# {key}: {value}")
         lines.append("")
 
+    # Script variables (before tags: tag expressions may reference them)
+    if variables:
+        lines.append("# Script variables")
+        for variable in variables:
+            lines.append("[[variables]]")
+            if "name" in variable and variable["name"]:
+                lines.append(f'name = "{_escape_toml_string(variable["name"])}"')
+            if "expression" in variable and variable["expression"]:
+                lines.append(f'expression = "{_escape_toml_string(variable["expression"])}"')
+            lines.append("")
+
     # Tags
     if tags:
         lines.append("# Tags")
@@ -118,6 +142,8 @@ def write_toml_schedule(
                 lines.append(f'name = "{_escape_toml_string(tag["name"])}"')
             if "team" in tag and tag["team"]:
                 lines.append(f'team = "{_escape_toml_string(tag["team"])}"')
+            if "expression" in tag and tag["expression"]:
+                lines.append(f'expression = "{_escape_toml_string(tag["expression"])}"')
             lines.append("")
 
     # Fields

--- a/docs/arctos-schedule-script.md
+++ b/docs/arctos-schedule-script.md
@@ -222,6 +222,49 @@ Given environment bindings `teamlist` and `matchlist` (or literal lists):
 Higher wins first; ties broken by points won; remaining ties keep
 original order (stable sort).
 
+## Tags as Expressions
+
+Besides assigning a team to a tag by hand, a tag can be defined by an
+ASS expression whose result is a team, for example:
+
+```
+(winner {Semi A})
+```
+
+The tag then resolves automatically: once `{Semi A}` completes,
+`[tag::...]` references to it (in match slots, ref slots, and other
+expressions) resolve to the winning team. Until then the tag stays
+unresolved. A manually assigned team acts as an *override* — if both
+are set, the manual team wins. Tag expressions may reference other
+tags; circular references simply never resolve.
+
+Edit tag expressions from the **Tags** modal on the schedule edit
+page.
+
+## Variables
+
+Tournament-wide variables can be defined in the **Scripting** modal on
+the schedule edit page. A variable has a name (a plain identifier,
+e.g. `threshold` — it can't collide with builtin function names) and
+an ASS expression. The variable can then be used by name in any
+expression in the tournament:
+
+```
+(> (wins [ursae]) threshold)
+```
+
+Variables may reference other variables (circular definitions are
+rejected), can hold any type — including functions:
+
+```
+; variable double-wins:
+(lambda (t) (* 2 (wins t)))
+; used in a skip condition:
+(> (double-wins [ursae]) 4)
+```
+
+They work in skip conditions, tag expressions, and other variables.
+
 ## When are things evaluated?
 
 Everything is evaluated when a match's last dependency becomes

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -3658,6 +3658,80 @@ pub async fn delete_tag(tournament_url: &str, tag_id: u32) -> Result<(), String>
     Err(err_msg)
 }
 
+pub async fn create_script_variable(
+    tournament_url: &str,
+    req: &CreateScriptVariableRequest,
+) -> Result<CreateScriptVariableResponse, String> {
+    let c = client();
+    let r = with_credentials(
+        c.post(format!(
+            "{}/_api/tournaments/{}/script-variables",
+            base(),
+            tournament_url
+        ))
+        .json(req),
+    )
+    .send()
+    .await
+    .map_err(|e| e.to_string())?;
+    response_json(r).await
+}
+
+pub async fn update_script_variable(
+    tournament_url: &str,
+    var_id: u32,
+    req: &UpdateScriptVariableRequest,
+) -> Result<(), String> {
+    let c = client();
+    let r = with_credentials(
+        c.put(format!(
+            "{}/_api/tournaments/{}/script-variables/{}",
+            base(),
+            tournament_url,
+            var_id
+        ))
+        .json(req),
+    )
+    .send()
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let data: Value = response_json(r).await?;
+    if data.get("success").and_then(|v| v.as_bool()) == Some(true) {
+        Ok(())
+    } else {
+        Err(data
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unknown error")
+            .to_string())
+    }
+}
+
+pub async fn delete_script_variable(tournament_url: &str, var_id: u32) -> Result<(), String> {
+    let c = client();
+    let r = with_credentials(c.delete(format!(
+        "{}/_api/tournaments/{}/script-variables/{}",
+        base(),
+        tournament_url,
+        var_id
+    )))
+    .send()
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let data: Value = response_json(r).await?;
+    if data.get("success").and_then(|v| v.as_bool()) == Some(true) {
+        Ok(())
+    } else {
+        Err(data
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unknown error")
+            .to_string())
+    }
+}
+
 #[allow(dead_code)]
 pub async fn update_all_references(tournament_url: &str) -> Result<(), String> {
     let c = client();

--- a/frontend/src/components/ass_entry.rs
+++ b/frontend/src/components/ass_entry.rs
@@ -671,7 +671,7 @@ fn resolve_team_literal(
         let resolved = tags
             .iter()
             .find(|t| t.name.eq_ignore_ascii_case(name))
-            .and_then(|t| t.team.clone())
+            .and_then(|t| t.team.clone().or_else(|| t.resolved_team.clone()))
             .and_then(|tid| team_options.iter().find(|t| t.id == tid).cloned())
             .map(|t| TeamRefResolved {
                 profile_photo: t.profile_photo.clone(),
@@ -1083,7 +1083,7 @@ fn collect_team_options(
         .map(|tag| AcOption::Tag {
             insert: format!("tag::{}", tag.name),
             display: tag.name.clone(),
-            resolved_team: tag.team.clone(),
+            resolved_team: tag.team.clone().or_else(|| tag.resolved_team.clone()),
         })
         .collect();
     let mut match_ref_opts: Vec<AcOption> = Vec::new();

--- a/frontend/src/pages/schedule.rs
+++ b/frontend/src/pages/schedule.rs
@@ -1161,6 +1161,7 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                                 if editor {
                                     div { class: "d-flex flex-wrap align-items-center gap-1",
                                             button { class: "btn btn-sm btn-outline-secondary", onclick: move |_| active_modal.set("tags".to_string()), "Tags" }
+                                            button { class: "btn btn-sm btn-outline-secondary", onclick: move |_| active_modal.set("scripting".to_string()), "Scripting" }
                                             button { class: "btn btn-sm btn-outline-secondary", onclick: move |_| active_modal.set("fields".to_string()), "Fields" }
                                             div {
                                                 class: "d-flex align-items-center gap-1 ms-1",
@@ -1660,6 +1661,14 @@ fn SchedulePage(url: String, view: String, team: String, field: String, editor: 
                     // Modals that don't need the schedule visible stay as real modals.
                     if active_modal() == "tags" {
                         TagsModal {
+                            tournament_url: url.clone(),
+                            data: data.clone(),
+                            on_close: move |_| active_modal.set("none".to_string()),
+                            on_change: move |_| refresh()
+                        }
+                    }
+                    if active_modal() == "scripting" {
+                        ScriptingModal {
                             tournament_url: url.clone(),
                             data: data.clone(),
                             on_close: move |_| active_modal.set("none".to_string()),
@@ -3657,15 +3666,22 @@ fn TagsModal(
     // Local state for dropdowns: tag_id -> team_id. Synced from data when modal has data so dropdowns show current values.
     let mut tag_teams = use_signal(|| HashMap::<u32, String>::new());
     let mut updating_tag_id = use_signal(|| None::<u32>);
+    // Per-tag ASS expression drafts + their latest validation verdicts.
+    let mut tag_exprs = use_signal(|| HashMap::<u32, String>::new());
+    let mut tag_expr_valid = use_signal(|| HashMap::<u32, Option<Result<(), String>>>::new());
 
-    // Sync tag_teams from data whenever we have tags, so dropdowns show correct values on open and after refetch.
+    // Sync tag_teams / expression drafts from data whenever we have tags, so
+    // inputs show correct values on open and after refetch.
     let data_effect = data.clone();
     use_effect(move || {
         let tags = data_effect.tags.clone();
         let mut map = tag_teams.write();
         map.clear();
+        let mut exprs = tag_exprs.write();
+        exprs.clear();
         for tag in tags {
             map.insert(tag.id, tag.team.unwrap_or_default());
+            exprs.insert(tag.id, tag.expression.unwrap_or_default());
         }
     });
 
@@ -3698,7 +3714,7 @@ fn TagsModal(
                                     }
                                     error.set(None);
                                     spawn(async move {
-                                        let req = CreateTagRequest { name };
+                                        let req = CreateTagRequest { name, expression: None };
                                         match api::create_tag(&u, &req).await {
                                             Ok(_) => { new_tag.set("".to_string()); on_change.call(()); }
                                             Err(e) => error.set(Some(e)),
@@ -3716,65 +3732,363 @@ fn TagsModal(
                                 let current_team = tag_teams().get(&tag_id).cloned().unwrap_or_default();
                                 let tag_name = tag.name.clone();
                                 let is_updating = updating_tag_id() == Some(tag_id);
+                                let saved_expr = tag.expression.clone().unwrap_or_default();
+                                let edited_expr = tag_exprs()
+                                    .get(&tag_id)
+                                    .cloned()
+                                    .unwrap_or_else(|| saved_expr.clone());
+                                let expr_dirty = edited_expr.trim() != saved_expr.trim();
+                                let expr_verdict = tag_expr_valid().get(&tag_id).cloned().flatten();
+                                // Clearing (empty) is always saveable; otherwise require a passing validation.
+                                let expr_can_save = expr_dirty
+                                    && (edited_expr.trim().is_empty() || matches!(expr_verdict, Some(Ok(()))));
+                                // Effective resolution hint: override beats expression.
+                                let team_label = |tid: &str| -> String {
+                                    data.team_options
+                                        .iter()
+                                        .find(|t| t.id == tid)
+                                        .and_then(|t| t.pseudonym.clone())
+                                        .unwrap_or_else(|| tid.to_string())
+                                };
+                                let resolution_hint = if let Some(t) = tag.team.as_deref().filter(|t| !t.is_empty()) {
+                                    Some(format!("Resolves to {} (manual override)", team_label(t)))
+                                } else if let Some(t) = tag.resolved_team.as_deref().filter(|t| !t.is_empty()) {
+                                    Some(format!("Resolves to {} (from expression)", team_label(t)))
+                                } else if !saved_expr.trim().is_empty() {
+                                    Some("Expression not resolved yet".to_string())
+                                } else {
+                                    None
+                                };
                                 rsx! {
-                                    li { key: "{tag_id}", class: "list-group-item d-flex justify-content-between align-items-center gap-2 flex-wrap",
-                                        span { class: "flex-grow-1", "{tag_name}" }
-                                        div { class: "d-flex align-items-center gap-1",
-                                            select {
-                                                class: "form-select form-select-sm",
-                                                style: "max-width: 12rem;",
-                                                value: "{current_team}",
+                                    li { key: "{tag_id}", class: "list-group-item",
+                                        div { class: "d-flex justify-content-between align-items-center gap-2 flex-wrap",
+                                            span { class: "flex-grow-1 fw-semibold", "{tag_name}" }
+                                            div { class: "d-flex align-items-center gap-1",
+                                                span { class: "text-muted small", "Override:" }
+                                                select {
+                                                    class: "form-select form-select-sm",
+                                                    style: "max-width: 12rem;",
+                                                    value: "{current_team}",
+                                                    disabled: is_updating,
+                                                    onchange: move |e| {
+                                                        let u = url_sig();
+                                                        let team_id = e.value();
+                                                        let on_change = on_change.clone();
+                                                        tag_teams.write().insert(tag_id, team_id.clone());
+                                                        updating_tag_id.set(Some(tag_id));
+                                                        error.set(None);
+                                                        let prev_team = current_team.clone();
+                                                        spawn(async move {
+                                                            let req = UpdateTagsRequest {
+                                                                tag_id,
+                                                                team_id: Some(team_id),
+                                                                expression: None,
+                                                            };
+                                                            match api::update_tags(&u, &req).await {
+                                                                Ok(_) => {
+                                                                    updating_tag_id.set(None);
+                                                                    on_change.call(());
+                                                                }
+                                                                Err(e) => {
+                                                                    tag_teams.write().insert(tag_id, prev_team);
+                                                                    updating_tag_id.set(None);
+                                                                    error.set(Some(e));
+                                                                }
+                                                            }
+                                                        });
+                                                    },
+                                                    option { value: "", "No override" }
+                                                    for opt in &data.team_options {
+                                                        option { value: "{opt.id}", "{opt.pseudonym.as_deref().unwrap_or(&opt.id)}" }
+                                                    }
+                                                }
+                                                if is_updating {
+                                                    span { class: "spinner-border spinner-border-sm text-secondary", role: "status", "aria-hidden": "true" }
+                                                }
+                                            }
+                                            button { class: "btn btn-sm btn-outline-danger",
                                                 disabled: is_updating,
-                                                onchange: move |e| {
+                                                onclick: move |_| {
                                                     let u = url_sig();
-                                                    let team_id = e.value();
                                                     let on_change = on_change.clone();
-                                                    tag_teams.write().insert(tag_id, team_id.clone());
-                                                    updating_tag_id.set(Some(tag_id));
-                                                    error.set(None);
-                                                    let prev_team = current_team.clone();
                                                     spawn(async move {
-                                                        let req = UpdateTagsRequest { tag_id, team_id };
-                                                        match api::update_tags(&u, &req).await {
-                                                            Ok(_) => {
-                                                                updating_tag_id.set(None);
-                                                                on_change.call(());
-                                                            }
-                                                            Err(e) => {
-                                                                tag_teams.write().insert(tag_id, prev_team);
-                                                                updating_tag_id.set(None);
-                                                                error.set(Some(e));
-                                                            }
+                                                        match api::delete_tag(&u, tag_id).await {
+                                                            Ok(_) => { error.set(None); on_change.call(()); }
+                                                            Err(e) => error.set(Some(e)),
                                                         }
                                                     });
                                                 },
-                                                option { value: "", "No team" }
-                                                for opt in &data.team_options {
-                                                    option { value: "{opt.id}", "{opt.pseudonym.as_deref().unwrap_or(&opt.id)}" }
-                                                }
-                                            }
-                                            if is_updating {
-                                                span { class: "spinner-border spinner-border-sm text-secondary", role: "status", "aria-hidden": "true" }
+                                                "×"
                                             }
                                         }
-                                        button { class: "btn btn-sm btn-outline-danger",
-                                            disabled: is_updating,
-                                            onclick: move |_| {
-                                                let u = url_sig();
-                                                let on_change = on_change.clone();
-                                                spawn(async move {
-                                                    match api::delete_tag(&u, tag_id).await {
-                                                        Ok(_) => { error.set(None); on_change.call(()); }
-                                                        Err(e) => error.set(Some(e)),
+                                        div { class: "mt-2 d-flex align-items-start gap-2",
+                                            div { class: "flex-grow-1",
+                                                AssEntry {
+                                                    id_suffix: format!("tag-expr-{tag_id}"),
+                                                    value: edited_expr.clone(),
+                                                    on_change: move |v: String| { tag_exprs.write().insert(tag_id, v); },
+                                                    team_options: data.team_options.clone(),
+                                                    tags: data.tags.clone(),
+                                                    matches: data.matches.clone(),
+                                                    tournament_url: url_sig(),
+                                                    placeholder: "Expression, e.g. (winner {Semi A})".to_string(),
+                                                    expected_type: vec!["TEAM".to_string()],
+                                                    on_validity_change: move |v: Option<Result<(), String>>| {
+                                                        tag_expr_valid.write().insert(tag_id, v);
+                                                    },
+                                                }
+                                            }
+                                            button { class: "btn btn-sm btn-outline-primary",
+                                                disabled: !expr_can_save || is_updating,
+                                                onclick: {
+                                                    let expr_to_save = edited_expr.clone();
+                                                    move |_| {
+                                                        let u = url_sig();
+                                                        let on_change = on_change.clone();
+                                                        let expression = expr_to_save.trim().to_string();
+                                                        updating_tag_id.set(Some(tag_id));
+                                                        error.set(None);
+                                                        spawn(async move {
+                                                            let req = UpdateTagsRequest {
+                                                                tag_id,
+                                                                team_id: None,
+                                                                expression: Some(expression),
+                                                            };
+                                                            match api::update_tags(&u, &req).await {
+                                                                Ok(_) => {
+                                                                    updating_tag_id.set(None);
+                                                                    on_change.call(());
+                                                                }
+                                                                Err(e) => {
+                                                                    updating_tag_id.set(None);
+                                                                    error.set(Some(e));
+                                                                }
+                                                            }
+                                                        });
                                                     }
-                                                });
-                                            },
-                                            "×"
+                                                },
+                                                "Save"
+                                            }
+                                        }
+                                        if let Some(hint) = resolution_hint {
+                                            div { class: "form-text text-muted", "{hint}" }
                                         }
                                     }
                                 }
                             })}
                         }
+                        div { class: "form-text mt-2",
+                            "A tag resolves to its Override team if set, otherwise by evaluating its expression (which must produce a TEAM)."
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn ScriptingModal(
+    tournament_url: String,
+    data: ScheduleSetupResponse,
+    on_close: EventHandler<()>,
+    on_change: EventHandler<()>,
+) -> Element {
+    let url_sig = use_signal(|| tournament_url.clone());
+    let mut error = use_signal(|| None::<String>);
+    let mut saving_var_id = use_signal(|| None::<u32>);
+    // New-variable form.
+    let mut new_name = use_signal(|| "".to_string());
+    let mut new_expr = use_signal(|| "".to_string());
+    let mut new_expr_valid = use_signal(|| None::<Result<(), String>>);
+    // Per-variable drafts (name + expression) and validation verdicts.
+    let mut var_names = use_signal(|| HashMap::<u32, String>::new());
+    let mut var_exprs = use_signal(|| HashMap::<u32, String>::new());
+    let mut var_expr_valid = use_signal(|| HashMap::<u32, Option<Result<(), String>>>::new());
+
+    // Sync drafts from data so inputs show current values on open and after refetch.
+    let data_effect = data.clone();
+    use_effect(move || {
+        let vars = data_effect.script_variables.clone();
+        let mut names = var_names.write();
+        names.clear();
+        let mut exprs = var_exprs.write();
+        exprs.clear();
+        for v in vars {
+            names.insert(v.id, v.name);
+            exprs.insert(v.id, v.expression);
+        }
+    });
+
+    let new_can_add = !new_name().trim().is_empty()
+        && !new_expr().trim().is_empty()
+        && matches!(new_expr_valid(), Some(Ok(())));
+
+    rsx! {
+        div { class: "modal d-block", tabindex: "-1", style: "background: rgba(0,0,0,0.5)",
+            div { class: "modal-dialog modal-lg",
+                div { class: "modal-content",
+                    div { class: "modal-header d-flex justify-content-between align-items-center",
+                        h5 { class: "modal-title mb-0", "Scripting" }
+                        button { type: "button", class: "btn-close", "aria-label": "Close", onclick: move |_| on_close.call(()) }
+                    }
+                    div { class: "modal-body",
+                        if let Some(err) = error() { div { class: "alert alert-danger", "{err}" } }
+                        p { class: "form-text",
+                            "Variables can be used by name in any ASS expression in this tournament — skip conditions, tag expressions, and other variables."
+                        }
+
+                        h6 { "New Variable" }
+                        div { class: "d-flex align-items-start gap-2 mb-3",
+                            input {
+                                class: "form-control",
+                                style: "max-width: 12rem;",
+                                placeholder: "name (e.g. threshold)",
+                                value: "{new_name}",
+                                oninput: move |e| { new_name.set(e.value()); error.set(None); },
+                            }
+                            div { class: "flex-grow-1",
+                                AssEntry {
+                                    id_suffix: "script-var-new".to_string(),
+                                    value: new_expr(),
+                                    on_change: move |v: String| new_expr.set(v),
+                                    team_options: data.team_options.clone(),
+                                    tags: data.tags.clone(),
+                                    matches: data.matches.clone(),
+                                    tournament_url: url_sig(),
+                                    placeholder: "expression, e.g. (+ 1 2)".to_string(),
+                                    on_validity_change: move |v: Option<Result<(), String>>| {
+                                        new_expr_valid.set(v);
+                                    },
+                                }
+                            }
+                            button { class: "btn btn-outline-success",
+                                disabled: !new_can_add,
+                                onclick: move |_| {
+                                    let u = url_sig();
+                                    let on_change = on_change.clone();
+                                    let req = CreateScriptVariableRequest {
+                                        name: new_name().trim().to_string(),
+                                        expression: new_expr().trim().to_string(),
+                                    };
+                                    error.set(None);
+                                    spawn(async move {
+                                        match api::create_script_variable(&u, &req).await {
+                                            Ok(_) => {
+                                                new_name.set("".to_string());
+                                                new_expr.set("".to_string());
+                                                new_expr_valid.set(None);
+                                                on_change.call(());
+                                            }
+                                            Err(e) => error.set(Some(e)),
+                                        }
+                                    });
+                                },
+                                "Add"
+                            }
+                        }
+
+                        h6 { "Variables" }
+                        if data.script_variables.is_empty() {
+                            p { class: "text-muted small", "No variables defined yet." }
+                        }
+                        ul { class: "list-group",
+                            {data.script_variables.iter().map(|var| {
+                                let var_id = var.id;
+                                let saved_name = var.name.clone();
+                                let saved_expr = var.expression.clone();
+                                let edited_name = var_names()
+                                    .get(&var_id)
+                                    .cloned()
+                                    .unwrap_or_else(|| saved_name.clone());
+                                let edited_expr = var_exprs()
+                                    .get(&var_id)
+                                    .cloned()
+                                    .unwrap_or_else(|| saved_expr.clone());
+                                let dirty = edited_name.trim() != saved_name
+                                    || edited_expr.trim() != saved_expr.trim();
+                                let expr_changed = edited_expr.trim() != saved_expr.trim();
+                                let verdict = var_expr_valid().get(&var_id).cloned().flatten();
+                                let can_save = dirty
+                                    && !edited_name.trim().is_empty()
+                                    && !edited_expr.trim().is_empty()
+                                    && (!expr_changed || matches!(verdict, Some(Ok(()))));
+                                let is_saving = saving_var_id() == Some(var_id);
+                                let name_to_save = edited_name.clone();
+                                let expr_to_save = edited_expr.clone();
+                                rsx! {
+                                    li { key: "{var_id}", class: "list-group-item",
+                                        div { class: "d-flex align-items-start gap-2",
+                                            input {
+                                                class: "form-control font-monospace",
+                                                style: "max-width: 12rem;",
+                                                value: "{edited_name}",
+                                                disabled: is_saving,
+                                                oninput: move |e| { var_names.write().insert(var_id, e.value()); },
+                                            }
+                                            div { class: "flex-grow-1",
+                                                AssEntry {
+                                                    id_suffix: format!("script-var-{var_id}"),
+                                                    value: edited_expr.clone(),
+                                                    on_change: move |v: String| { var_exprs.write().insert(var_id, v); },
+                                                    team_options: data.team_options.clone(),
+                                                    tags: data.tags.clone(),
+                                                    matches: data.matches.clone(),
+                                                    tournament_url: url_sig(),
+                                                    placeholder: "expression".to_string(),
+                                                    on_validity_change: move |v: Option<Result<(), String>>| {
+                                                        var_expr_valid.write().insert(var_id, v);
+                                                    },
+                                                }
+                                            }
+                                            button { class: "btn btn-sm btn-outline-primary",
+                                                disabled: !can_save || is_saving,
+                                                onclick: move |_| {
+                                                    let u = url_sig();
+                                                    let on_change = on_change.clone();
+                                                    let req = UpdateScriptVariableRequest {
+                                                        name: name_to_save.trim().to_string(),
+                                                        expression: expr_to_save.trim().to_string(),
+                                                    };
+                                                    saving_var_id.set(Some(var_id));
+                                                    error.set(None);
+                                                    spawn(async move {
+                                                        match api::update_script_variable(&u, var_id, &req).await {
+                                                            Ok(_) => {
+                                                                saving_var_id.set(None);
+                                                                on_change.call(());
+                                                            }
+                                                            Err(e) => {
+                                                                saving_var_id.set(None);
+                                                                error.set(Some(e));
+                                                            }
+                                                        }
+                                                    });
+                                                },
+                                                "Save"
+                                            }
+                                            button { class: "btn btn-sm btn-outline-danger",
+                                                disabled: is_saving,
+                                                onclick: move |_| {
+                                                    let u = url_sig();
+                                                    let on_change = on_change.clone();
+                                                    spawn(async move {
+                                                        match api::delete_script_variable(&u, var_id).await {
+                                                            Ok(_) => { error.set(None); on_change.call(()); }
+                                                            Err(e) => error.set(Some(e)),
+                                                        }
+                                                    });
+                                                },
+                                                "×"
+                                            }
+                                        }
+                                    }
+                                }
+                            })}
+                        }
+                    }
+                    div { class: "modal-footer",
+                        button { class: "btn btn-secondary", onclick: move |_| on_close.call(()), "Close" }
                     }
                 }
             }

--- a/frontend/src/types.rs
+++ b/frontend/src/types.rs
@@ -1448,6 +1448,8 @@ pub struct ScheduleSetupResponse {
     pub matches: Vec<MatchSetupData>,
     pub fields: Vec<FieldSetupData>,
     pub tags: Vec<TagSetupData>,
+    #[serde(default)]
+    pub script_variables: Vec<ScriptVariableData>,
     pub team_options: Vec<TeamOption>,
     pub is_to: bool,
 }
@@ -1492,8 +1494,23 @@ pub struct FieldSetupData {
 pub struct TagSetupData {
     pub id: u32,
     pub name: String,
+    /// Manually assigned team (an override for `expression`).
     #[serde(default)]
     pub team: Option<String>,
+    /// ASS expression resolving to a TEAM, used when `team` is unset.
+    #[serde(default)]
+    pub expression: Option<String>,
+    /// Effective resolution: `team` if set, else the evaluated expression.
+    #[serde(default)]
+    pub resolved_team: Option<String>,
+}
+
+/// A tournament-scoped ASS script variable (identifier + expression).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ScriptVariableData {
+    pub id: u32,
+    pub name: String,
+    pub expression: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1626,6 +1643,8 @@ pub struct CreateFieldResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CreateTagRequest {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expression: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1642,7 +1661,30 @@ pub struct PushBackRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UpdateTagsRequest {
     pub tag_id: u32,
-    pub team_id: String,
+    /// Manual team override ("" clears it). Omitted → unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<String>,
+    /// ASS expression ("" clears it). Omitted → unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expression: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreateScriptVariableRequest {
+    pub name: String,
+    pub expression: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreateScriptVariableResponse {
+    pub success: bool,
+    pub id: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UpdateScriptVariableRequest {
+    pub name: String,
+    pub expression: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/migrations/versions/0013_tag_expressions_script_variables.py
+++ b/migrations/versions/0013_tag_expressions_script_variables.py
@@ -1,0 +1,53 @@
+"""Tag expressions and tournament script variables.
+
+Two additions for ASS (Arctos Schedule Script) scripting support:
+
+* ``tags.expression`` — nullable TEXT column holding an ASS expression whose
+  result type includes TEAM. The manually assigned ``tags.team`` column acts
+  as an override; when unset, the expression is evaluated to resolve the tag.
+* ``script_variables`` — new table of per-tournament ASS variables
+  (identifier name + expression), unique per (event, name). Variables are
+  bound into the interpreter environment for every expression evaluated in
+  the tournament.
+
+SQLite supports plain ADD COLUMN for a nullable column with no default, so no
+batch_alter is needed for the upgrade; the downgrade drops the column with
+batch_alter (table rebuild) for SQLite compatibility.
+
+Revision ID: 0013_tag_expr_script_vars
+Revises: 0012_statbreak
+Create Date: 2026-08-13
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0013_tag_expr_script_vars"
+down_revision: Union[str, Sequence[str], None] = "0012_statbreak"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("tags", sa.Column("expression", sa.Text(), nullable=True))
+    op.create_table(
+        "script_variables",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("event", sa.String(length=100), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("expression", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(["event"], ["tournaments.url"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("event", "name", name="uq_script_variables_event_name"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("script_variables")
+    with op.batch_alter_table("tags") as batch_op:
+        batch_op.drop_column("expression")

--- a/tests/unit/test_league_vs_standalone_registration.py
+++ b/tests/unit/test_league_vs_standalone_registration.py
@@ -305,7 +305,7 @@ def test_schedule_import_registered_teams_league_and_standalone(app, test_db):
         db.session.commit()
 
         for t in (sa, lg):
-            tags_out, matches_out, warnings, auto_tag_names = ScheduleImportExportService._rewrite_unknown_team_refs(
+            tags_out, matches_out, _, warnings, auto_tag_names = ScheduleImportExportService._rewrite_unknown_team_refs(
                 t,
                 tags_data=[{"name": "T", "team": f"ok-{t.url}"}],
                 matches_data=[

--- a/tests/unit/test_schedule_import_export.py
+++ b/tests/unit/test_schedule_import_export.py
@@ -724,3 +724,297 @@ def test_reimport_of_rewritten_schedule_is_idempotent(test_db, tournament):
     assert m1.team1_initial == "tag::Mystery Team"
     tags = Tag.query.filter_by(event=tournament_url, name="Mystery Team").all()
     assert len(tags) == 1
+
+
+@pytest.mark.unit
+def test_tag_expression_roundtrips_through_toml(test_db, tournament):
+    """Tag expressions survive export -> wipe -> import, alongside a team override."""
+    tournament_url = tournament.url
+    _register_team(tournament_url, "known-team")
+
+    field = Field(event=tournament_url, name="Field 1", camera=None)
+    m1 = Match(
+        name="Semi A",
+        event=tournament_url,
+        field="Field 1",
+        schedule_type="STATIC",
+        set_type="SETS",
+        nominal_length=60,
+    )
+    expr_tag = Tag(event=tournament_url, name="SemiWinner", expression="(winner {Semi A})")
+    both_tag = Tag(event=tournament_url, name="Champ", team="known-team", expression="(winner {Semi A})")
+    db.session.add_all([field, m1, expr_tag, both_tag])
+    db.session.commit()
+
+    export_res = ScheduleImportExportService.export_schedule(tournament_url)
+    assert isinstance(export_res, Ok), getattr(export_res, "value", export_res)
+    exported = export_res.val
+    assert 'expression = "(winner {Semi A})"' in exported
+    assert 'team = "known-team"' in exported
+
+    # Wipe the tags to simulate a fresh tournament state, then re-import.
+    Tag.query.filter_by(event=tournament_url).delete()
+    db.session.commit()
+
+    res = ScheduleImportExportService.import_schedule(tournament_url, exported)
+    assert isinstance(res, Ok), getattr(res, "value", res)
+    assert res.val.warnings == []
+
+    restored = Tag.query.filter_by(event=tournament_url, name="SemiWinner").first()
+    assert restored is not None
+    assert restored.expression == "(winner {Semi A})"
+    assert restored.team is None
+
+    # A tag with BOTH an expression and a manual team override keeps both.
+    restored_both = Tag.query.filter_by(event=tournament_url, name="Champ").first()
+    assert restored_both is not None
+    assert restored_both.expression == "(winner {Semi A})"
+    assert restored_both.team == "known-team"
+
+
+@pytest.mark.unit
+def test_script_variables_roundtrip_through_toml(test_db, tournament):
+    """Variables export as a [[variables]] section and survive export -> wipe -> import."""
+    from models import ScriptVariable
+
+    tournament_url = tournament.url
+    db.session.add(ScriptVariable(event=tournament_url, name="base", expression="2"))
+    db.session.add(ScriptVariable(event=tournament_url, name="doubled", expression="(* base 2)"))
+    db.session.commit()
+
+    export_res = ScheduleImportExportService.export_schedule(tournament_url)
+    assert isinstance(export_res, Ok), getattr(export_res, "value", export_res)
+    exported = export_res.val
+    assert "[[variables]]" in exported
+    assert 'name = "base"' in exported
+    assert 'expression = "(* base 2)"' in exported
+
+    # Wipe all variables, then re-import the exported file.
+    ScriptVariable.query.filter_by(event=tournament_url).delete()
+    db.session.commit()
+
+    res = ScheduleImportExportService.import_schedule(tournament_url, exported)
+    assert isinstance(res, Ok), getattr(res, "value", res)
+    assert res.val.variables_created == 2
+    assert res.val.warnings == []
+
+    rows = {v.name: v.expression for v in ScriptVariable.query.filter_by(event=tournament_url).all()}
+    assert rows == {"base": "2", "doubled": "(* base 2)"}
+
+
+@pytest.mark.unit
+def test_variables_export_section_placed_before_tags(test_db, tournament):
+    """[[variables]] is written near (before) the [[tags]] section, and only when variables exist."""
+    from models import ScriptVariable
+
+    tournament_url = tournament.url
+
+    # Without variables the section is omitted entirely.
+    db.session.add(Tag(event=tournament_url, name="Pool A"))
+    db.session.commit()
+    export_res = ScheduleImportExportService.export_schedule(tournament_url)
+    assert isinstance(export_res, Ok)
+    assert "[[variables]]" not in export_res.val
+
+    db.session.add(ScriptVariable(event=tournament_url, name="threshold", expression="(+ 1 2)"))
+    db.session.commit()
+    export_res = ScheduleImportExportService.export_schedule(tournament_url)
+    assert isinstance(export_res, Ok)
+    exported = export_res.val
+    assert exported.index("[[variables]]") < exported.index("[[tags]]")
+
+
+@pytest.mark.unit
+def test_import_reconciles_variables_and_deletes_missing(test_db, tournament):
+    """Import updates variables by name, creates new ones, and deletes those absent from the file."""
+    from models import ScriptVariable
+
+    tournament_url = tournament.url
+    db.session.add(ScriptVariable(event=tournament_url, name="keep", expression="1"))
+    db.session.add(ScriptVariable(event=tournament_url, name="stale", expression="2"))
+    db.session.commit()
+
+    toml_content = textwrap.dedent(
+        """
+        [[variables]]
+        name = "keep"
+        expression = "(+ 1 1)"
+
+        [[variables]]
+        name = "fresh"
+        expression = "3"
+        """
+    ).strip()
+
+    res = ScheduleImportExportService.import_schedule(tournament_url, toml_content)
+    assert isinstance(res, Ok), getattr(res, "value", res)
+    assert res.val.variables_updated == 1
+    assert res.val.variables_created == 1
+
+    rows = {v.name: v.expression for v in ScriptVariable.query.filter_by(event=tournament_url).all()}
+    assert rows == {"keep": "(+ 1 1)", "fresh": "3"}
+
+    # A file without a [[variables]] section is authoritative too: all
+    # variables for the tournament are deleted (same semantics as tags).
+    res = ScheduleImportExportService.import_schedule(tournament_url, "")
+    assert isinstance(res, Ok)
+    assert ScriptVariable.query.filter_by(event=tournament_url).count() == 0
+
+
+@pytest.mark.unit
+def test_import_rejects_invalid_variable_entries(test_db, tournament):
+    """Bad identifiers, reserved names, cycles, and unparseable expressions fail the import."""
+    from app.exceptions import ValidationError
+    from models import ScriptVariable
+
+    bad_files = {
+        "bad identifier": '[[variables]]\nname = "has space"\nexpression = "1"',
+        "reserved name": '[[variables]]\nname = "winner"\nexpression = "1"',
+        "missing expression": '[[variables]]\nname = "x"',
+        "duplicate name": (
+            '[[variables]]\nname = "x"\nexpression = "1"\n\n[[variables]]\nname = "x"\nexpression = "2"'
+        ),
+        "cycle": (
+            '[[variables]]\nname = "a"\nexpression = "(+ b 1)"\n\n[[variables]]\nname = "b"\nexpression = "(+ a 1)"'
+        ),
+        "self reference": '[[variables]]\nname = "loop"\nexpression = "(+ loop 1)"',
+        "unparseable expression": '[[variables]]\nname = "bad"\nexpression = "(+ 1"',
+    }
+
+    for label, toml_content in bad_files.items():
+        res = ScheduleImportExportService.import_schedule(tournament.url, toml_content)
+        match res:
+            case Ok(_):
+                raise AssertionError(f"Expected Err(ValidationError) for {label}")
+            case Err(err):
+                assert isinstance(err, ValidationError), label
+        # Failed imports must not leave any variables behind.
+        assert ScriptVariable.query.filter_by(event=tournament.url).count() == 0, label
+
+
+@pytest.mark.unit
+def test_import_orders_variables_before_dependent_tag_expressions(test_db, tournament):
+    """A tag expression referencing a variable (which references an in-file match) imports cleanly."""
+    from models import ScriptVariable
+
+    tournament_url = tournament.url
+
+    toml_content = textwrap.dedent(
+        """
+        [[variables]]
+        name = "semi-winner"
+        expression = "(winner {Semi A})"
+
+        [[tags]]
+        name = "Champ"
+        expression = "semi-winner"
+
+        [[fields]]
+        name = "Field 1"
+
+        [[matches]]
+        name = "Semi A"
+        field = "Field 1"
+        schedule_type = "STATIC"
+        set_type = "SETS"
+        nominal_length = 60
+        """
+    ).strip()
+
+    res = ScheduleImportExportService.import_schedule(tournament_url, toml_content)
+    match res:
+        case Ok(result):
+            assert result.variables_created == 1
+            assert result.tags_created == 1
+            assert result.warnings == []
+        case Err(err):
+            raise AssertionError(f"Expected Ok(ImportResult), got Err({err})")
+
+    var = ScriptVariable.query.filter_by(event=tournament_url, name="semi-winner").first()
+    assert var is not None and var.expression == "(winner {Semi A})"
+    tag = Tag.query.filter_by(event=tournament_url, name="Champ").first()
+    assert tag is not None and tag.expression == "semi-winner"
+
+
+@pytest.mark.unit
+def test_import_rewrites_unknown_team_literals_in_tag_and_variable_expressions(test_db, tournament):
+    """Unknown [Team] literals in tag / variable expressions become [tag::Team] with warnings + auto-tags."""
+    from models import ScriptVariable
+
+    tournament_url = tournament.url
+    _register_team(tournament_url, "known-team")
+
+    toml_content = textwrap.dedent(
+        """
+        [[variables]]
+        name = "ghost"
+        expression = "[Ghost Team]"
+
+        [[tags]]
+        name = "Phantom"
+        expression = "[Phantom Squad]"
+
+        [[tags]]
+        name = "Known"
+        expression = "[known-team]"
+        """
+    ).strip()
+
+    res = ScheduleImportExportService.import_schedule(tournament_url, toml_content)
+    match res:
+        case Ok(result):
+            assert any("Ghost Team" in w for w in result.warnings)
+            assert any("Phantom Squad" in w for w in result.warnings)
+            assert not any("known-team" in w for w in result.warnings)
+        case Err(err):
+            raise AssertionError(f"Expected Ok(ImportResult), got Err({err})")
+
+    var = ScriptVariable.query.filter_by(event=tournament_url, name="ghost").first()
+    assert var.expression == "[tag::Ghost Team]"
+    assert Tag.query.filter_by(event=tournament_url, name="Phantom").first().expression == "[tag::Phantom Squad]"
+    # Registered team literal untouched.
+    assert Tag.query.filter_by(event=tournament_url, name="Known").first().expression == "[known-team]"
+
+    # Auto-created unassigned tags back the rewritten references.
+    for auto_name in ("Ghost Team", "Phantom Squad"):
+        auto_tag = Tag.query.filter_by(event=tournament_url, name=auto_name).first()
+        assert auto_tag is not None
+        assert auto_tag.team is None
+
+
+@pytest.mark.unit
+def test_reimport_of_rewritten_expressions_is_idempotent(test_db, tournament):
+    """Re-importing an export produced after expression rewrites must not double-tag (no tag::tag::X)."""
+    from models import ScriptVariable
+
+    tournament_url = tournament.url
+
+    toml_content = textwrap.dedent(
+        """
+        [[variables]]
+        name = "ghost"
+        expression = "[Ghost Team]"
+
+        [[tags]]
+        name = "Phantom"
+        expression = "[Phantom Squad]"
+        """
+    ).strip()
+
+    res = ScheduleImportExportService.import_schedule(tournament_url, toml_content)
+    assert isinstance(res, Ok), getattr(res, "value", res)
+    assert len(res.val.warnings) == 2
+
+    export_res = ScheduleImportExportService.export_schedule(tournament_url)
+    assert isinstance(export_res, Ok)
+    exported = export_res.val
+    assert 'expression = "[tag::Ghost Team]"' in exported
+    assert "tag::tag::" not in exported
+
+    res2 = ScheduleImportExportService.import_schedule(tournament_url, exported)
+    assert isinstance(res2, Ok), getattr(res2, "value", res2)
+    assert res2.val.warnings == []
+
+    assert ScriptVariable.query.filter_by(event=tournament_url, name="ghost").first().expression == "[tag::Ghost Team]"
+    assert Tag.query.filter_by(event=tournament_url, name="Phantom").first().expression == "[tag::Phantom Squad]"
+    assert len(Tag.query.filter_by(event=tournament_url, name="Ghost Team").all()) == 1

--- a/tests/unit/test_script_variables.py
+++ b/tests/unit/test_script_variables.py
@@ -1,0 +1,221 @@
+"""Tests for tournament-scoped ASS script variables.
+
+Variables are usable as identifiers in any ASS expression evaluated in the
+tournament (skip conditions, tag expressions, other variables). They're
+seeded into the interpreter environment by ``get_parser(event)``.
+"""
+
+import pytest
+
+from app.domain.enums import MatchStatus
+from app.utils.helpers import resolve_tag_to_team
+from app.utils.parser import get_parser
+from models import TO, Field, Match, ScriptVariable, Tag, db
+from tests.utils import login_as
+
+
+def _make_completed_match(tournament_url, name="Semi A", winner="team1", loser="team2"):
+    m = Match(
+        name=name,
+        event=tournament_url,
+        field="Field 1",
+        schedule_type="STATIC",
+        set_type="SETS",
+        nominal_length=60,
+        team1=winner,
+        team2=loser,
+        status=MatchStatus.COMPLETED,
+    )
+    m.match_winner = "TEAM1"
+    db.session.add(m)
+    db.session.flush()
+    return m
+
+
+@pytest.mark.unit
+def test_variable_usable_in_expression(test_db, tournament, app):
+    db.session.add(ScriptVariable(event=tournament.url, name="threshold", expression="(+ 1 2)"))
+    db.session.commit()
+
+    parser = get_parser(tournament.url)
+    assert parser.parse("(+ threshold 10)") == 13
+    assert parser.parse("(> threshold 2)") is True
+
+
+@pytest.mark.unit
+def test_variable_referencing_variable(test_db, tournament, app):
+    db.session.add(ScriptVariable(event=tournament.url, name="base", expression="2"))
+    db.session.add(ScriptVariable(event=tournament.url, name="doubled", expression="(* base 2)"))
+    db.session.commit()
+
+    parser = get_parser(tournament.url)
+    assert parser.parse("doubled") == 4
+    assert parser.parse("(+ doubled base)") == 6
+
+
+@pytest.mark.unit
+def test_lambda_valued_variable_is_callable(test_db, tournament, app):
+    db.session.add(ScriptVariable(event=tournament.url, name="square", expression="(lambda (x) (* x x))"))
+    db.session.commit()
+
+    parser = get_parser(tournament.url)
+    assert parser.parse("(square 5)") == 25
+
+
+@pytest.mark.unit
+def test_cyclic_variables_stay_unbound_at_eval_time(test_db, tournament, app):
+    # Bypass write-time validation; the env builder must not blow up and the
+    # cyclic names simply stay unbound.
+    db.session.add(ScriptVariable(event=tournament.url, name="a", expression="(+ b 1)"))
+    db.session.add(ScriptVariable(event=tournament.url, name="b", expression="(+ a 1)"))
+    db.session.add(ScriptVariable(event=tournament.url, name="ok", expression="7"))
+    db.session.commit()
+
+    parser = get_parser(tournament.url)
+    assert parser.parse("ok") == 7
+    # The cyclic variable is an unresolved identifier — arithmetic on it preserves.
+    result = parser.parse("(+ a 1)")
+    assert not isinstance(result, int)
+
+
+@pytest.mark.unit
+def test_variable_in_skip_condition_changes_solver_behavior(test_db, tournament, app, seeded_teams):
+    from app.utils.scheduling import recompute_scheduled_and_nominal_times
+
+    db.session.add(ScriptVariable(event=tournament.url, name="always-skip", expression="true"))
+    _make_completed_match(tournament.url)
+    m = Match(
+        name="Maybe Skipped",
+        event=tournament.url,
+        field="Field 1",
+        schedule_type="SAFE",
+        set_type="SETS",
+        nominal_length=60,
+        team1="team1",
+        team2="team2",
+        status=MatchStatus.NOT_STARTED,
+        skip_condition="always-skip",
+    )
+    db.session.add(m)
+    db.session.commit()
+    match_id = m.uuid
+
+    recompute_scheduled_and_nominal_times(tournament.url)
+    assert Match.query.get(match_id).status == MatchStatus.SKIPPED
+
+
+@pytest.mark.unit
+def test_tag_expression_using_variable_resolves(test_db, tournament, app, seeded_teams):
+    _make_completed_match(tournament.url)
+    db.session.add(ScriptVariable(event=tournament.url, name="semi-winner", expression="(winner {Semi A})"))
+    db.session.add(Tag(event=tournament.url, name="Champ", expression="semi-winner"))
+    db.session.commit()
+
+    assert resolve_tag_to_team("tag::Champ", tournament.url) == "team1"
+
+
+class TestScriptVariableCrud:
+    """Write-time validation via the script-variable endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, app, client, test_db, tournament, player, seeded_teams):
+        self.client = client
+        self.url = tournament.url
+        db.session.add(TO(user_id=player.id, user_type="player", event=self.url))
+        db.session.add(Field(event=self.url, name="Field 1"))
+        db.session.commit()
+        login_as(client, player)
+
+    def _create(self, name, expression):
+        return self.client.post(
+            f"/_api/tournaments/{self.url}/script-variables",
+            json={"name": name, "expression": expression},
+        )
+
+    def test_create_and_list(self):
+        resp = self._create("threshold", "(+ 1 2)")
+        assert resp.status_code == 200, resp.get_json()
+        var_id = resp.get_json()["id"]
+
+        resp = self.client.get(f"/_api/tournaments/{self.url}/script-variables")
+        assert resp.status_code == 200
+        rows = resp.get_json()["script_variables"]
+        assert rows == [{"id": var_id, "name": "threshold", "expression": "(+ 1 2)"}]
+
+    def test_builtin_name_collision_rejected(self):
+        for name in ("winner", "if", "lambda", "quote", "true", "nil", "+"):
+            resp = self._create(name, "1")
+            assert resp.status_code == 400, name
+            assert "builtin" in resp.get_json()["error"]
+
+    def test_invalid_identifier_rejected(self):
+        for name in ("1abc", "has space", "-9", "a]b", "tag::x", ""):
+            resp = self._create(name, "1")
+            assert resp.status_code == 400, name
+
+    def test_duplicate_name_rejected(self):
+        assert self._create("x", "1").status_code == 200
+        resp = self._create("x", "2")
+        assert resp.status_code == 400
+        assert "already exists" in resp.get_json()["error"]
+
+    def test_unparseable_expression_rejected(self):
+        resp = self._create("bad", "(+ 1")
+        assert resp.status_code == 400
+
+    def test_self_reference_rejected(self):
+        resp = self._create("loop", "(+ loop 1)")
+        assert resp.status_code == 400
+        assert "Cyclic" in resp.get_json()["error"]
+
+    def test_cycle_via_update_rejected(self):
+        assert self._create("a", "1").status_code == 200
+        resp = self._create("b", "(+ a 1)")
+        assert resp.status_code == 200
+        a_id = ScriptVariable.query.filter_by(event=self.url, name="a").first().id
+
+        # Updating a to reference b closes the cycle a -> b -> a.
+        resp = self.client.put(
+            f"/_api/tournaments/{self.url}/script-variables/{a_id}",
+            json={"expression": "(+ b 1)"},
+        )
+        assert resp.status_code == 400
+        assert "Cyclic" in resp.get_json()["error"]
+
+    def test_update_and_delete(self):
+        resp = self._create("x", "1")
+        var_id = resp.get_json()["id"]
+
+        resp = self.client.put(
+            f"/_api/tournaments/{self.url}/script-variables/{var_id}",
+            json={"name": "y", "expression": "(+ 1 1)"},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        var = ScriptVariable.query.get(var_id)
+        assert (var.name, var.expression) == ("y", "(+ 1 1)")
+
+        resp = self.client.delete(f"/_api/tournaments/{self.url}/script-variables/{var_id}")
+        assert resp.status_code == 200
+        assert ScriptVariable.query.get(var_id) is None
+
+    def test_validate_dsl_accepts_variable(self):
+        assert self._create("threshold", "(+ 1 2)").status_code == 200
+        resp = self.client.post(
+            f"/_api/{self.url}/validate-dsl",
+            json={"expression": "(> threshold 2)"},
+        )
+        data = resp.get_json()
+        assert data["valid"] is True
+        assert data["result_type"] == ["BOOL"]
+
+    def test_variable_with_team_type_infers_through(self):
+        _make_completed_match(self.url)
+        db.session.commit()
+        assert self._create("champ", "(winner {Semi A})").status_code == 200
+        resp = self.client.post(
+            f"/_api/{self.url}/validate-dsl",
+            json={"expression": "champ"},
+        )
+        data = resp.get_json()
+        assert data["valid"] is True
+        assert data["result_type"] == ["TEAM"]

--- a/tests/unit/test_tag_expressions.py
+++ b/tests/unit/test_tag_expressions.py
@@ -1,0 +1,244 @@
+"""Tests for tags defined by ASS expressions.
+
+A tag resolves to a team in this order:
+1. The manually assigned ``team`` column (an override).
+2. Evaluating the tag's ASS ``expression`` to a concrete team.
+3. Otherwise unresolved (None).
+"""
+
+import pytest
+
+from app.domain.enums import MatchStatus
+from app.utils.helpers import resolve_tag_to_team
+from models import TO, Field, Match, Tag, db
+from tests.utils import login_as
+
+
+def _make_completed_match(tournament_url, name="Semi A", winner="team1", loser="team2"):
+    m = Match(
+        name=name,
+        event=tournament_url,
+        field="Field 1",
+        schedule_type="STATIC",
+        set_type="SETS",
+        nominal_length=60,
+        team1=winner,
+        team2=loser,
+        status=MatchStatus.COMPLETED,
+    )
+    m.match_winner = "TEAM1"
+    db.session.add(m)
+    db.session.flush()
+    return m
+
+
+@pytest.mark.unit
+def test_tag_expression_resolves_winner_of_completed_match(test_db, tournament, app, seeded_teams):
+    _make_completed_match(tournament.url)
+    tag = Tag(event=tournament.url, name="SemiWinner", expression="(winner {Semi A})")
+    db.session.add(tag)
+    db.session.commit()
+
+    assert resolve_tag_to_team("tag::SemiWinner", tournament.url) == "team1"
+
+
+@pytest.mark.unit
+def test_tag_manual_team_overrides_expression(test_db, tournament, app, seeded_teams):
+    _make_completed_match(tournament.url)
+    tag = Tag(
+        event=tournament.url,
+        name="SemiWinner",
+        team="team3",
+        expression="(winner {Semi A})",
+    )
+    db.session.add(tag)
+    db.session.commit()
+
+    # Manual assignment wins over the expression (which would say team1).
+    assert resolve_tag_to_team("tag::SemiWinner", tournament.url) == "team3"
+
+
+@pytest.mark.unit
+def test_tag_expression_unresolved_while_match_incomplete(test_db, tournament, app, seeded_teams):
+    m = Match(
+        name="Semi A",
+        event=tournament.url,
+        field="Field 1",
+        schedule_type="STATIC",
+        set_type="SETS",
+        nominal_length=60,
+        team1="team1",
+        team2="team2",
+        status=MatchStatus.NOT_STARTED,
+    )
+    db.session.add(m)
+    tag = Tag(event=tournament.url, name="SemiWinner", expression="(winner {Semi A})")
+    db.session.add(tag)
+    db.session.commit()
+
+    assert resolve_tag_to_team("tag::SemiWinner", tournament.url) is None
+
+
+@pytest.mark.unit
+def test_cyclic_tag_expressions_resolve_to_none(test_db, tournament, app, seeded_teams):
+    tag_a = Tag(event=tournament.url, name="A", expression="[tag::B]")
+    tag_b = Tag(event=tournament.url, name="B", expression="[tag::A]")
+    db.session.add_all([tag_a, tag_b])
+    db.session.commit()
+
+    assert resolve_tag_to_team("tag::A", tournament.url) is None
+    assert resolve_tag_to_team("tag::B", tournament.url) is None
+
+
+@pytest.mark.unit
+def test_self_referencing_tag_expression_resolves_to_none(test_db, tournament, app, seeded_teams):
+    tag = Tag(event=tournament.url, name="Loop", expression="[tag::Loop]")
+    db.session.add(tag)
+    db.session.commit()
+
+    assert resolve_tag_to_team("tag::Loop", tournament.url) is None
+
+
+@pytest.mark.unit
+def test_tag_expression_chains_through_other_tag(test_db, tournament, app, seeded_teams):
+    _make_completed_match(tournament.url)
+    inner = Tag(event=tournament.url, name="Inner", expression="(winner {Semi A})")
+    outer = Tag(event=tournament.url, name="Outer", expression="[tag::Inner]")
+    db.session.add_all([inner, outer])
+    db.session.commit()
+
+    assert resolve_tag_to_team("tag::Outer", tournament.url) == "team1"
+
+
+@pytest.mark.unit
+def test_tag_expression_error_resolves_to_none(test_db, tournament, app, seeded_teams):
+    # Unbalanced expression stored directly in the DB (bypassing write-time
+    # validation) must resolve to None, not raise.
+    tag = Tag(event=tournament.url, name="Broken", expression="(winner {Semi A}")
+    db.session.add(tag)
+    db.session.commit()
+
+    assert resolve_tag_to_team("tag::Broken", tournament.url) is None
+
+
+@pytest.mark.unit
+def test_slot_resolved_uses_tag_expression(test_db, tournament, app, seeded_teams):
+    from app.utils.scheduling import _slot_resolved
+
+    _make_completed_match(tournament.url)
+    tag = Tag(event=tournament.url, name="SemiWinner", expression="(winner {Semi A})")
+    unresolved = Tag(event=tournament.url, name="Nothing")
+    db.session.add_all([tag, unresolved])
+    db.session.commit()
+
+    assert _slot_resolved(None, "tag::SemiWinner", tournament.url, {}) is True
+    assert _slot_resolved(None, "tag::Nothing", tournament.url, {}) is False
+
+
+class TestTagExpressionWriteValidation:
+    """Write-time validation via the tag CRUD endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, app, client, test_db, tournament, player, seeded_teams):
+        self.client = client
+        self.url = tournament.url
+        db.session.add(TO(user_id=player.id, user_type="player", event=self.url))
+        db.session.add(Field(event=self.url, name="Field 1"))
+        db.session.commit()
+        login_as(client, player)
+
+    def test_create_tag_with_valid_team_expression(self):
+        _make_completed_match(self.url)
+        db.session.commit()
+        resp = self.client.post(
+            f"/_api/tournaments/{self.url}/tags",
+            json={"name": "SemiWinner", "expression": "(winner {Semi A})"},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        tag = Tag.query.filter_by(event=self.url, name="SemiWinner").first()
+        assert tag.expression == "(winner {Semi A})"
+
+    def test_create_tag_rejects_non_team_expression(self):
+        resp = self.client.post(
+            f"/_api/tournaments/{self.url}/tags",
+            json={"name": "Bad", "expression": "(+ 1 2)"},
+        )
+        assert resp.status_code == 400
+        assert "TEAM" in resp.get_json()["error"]
+
+    def test_create_tag_rejects_unparseable_expression(self):
+        resp = self.client.post(
+            f"/_api/tournaments/{self.url}/tags",
+            json={"name": "Bad", "expression": "(winner {Oops"},
+        )
+        assert resp.status_code == 400
+
+    def test_create_tag_rejects_unknown_match_reference(self):
+        resp = self.client.post(
+            f"/_api/tournaments/{self.url}/tags",
+            json={"name": "Bad", "expression": "(winner {No Such Match})"},
+        )
+        assert resp.status_code == 400
+        assert "Unknown match" in resp.get_json()["error"]
+
+    def test_update_tags_sets_and_clears_expression(self):
+        _make_completed_match(self.url)
+        tag = Tag(event=self.url, name="SemiWinner")
+        db.session.add(tag)
+        db.session.commit()
+        tag_id = tag.id
+
+        resp = self.client.post(
+            f"/_api/tournaments/{self.url}/update-tags",
+            json={"tag_id": tag_id, "expression": "(winner {Semi A})"},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert Tag.query.get(tag_id).expression == "(winner {Semi A})"
+
+        # Empty expression clears it.
+        resp = self.client.post(
+            f"/_api/tournaments/{self.url}/update-tags",
+            json={"tag_id": tag_id, "expression": ""},
+        )
+        assert resp.status_code == 200
+        assert Tag.query.get(tag_id).expression is None
+
+    def test_update_tags_rejects_bool_expression(self):
+        tag = Tag(event=self.url, name="SemiWinner")
+        db.session.add(tag)
+        db.session.commit()
+
+        resp = self.client.post(
+            f"/_api/tournaments/{self.url}/update-tags",
+            json={"tag_id": tag.id, "expression": "(== 1 1)"},
+        )
+        assert resp.status_code == 400
+        assert "TEAM" in resp.get_json()["error"]
+
+    def test_update_tags_expression_fills_matches(self):
+        """Setting a resolving expression eagerly fills matches that use the tag."""
+        _make_completed_match(self.url)
+        tag = Tag(event=self.url, name="SemiWinner")
+        db.session.add(tag)
+        m = Match(
+            name="Final",
+            event=self.url,
+            field="Field 1",
+            schedule_type="STATIC",
+            set_type="SETS",
+            nominal_length=60,
+            team1_initial="tag::SemiWinner",
+            team2_initial="team3",
+            team2="team3",
+            status=MatchStatus.NOT_STARTED,
+        )
+        db.session.add(m)
+        db.session.commit()
+        match_id = m.uuid
+
+        resp = self.client.post(
+            f"/_api/tournaments/{self.url}/update-tags",
+            json={"tag_id": tag.id, "expression": "(winner {Semi A})"},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert Match.query.get(match_id).team1 == "team1"


### PR DESCRIPTION
## Summary

- tags can now be *defined* by an ASS expression instead of hand-assigned (can still be manually overridden)
- tournaments get named script variables usable in any expression. 

the idea is that:
- lots of logic (ie, seeding logic) can be done automagically now, combined with #251  
- this provides a way to set teams with ASS expressions without breaking the solver's dependency analysis system and without doing really complicated formal analysis of the ASS to figure out what the true dependencies are

## What changed

Tags:

- a tag may carry an ASS expression whose result type must be TEAM (e.g. `(winner {Semi A})`). the existing team dropdown becomes an **override** that always wins when set. resolution order: manual override → evaluate expression → unresolved.
- resolution is centralized in `resolve_tag_to_team` with a cycle guard (tag expressions referencing `[tag::Other]` in a loop resolve to nothing instead of recursing forever), so slot resolution, solver readiness, and `[tag::X]` literals inside other expressions all pick it up for free. tags resolve themselves as results come in — no new triggers needed.
- write-time validation: expression must parse, pass static checks, and infer TEAM. the tags modal gets a validated expression editor with an effective-resolution hint.

Script variables:

- named variables, one expression each, usable as identifiers in *any* ASS expression in the tournament — skip conditions, tag definitions, other variables. lambda-valued variables are callable.
- evaluated eagerly in topological order into the interpreter env. cycles are rejected at write time (and degrade safely at eval time); names must be valid identifiers and can't shadow builtins.
- managed from a new Scripting modal on the schedule editor.

TOML:

- variables round-trip through export/import (`[[variables]]` section, written before `[[tags]]` since tag/match expressions may reference them; reconciled like tags: update by name, create, delete missing; validated with the same rules as the CRUD endpoints).
- found and fixed while verifying: tag expressions were *imported* but never *exported* — they silently vanished from exported files. also fixed import validation errors crashing with an AttributeError instead of reporting (`Err` stores `.val`, not `.value` :skull:).
- PR 1's unknown-team rewriter extends to the new surfaces: `[Team]` literals inside imported tag expressions and variable expressions get the same `tag::` rewrite + warning.

Docs:

- short "Tags as Expressions" and "Variables" sections in the ASS docs.

## Migration impact

- Alembic revisions added: #0013 (`0013_tag_expr_script_vars`). adds nullable `tags.expression` and the `script_variables` table.
- Run `just db-backup && just db-migrate` before deploy.
- Backwards compatible: tags without expressions behave exactly as before.

## Test plan

- [x] `just test` passes (521; 39 new: resolution order, cycles, `_slot_resolved` integration, variable topo/eval/cycle handling, a skip-condition-via-variable actually skipping through the solver, TOML round-trips + rewriter + idempotence)
- [x] `just lint` clean, `cargo check` clean
- [x] Manual verification:
  - [x] defined `Seed 1` as `(winner {Semi A})`, finalized Semi A, watched the dependent match go ready
  - [x] override beats expression; clearing the override falls back
  - [x] export → wipe → import: expressions and variables intact

## Linked issues

Refs #215, #243

---

### Pre-review checklist

<!-- Strike through (~~item~~) anything that doesn't apply, rather than
     deleting, so reviewers can see you thought about it. -->

- [x] Title prefixed with one of `[Feature]`, `[Bugfix]`, `[Refactor]`, `[Documentation]`.
- [x] Branch name follows `category/name` (`feat/...`, `bugfix/...`, `refactor/...`).
- [x] Targeting `dev`, not `main` (unless this is a release PR).
- [x] `just lint` and `just format` are clean.
- [x] Tests added or updated for the new behavior.
- ~~If a new module was added under `app/`: corresponding `app/<area>/README.md` and `docs/api/*.rst` are updated.~~
- ~~If developer workflow changes: `README.md`, `CONTRIBUTING.md`, or `TESTING.md` updated.~~
- [x] No merge conflicts with the base branch.
